### PR TITLE
Centralize hardcoded publication ID and add Vitest test framework

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ OPENAI_API_KEY=your-openai-api-key
 # Email - MailerLite
 MAILERLITE_API_KEY=your-mailerlite-api-key
 
+# Publication & Site
+# Set these to run against your own Supabase instance (defaults to AI Pros Daily)
+DEFAULT_PUBLICATION_ID=your-publication-uuid
+NEXT_PUBLIC_SITE_URL=https://your-site.com
+
 # Cron Security
 CRON_SECRET=generate-random-32-char-string
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,10 @@
       },
       "devDependencies": {
         "@types/nodemailer": "^7.0.2",
-        "@types/uuid": "^9.0.8"
+        "@types/uuid": "^9.0.8",
+        "@vitest/coverage-v8": "^4.0.18",
+        "vite-tsconfig-paths": "^6.1.1",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1618,6 +1621,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
@@ -1627,6 +1640,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
@@ -1634,6 +1663,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@clerk/backend": {
@@ -3845,6 +3898,356 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -5170,6 +5573,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -5231,6 +5645,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -5916,6 +6337,148 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@workflow/astro": {
@@ -7174,10 +7737,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
+      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async": {
@@ -7721,6 +8313,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -8830,6 +9432,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -9419,6 +10028,16 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -9794,6 +10413,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -10116,6 +10750,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/google-auth-library": {
       "version": "10.3.0",
@@ -11031,6 +11672,52 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports/node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -11684,6 +12371,34 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -12273,6 +12988,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/ohash": {
       "version": "2.0.11",
@@ -13222,6 +13948,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rss-parser": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
@@ -13571,6 +14342,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -13605,6 +14383,13 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/standardwebhooks": {
@@ -14086,6 +14871,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -14109,6 +14901,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -14145,6 +14947,27 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/tsconfig-paths": {
@@ -14529,6 +15352,673 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -14693,6 +16183,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "build:all": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "type-check": "tsc --noEmit",
     "migrate:normalize-ads": "npx tsx scripts/migrate-normalize-ads.ts",
     "migrate:advertorial-to-module": "npx tsx scripts/migrate-advertorial-to-module.ts"
@@ -69,6 +72,9 @@
   },
   "devDependencies": {
     "@types/nodemailer": "^7.0.2",
-    "@types/uuid": "^9.0.8"
+    "@types/uuid": "^9.0.8",
+    "@vitest/coverage-v8": "^4.0.18",
+    "vite-tsconfig-paths": "^6.1.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/app/account/ads/page.tsx
+++ b/src/app/account/ads/page.tsx
@@ -4,8 +4,7 @@ import { supabaseAdmin } from '@/lib/supabase'
 import Link from 'next/link'
 import Image from 'next/image'
 import { Star, Newspaper, ArrowRight, Crown, Clock } from 'lucide-react'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 export const dynamic = 'force-dynamic'
 

--- a/src/app/account/ads/profile/page.tsx
+++ b/src/app/account/ads/profile/page.tsx
@@ -5,8 +5,7 @@ import { getCategoriesWithFeaturedTools, getDirectoryPricing } from '@/lib/direc
 import Link from 'next/link'
 import Image from 'next/image'
 import { Star, Check, TrendingUp, Eye, ArrowRight, Crown, Clock } from 'lucide-react'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 export const dynamic = 'force-dynamic'
 

--- a/src/app/account/ads/upgrade/page.tsx
+++ b/src/app/account/ads/upgrade/page.tsx
@@ -3,8 +3,7 @@ import { redirect } from 'next/navigation'
 import { supabaseAdmin } from '@/lib/supabase'
 import { getCategoriesWithFeaturedTools, getDirectoryPricing } from '@/lib/directory'
 import { UpgradeForm } from './UpgradeForm'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 export const dynamic = 'force-dynamic'
 

--- a/src/app/account/ads/upgrade/success/page.tsx
+++ b/src/app/account/ads/upgrade/success/page.tsx
@@ -3,8 +3,7 @@ import { redirect } from 'next/navigation'
 import { supabaseAdmin } from '@/lib/supabase'
 import Link from 'next/link'
 import { CheckCircle, Star, Crown, ArrowRight } from 'lucide-react'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 export const dynamic = 'force-dynamic'
 

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -3,8 +3,7 @@ import { redirect } from 'next/navigation'
 import { supabaseAdmin } from '@/lib/supabase'
 import { ProfileCard } from './components/ProfileCard'
 import { NoProfileCard } from './components/NoProfileCard'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 // Categories mapping for ai_applications - matches directory.ts
 const CATEGORIES = [

--- a/src/app/api/account/profile/route.ts
+++ b/src/app/api/account/profile/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { currentUser } from '@clerk/nextjs/server'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 export async function PUT(request: NextRequest) {
   try {

--- a/src/app/api/account/tools/checkout/route.ts
+++ b/src/app/api/account/tools/checkout/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { currentUser } from '@clerk/nextjs/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import Stripe from 'stripe'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 // Initialize Stripe
 const stripe = process.env.STRIPE_SECRET_KEY

--- a/src/app/api/cron/sync-sparkloop/route.ts
+++ b/src/app/api/cron/sync-sparkloop/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { SparkLoopService } from '@/lib/sparkloop-client'
-
-// Default publication ID for AI Pro Daily
-const DEFAULT_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 /**
  * GET /api/cron/sync-sparkloop
@@ -24,10 +22,10 @@ export async function GET(request: NextRequest) {
     console.log('[SparkLoop Cron] Starting sync...')
 
     const service = new SparkLoopService()
-    const result = await service.syncRecommendationsToDatabase(DEFAULT_PUBLICATION_ID)
+    const result = await service.syncRecommendationsToDatabase(PUBLICATION_ID)
 
     // Take daily snapshot after sync (idempotent — last sync of the day wins)
-    const snapshotCount = await service.takeDailySnapshot(DEFAULT_PUBLICATION_ID)
+    const snapshotCount = await service.takeDailySnapshot(PUBLICATION_ID)
 
     console.log(`[SparkLoop Cron] Completed: ${result.synced} synced, ${result.outOfBudget} auto-excluded, +${result.confirmDeltas} confirms, +${result.rejectionDeltas} rejections, ${snapshotCount} snapshot rows`)
 

--- a/src/app/api/debug/(checks)/check-tool-visibility/route.ts
+++ b/src/app/api/debug/(checks)/check-tool-visibility/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const EXPECTED_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID as EXPECTED_PUBLICATION_ID } from '@/lib/config'
 
 export async function GET(request: NextRequest) {
   try {

--- a/src/app/api/debug/sparkloop-test/route.ts
+++ b/src/app/api/debug/sparkloop-test/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { SparkLoopService } from '@/lib/sparkloop-client'
+import { PUBLICATION_ID } from '@/lib/config'
 
 /**
  * POST /api/debug/sparkloop-test
@@ -77,9 +78,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const service = new SparkLoopService()
-    const stored = await service.getStoredRecommendations(
-      'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
-    )
+    const stored = await service.getStoredRecommendations(PUBLICATION_ID)
 
     const active = stored.filter(r => r.status === 'active' && !(r as any).excluded)
 

--- a/src/app/api/sparkloop/admin/daterange/route.ts
+++ b/src/app/api/sparkloop/admin/daterange/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
-
-// Default publication ID for AI Pro Daily
-const DEFAULT_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 const PAGE_SIZE = 1000
 
 /**
@@ -38,7 +36,7 @@ export async function GET(request: NextRequest) {
       const { data: page, error } = await supabaseAdmin
         .from('sparkloop_events')
         .select('raw_payload')
-        .eq('publication_id', DEFAULT_PUBLICATION_ID)
+        .eq('publication_id', PUBLICATION_ID)
         .eq('event_type', 'popup_opened')
         .gte('event_timestamp', startDate)
         .lte('event_timestamp', endDate)
@@ -71,7 +69,7 @@ export async function GET(request: NextRequest) {
       const { data: page, error } = await supabaseAdmin
         .from('sparkloop_referrals')
         .select('ref_code, status, source')
-        .eq('publication_id', DEFAULT_PUBLICATION_ID)
+        .eq('publication_id', PUBLICATION_ID)
         .in('source', ['custom_popup', 'recs_page'])
         .gte('subscribed_at', startDate)
         .lte('subscribed_at', endDate)
@@ -119,7 +117,7 @@ export async function GET(request: NextRequest) {
       const { data: page } = await supabaseAdmin
         .from('sparkloop_events')
         .select('raw_payload')
-        .eq('publication_id', DEFAULT_PUBLICATION_ID)
+        .eq('publication_id', PUBLICATION_ID)
         .eq('event_type', 'api_subscribe_confirmed')
         .gte('event_timestamp', startDate)
         .lte('event_timestamp', endDate)
@@ -148,7 +146,7 @@ export async function GET(request: NextRequest) {
       const { data: page } = await supabaseAdmin
         .from('sparkloop_events')
         .select('raw_payload')
-        .eq('publication_id', DEFAULT_PUBLICATION_ID)
+        .eq('publication_id', PUBLICATION_ID)
         .eq('event_type', 'subscriptions_success')
         .gte('event_timestamp', startDate)
         .lte('event_timestamp', endDate)

--- a/src/app/api/sparkloop/admin/submissions/route.ts
+++ b/src/app/api/sparkloop/admin/submissions/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const DEFAULT_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 /**
  * GET /api/sparkloop/admin/submissions
@@ -40,7 +39,7 @@ export async function GET(request: NextRequest) {
     const { data: referrals, error } = await supabaseAdmin
       .from('sparkloop_referrals')
       .select('subscriber_email, subscribed_at, status, source')
-      .eq('publication_id', DEFAULT_PUBLICATION_ID)
+      .eq('publication_id', PUBLICATION_ID)
       .eq('ref_code', refCode)
       .gte('subscribed_at', startDate)
       .lte('subscribed_at', endDateFinal)

--- a/src/app/api/sparkloop/fb-conversion/route.ts
+++ b/src/app/api/sparkloop/fb-conversion/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const DEFAULT_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 /**
  * POST /api/sparkloop/fb-conversion
@@ -43,7 +42,7 @@ export async function POST(request: NextRequest) {
     const { data, error } = await supabaseAdmin
       .from('sparkloop_referrals')
       .update({ fb_conversion_sent_at: now, updated_at: now })
-      .eq('publication_id', DEFAULT_PUBLICATION_ID)
+      .eq('publication_id', PUBLICATION_ID)
       .eq('subscriber_email', email)
       .is('fb_conversion_sent_at', null)
       .select('id, ref_code')

--- a/src/app/api/sparkloop/module-subscribe/route.ts
+++ b/src/app/api/sparkloop/module-subscribe/route.ts
@@ -4,8 +4,7 @@ import { SparkLoopService } from '@/lib/sparkloop-client'
 import { supabaseAdmin } from '@/lib/supabase'
 import { checkUserAgent } from '@/lib/bot-detection'
 import { isIPExcluded, IPExclusion } from '@/lib/ip-utils'
-
-const DEFAULT_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://aiprodaily.com'
 
 /**
@@ -48,7 +47,7 @@ export async function GET(request: NextRequest) {
     const { data: exclusions } = await supabaseAdmin
       .from('excluded_ips')
       .select('ip_address, is_range, cidr_prefix')
-      .eq('publication_id', DEFAULT_PUBLICATION_ID)
+      .eq('publication_id', PUBLICATION_ID)
 
     if (exclusions && ipAddress) {
       ipExcluded = isIPExcluded(ipAddress, exclusions as IPExclusion[])
@@ -65,7 +64,7 @@ export async function GET(request: NextRequest) {
     .from('sparkloop_module_clicks')
     .insert({
       id: clickRecordId,
-      publication_id: DEFAULT_PUBLICATION_ID,
+      publication_id: PUBLICATION_ID,
       subscriber_email: email,
       ref_code: refCode,
       issue_id: issueId || null,
@@ -90,7 +89,7 @@ export async function GET(request: NextRequest) {
     const { data: rec } = await supabaseAdmin
       .from('sparkloop_recommendations')
       .select('publication_name')
-      .eq('publication_id', DEFAULT_PUBLICATION_ID)
+      .eq('publication_id', PUBLICATION_ID)
       .eq('ref_code', refCode)
       .single()
 
@@ -104,7 +103,7 @@ export async function GET(request: NextRequest) {
     const { data: rec } = await supabaseAdmin
       .from('sparkloop_recommendations')
       .select('ref_code, publication_name, status, excluded')
-      .eq('publication_id', DEFAULT_PUBLICATION_ID)
+      .eq('publication_id', PUBLICATION_ID)
       .eq('ref_code', refCode)
       .single()
 
@@ -154,7 +153,7 @@ export async function GET(request: NextRequest) {
       await supabaseAdmin
         .from('sparkloop_referrals')
         .upsert({
-          publication_id: DEFAULT_PUBLICATION_ID,
+          publication_id: PUBLICATION_ID,
           subscriber_email: email,
           ref_code: refCode,
           source: 'newsletter_module',
@@ -171,7 +170,7 @@ export async function GET(request: NextRequest) {
     // Record event in sparkloop_events
     try {
       await supabaseAdmin.from('sparkloop_events').insert({
-        publication_id: DEFAULT_PUBLICATION_ID,
+        publication_id: PUBLICATION_ID,
         event_type: 'newsletter_module_subscribe',
         subscriber_email: email,
         raw_payload: {
@@ -191,7 +190,7 @@ export async function GET(request: NextRequest) {
     // Increment our_total_subscribes
     try {
       await supabaseAdmin.rpc('increment_our_subscribes', {
-        p_publication_id: DEFAULT_PUBLICATION_ID,
+        p_publication_id: PUBLICATION_ID,
         p_ref_codes: [refCode],
       })
     } catch (aggErr) {

--- a/src/app/api/sparkloop/offer-stats/route.ts
+++ b/src/app/api/sparkloop/offer-stats/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 const PAGE_SIZE = 1000
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/sparkloop/offer-track/route.ts
+++ b/src/app/api/sparkloop/offer-track/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/sparkloop/stats/route.ts
+++ b/src/app/api/sparkloop/stats/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { getPublicationSettings } from '@/lib/publication-settings'
-
-// Default publication ID for AI Pro Daily
-const DEFAULT_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 const FALLBACK_DEFAULT_RCR = 25
 
 interface DailyStats {
@@ -43,7 +41,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Load default RCR from publication_settings
-    const defaults = await getPublicationSettings(DEFAULT_PUBLICATION_ID, [
+    const defaults = await getPublicationSettings(PUBLICATION_ID, [
       'sparkloop_default_rcr',
     ])
     const defaultRcr = defaults.sparkloop_default_rcr
@@ -54,7 +52,7 @@ export async function GET(request: NextRequest) {
     const { data: recommendations } = await supabaseAdmin
       .from('sparkloop_recommendations')
       .select('ref_code, cpa, sparkloop_rcr, override_rcr, our_pending, our_confirms, our_rejections, our_total_subscribes, sparkloop_earnings')
-      .eq('publication_id', DEFAULT_PUBLICATION_ID)
+      .eq('publication_id', PUBLICATION_ID)
 
     // Build a lookup: ref_code -> { cpaDollars, rcr }
     const recLookup = new Map<string, { cpaDollars: number; rcr: number }>()
@@ -79,7 +77,7 @@ export async function GET(request: NextRequest) {
       const { data: page } = await supabaseAdmin
         .from('sparkloop_referrals')
         .select('ref_code, status, subscribed_at, confirmed_at')
-        .eq('publication_id', DEFAULT_PUBLICATION_ID)
+        .eq('publication_id', PUBLICATION_ID)
         .in('source', ['custom_popup', 'recs_page'])
         .gte('subscribed_at', fromDate.toISOString())
         .lte('subscribed_at', toDate.toISOString())
@@ -118,7 +116,7 @@ export async function GET(request: NextRequest) {
       const { data: snapPage } = await supabaseAdmin
         .from('sparkloop_daily_snapshots')
         .select('snapshot_date, sparkloop_pending, sparkloop_confirmed, sparkloop_rejected')
-        .eq('publication_id', DEFAULT_PUBLICATION_ID)
+        .eq('publication_id', PUBLICATION_ID)
         .gte('snapshot_date', snapshotFromDate.toISOString().split('T')[0])
         .lte('snapshot_date', toDate.toISOString().split('T')[0])
         .order('snapshot_date', { ascending: true })
@@ -202,7 +200,7 @@ export async function GET(request: NextRequest) {
     const { data: topRecs } = await supabaseAdmin
       .from('sparkloop_recommendations')
       .select('publication_name, publication_logo, our_confirms, sparkloop_earnings')
-      .eq('publication_id', DEFAULT_PUBLICATION_ID)
+      .eq('publication_id', PUBLICATION_ID)
       .gt('sparkloop_earnings', 0)
       .order('sparkloop_earnings', { ascending: false })
       .limit(9)

--- a/src/app/api/sparkloop/sync/route.ts
+++ b/src/app/api/sparkloop/sync/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { SparkLoopService } from '@/lib/sparkloop-client'
-
-// Default publication ID for AI Pro Daily
-const DEFAULT_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 /**
  * POST /api/sparkloop/sync
@@ -27,7 +25,7 @@ export async function POST(request: NextRequest) {
     }
 
     const service = new SparkLoopService()
-    const result = await service.syncRecommendationsToDatabase(DEFAULT_PUBLICATION_ID)
+    const result = await service.syncRecommendationsToDatabase(PUBLICATION_ID)
 
     return NextResponse.json({
       success: true,
@@ -55,7 +53,7 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   try {
     const service = new SparkLoopService()
-    const stored = await service.getStoredRecommendations(DEFAULT_PUBLICATION_ID)
+    const stored = await service.getStoredRecommendations(PUBLICATION_ID)
 
     // Find oldest sync time
     const lastSyncTimes = stored

--- a/src/app/api/sparkloop/track/route.ts
+++ b/src/app/api/sparkloop/track/route.ts
@@ -1,10 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createHash } from 'crypto'
 import { supabaseAdmin } from '@/lib/supabase'
+import { PUBLICATION_ID } from '@/lib/config'
 import type { SparkLoopPopupEvent } from '@/types/sparkloop'
-
-// Default publication ID for AI Pro Daily
-const DEFAULT_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
 
 /**
  * POST /api/sparkloop/track
@@ -46,7 +44,7 @@ export async function POST(request: NextRequest) {
     const { error } = await supabaseAdmin
       .from('sparkloop_events')
       .insert({
-        publication_id: DEFAULT_PUBLICATION_ID,
+        publication_id: PUBLICATION_ID,
         event_type: eventType,
         subscriber_email: event.subscriber_email,
         raw_payload: metadata,
@@ -67,14 +65,14 @@ export async function POST(request: NextRequest) {
             ? 'increment_sparkloop_page_impressions'
             : 'increment_sparkloop_impressions'
           await supabaseAdmin.rpc(rpcName, {
-            p_publication_id: DEFAULT_PUBLICATION_ID,
+            p_publication_id: PUBLICATION_ID,
             p_ref_codes: event.ref_codes,
           })
           console.log(`[SparkLoop Track] Recorded ${event.ref_codes.length} ${isRecsPage ? 'page' : 'popup'} impressions`)
         } else if (eventType === 'recommendation_selected') {
           // Record selection for the selected recommendation
           await supabaseAdmin.rpc('increment_sparkloop_selections', {
-            p_publication_id: DEFAULT_PUBLICATION_ID,
+            p_publication_id: PUBLICATION_ID,
             p_ref_codes: event.ref_codes,
           })
           console.log(`[SparkLoop Track] Recorded selection for ${event.ref_codes[0]}`)

--- a/src/app/api/tools/analytics/route.ts
+++ b/src/app/api/tools/analytics/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 /**
  * Tools Directory Analytics Endpoint

--- a/src/app/api/tools/entitlements/[id]/route.ts
+++ b/src/app/api/tools/entitlements/[id]/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 // GET - Fetch a single entitlement by ID
 export async function GET(

--- a/src/app/api/tools/entitlements/route.ts
+++ b/src/app/api/tools/entitlements/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 // GET - Fetch all customer entitlements
 export async function GET(request: NextRequest) {

--- a/src/app/api/tools/packages/[id]/route.ts
+++ b/src/app/api/tools/packages/[id]/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 // GET - Fetch a single package by ID
 export async function GET(

--- a/src/app/api/tools/packages/route.ts
+++ b/src/app/api/tools/packages/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 // GET - Fetch all sponsorship packages
 export async function GET(request: NextRequest) {

--- a/src/app/api/tools/pending-count/route.ts
+++ b/src/app/api/tools/pending-count/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 /**
  * Get count of pending tool submissions

--- a/src/app/api/tools/settings/route.ts
+++ b/src/app/api/tools/settings/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 // Default pricing values
 const DEFAULT_SETTINGS = {

--- a/src/app/api/tools/track-click/route.ts
+++ b/src/app/api/tools/track-click/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { incrementToolClicks, incrementToolViews } from '@/lib/directory'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 type ClickType = 'category_click' | 'tool_view' | 'external_link'
 

--- a/src/app/api/webhooks/sparkloop/route.ts
+++ b/src/app/api/webhooks/sparkloop/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { SlackNotificationService } from '@/lib/slack'
-
-// Default publication ID (can be overridden via webhook payload or config)
-const DEFAULT_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 // SparkLoop webhook event types
 const EVENT_TYPES = {
@@ -204,7 +202,7 @@ async function handlePartnerReferral(
     try {
       if (status === 'confirmed') {
         await supabaseAdmin.rpc('record_sparkloop_confirm', {
-          p_publication_id: DEFAULT_PUBLICATION_ID,
+          p_publication_id: PUBLICATION_ID,
           p_ref_code: refCode,
         })
         console.log(`[SparkLoop Webhook] Recorded confirm for ${refCode}`)
@@ -219,7 +217,7 @@ async function handlePartnerReferral(
         )
       } else if (status === 'rejected') {
         await supabaseAdmin.rpc('record_sparkloop_rejection', {
-          p_publication_id: DEFAULT_PUBLICATION_ID,
+          p_publication_id: PUBLICATION_ID,
           p_ref_code: refCode,
         })
         console.log(`[SparkLoop Webhook] Recorded rejection for ${refCode}`)
@@ -315,7 +313,7 @@ async function updateReferralTracking(
     const { data: updated } = await supabaseAdmin
       .from('sparkloop_referrals')
       .update({ status: 'pending', pending_at: now, updated_at: now })
-      .eq('publication_id', DEFAULT_PUBLICATION_ID)
+      .eq('publication_id', PUBLICATION_ID)
       .eq('subscriber_email', subscriberEmail)
       .eq('ref_code', refCode)
       .eq('source', 'custom_popup')
@@ -329,7 +327,7 @@ async function updateReferralTracking(
       const { error } = await supabaseAdmin
         .from('sparkloop_referrals')
         .upsert({
-          publication_id: DEFAULT_PUBLICATION_ID,
+          publication_id: PUBLICATION_ID,
           subscriber_email: subscriberEmail,
           ref_code: refCode,
           source: 'webhook_only',
@@ -348,7 +346,7 @@ async function updateReferralTracking(
     const { data: existing } = await supabaseAdmin
       .from('sparkloop_referrals')
       .select('id, source')
-      .eq('publication_id', DEFAULT_PUBLICATION_ID)
+      .eq('publication_id', PUBLICATION_ID)
       .eq('subscriber_email', subscriberEmail)
       .eq('ref_code', refCode)
       .limit(1)
@@ -363,7 +361,7 @@ async function updateReferralTracking(
       // Update aggregate columns if it was from our popup
       if (existing.source === 'custom_popup') {
         const { error: confirmErr } = await supabaseAdmin.rpc('record_our_confirm', {
-          p_publication_id: DEFAULT_PUBLICATION_ID,
+          p_publication_id: PUBLICATION_ID,
           p_ref_code: refCode,
         })
         if (confirmErr) console.error('[SparkLoop Webhook] Failed to record our confirm:', confirmErr)
@@ -374,7 +372,7 @@ async function updateReferralTracking(
       await supabaseAdmin
         .from('sparkloop_referrals')
         .upsert({
-          publication_id: DEFAULT_PUBLICATION_ID,
+          publication_id: PUBLICATION_ID,
           subscriber_email: subscriberEmail,
           ref_code: refCode,
           source: 'webhook_only',
@@ -389,7 +387,7 @@ async function updateReferralTracking(
     const { data: existing } = await supabaseAdmin
       .from('sparkloop_referrals')
       .select('id, source')
-      .eq('publication_id', DEFAULT_PUBLICATION_ID)
+      .eq('publication_id', PUBLICATION_ID)
       .eq('subscriber_email', subscriberEmail)
       .eq('ref_code', refCode)
       .limit(1)
@@ -403,7 +401,7 @@ async function updateReferralTracking(
 
       if (existing.source === 'custom_popup') {
         const { error: rejErr } = await supabaseAdmin.rpc('record_our_rejection', {
-          p_publication_id: DEFAULT_PUBLICATION_ID,
+          p_publication_id: PUBLICATION_ID,
           p_ref_code: refCode,
         })
         if (rejErr) console.error('[SparkLoop Webhook] Failed to record our rejection:', rejErr)
@@ -413,7 +411,7 @@ async function updateReferralTracking(
       await supabaseAdmin
         .from('sparkloop_referrals')
         .upsert({
-          publication_id: DEFAULT_PUBLICATION_ID,
+          publication_id: PUBLICATION_ID,
           subscriber_email: subscriberEmail,
           ref_code: refCode,
           source: 'webhook_only',
@@ -455,7 +453,7 @@ async function storeEvent(
   const { error } = await supabaseAdmin
     .from('sparkloop_events')
     .insert({
-      publication_id: DEFAULT_PUBLICATION_ID,
+      publication_id: PUBLICATION_ID,
       event_type: eventType,
       event_id: payload.id || payload.event_id,
       subscriber_email: subscriberEmail,

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { SlackNotificationService } from '@/lib/slack'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 // Stripe webhook event types we handle
 const CHECKOUT_SESSION_COMPLETED = 'checkout.session.completed'

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,12 +1,12 @@
 import { MetadataRoute } from 'next'
 import { supabaseAdmin } from '@/lib/supabase'
+import { PUBLICATION_ID, SITE_BASE_URL } from '@/lib/config'
 
 // Regenerate sitemap every hour (3600 seconds)
 // This ensures new tools, articles, and newsletters appear without redeploying
 export const revalidate = 3600
 
-const BASE_URL = 'https://aiaccountingdaily.com'
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+const BASE_URL = SITE_BASE_URL
 
 // Tool categories from directory.ts
 const TOOL_CATEGORIES = [

--- a/src/app/tools/[id]/page.tsx
+++ b/src/app/tools/[id]/page.tsx
@@ -9,8 +9,7 @@ import { Container } from '@/components/salient/Container'
 import { Button } from '@/components/salient/Button'
 import { ToolClickTracker } from './ToolClickTracker'
 import { ClaimListingButton } from './ClaimListingButton'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 
 interface ToolDetailPageProps {
   params: Promise<{ id: string }>

--- a/src/app/tools/actions.ts
+++ b/src/app/tools/actions.ts
@@ -4,8 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { supabaseAdmin } from '@/lib/supabase'
 import Stripe from 'stripe'
 import type { AIAppCategory } from '@/types/database'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from '@/lib/config'
 // Use SUPABASE_URL (server-side) instead of NEXT_PUBLIC_SUPABASE_URL
 const SUPABASE_STORAGE_URL = `${process.env.SUPABASE_URL}/storage/v1/object/public/tool-images/`
 

--- a/src/lib/__tests__/app-selector.test.ts
+++ b/src/lib/__tests__/app-selector.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { AppSelector } from '../app-selector'
+import type { AIApplication } from '@/types/database'
+
+function makeApp(overrides: Partial<AIApplication> = {}): AIApplication {
+  return {
+    id: crypto.randomUUID(),
+    app_name: 'Test App',
+    category: 'Productivity' as const,
+    is_affiliate: false,
+    is_active: true,
+    is_featured: false,
+    last_used_date: null,
+    publication_id: 'test',
+    ...overrides,
+  } as AIApplication
+}
+
+describe('AppSelector.isInCooldown', () => {
+  it('returns false for non-affiliate apps', () => {
+    const app = makeApp({ is_affiliate: false, last_used_date: new Date().toISOString() })
+    expect(AppSelector.isInCooldown(app, 7)).toBe(false)
+  })
+
+  it('returns false when app has never been used', () => {
+    const app = makeApp({ is_affiliate: true, last_used_date: null })
+    expect(AppSelector.isInCooldown(app, 7)).toBe(false)
+  })
+
+  it('returns true when affiliate was used within cooldown window', () => {
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
+    const app = makeApp({ is_affiliate: true, last_used_date: yesterday.toISOString() })
+    expect(AppSelector.isInCooldown(app, 7)).toBe(true)
+  })
+
+  it('returns false when affiliate was used outside cooldown window', () => {
+    const tenDaysAgo = new Date()
+    tenDaysAgo.setDate(tenDaysAgo.getDate() - 10)
+    const app = makeApp({ is_affiliate: true, last_used_date: tenDaysAgo.toISOString() })
+    expect(AppSelector.isInCooldown(app, 7)).toBe(false)
+  })
+})
+
+describe('AppSelector.getCategoryCounts', () => {
+  it('returns empty map for no apps', () => {
+    const counts = AppSelector.getCategoryCounts([])
+    expect(counts.size).toBe(0)
+  })
+
+  it('counts categories correctly', () => {
+    const apps = [
+      makeApp({ category: 'Productivity' }),
+      makeApp({ category: 'Productivity' }),
+      makeApp({ category: 'Tax & Compliance' }),
+    ]
+    const counts = AppSelector.getCategoryCounts(apps)
+    expect(counts.get('Productivity')).toBe(2)
+    expect(counts.get('Tax & Compliance')).toBe(1)
+  })
+
+  it('handles apps with no category as Unknown', () => {
+    const apps = [makeApp({ category: null })]
+    const counts = AppSelector.getCategoryCounts(apps)
+    expect(counts.get('Unknown')).toBe(1)
+  })
+})
+
+describe('AppSelector.wouldExceedCategoryMax', () => {
+  it('returns false when category has room', () => {
+    const existing = [makeApp({ category: 'Productivity' })]
+    const candidate = makeApp({ category: 'Productivity' })
+    expect(AppSelector.wouldExceedCategoryMax(candidate, existing, 3)).toBe(false)
+  })
+
+  it('returns true when category is at max', () => {
+    const existing = [
+      makeApp({ category: 'Productivity' }),
+      makeApp({ category: 'Productivity' }),
+      makeApp({ category: 'Productivity' }),
+    ]
+    const candidate = makeApp({ category: 'Productivity' })
+    expect(AppSelector.wouldExceedCategoryMax(candidate, existing, 3)).toBe(true)
+  })
+
+  it('allows different categories', () => {
+    const existing = [
+      makeApp({ category: 'Productivity' }),
+      makeApp({ category: 'Productivity' }),
+      makeApp({ category: 'Productivity' }),
+    ]
+    const candidate = makeApp({ category: 'Tax & Compliance' })
+    expect(AppSelector.wouldExceedCategoryMax(candidate, existing, 3)).toBe(false)
+  })
+})

--- a/src/lib/__tests__/rss-processor-refusal.test.ts
+++ b/src/lib/__tests__/rss-processor-refusal.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { RSSProcessor } from '../rss-processor'
+
+describe('RSSProcessor.detectAIRefusal', () => {
+  it('returns null for valid article content', () => {
+    const validContent = 'New AI tool streamlines accounting workflows for CPAs'
+    expect(RSSProcessor.detectAIRefusal(validContent)).toBeNull()
+  })
+
+  it('detects "I\'m sorry" refusals', () => {
+    const refusal = "I'm sorry, I need the actual article content to generate a summary."
+    expect(RSSProcessor.detectAIRefusal(refusal)).toBe("i'm sorry")
+  })
+
+  it('detects "I cannot" refusals', () => {
+    const refusal = 'I cannot generate content without access to the original article.'
+    expect(RSSProcessor.detectAIRefusal(refusal)).toBe('i cannot')
+  })
+
+  it('detects "please provide" refusals', () => {
+    const refusal = 'Please provide the article text so I can create a summary.'
+    expect(RSSProcessor.detectAIRefusal(refusal)).toBe('please provide')
+  })
+
+  it('detects "without access to" refusals', () => {
+    const refusal = 'Without access to the full article, it is not possible to summarize.'
+    expect(RSSProcessor.detectAIRefusal(refusal)).toBe('without access to')
+  })
+
+  it('is case-insensitive', () => {
+    expect(RSSProcessor.detectAIRefusal("I'M SORRY, I CANNOT")).toBe("i'm sorry")
+  })
+
+  it('handles empty string', () => {
+    expect(RSSProcessor.detectAIRefusal('')).toBeNull()
+  })
+
+  it('does not false-positive on normal content containing partial matches', () => {
+    // "provide" by itself should not trigger — only full phrases match
+    const content = 'This tool will provide accountants with better insights'
+    expect(RSSProcessor.detectAIRefusal(content)).toBeNull()
+  })
+})

--- a/src/lib/app-selector.ts
+++ b/src/lib/app-selector.ts
@@ -39,7 +39,7 @@ export class AppSelector {
    * Check if an affiliate app is within cooldown period
    * Cooldown is based on last_used_date which is set during send-final
    */
-  private static isInCooldown(app: AIApplication, cooldownDays: number): boolean {
+  static isInCooldown(app: AIApplication, cooldownDays: number): boolean {
     if (!app.is_affiliate || !app.last_used_date) {
       return false
     }
@@ -54,7 +54,7 @@ export class AppSelector {
   /**
    * Count how many apps from each category are already selected
    */
-  private static getCategoryCounts(selectedApps: AIApplication[]): Map<string, number> {
+  static getCategoryCounts(selectedApps: AIApplication[]): Map<string, number> {
     const counts = new Map<string, number>()
     for (const app of selectedApps) {
       const category = app.category || 'Unknown'
@@ -67,7 +67,7 @@ export class AppSelector {
   /**
    * Check if adding an app would exceed the category maximum
    */
-  private static wouldExceedCategoryMax(
+  static wouldExceedCategoryMax(
     app: AIApplication,
     selectedApps: AIApplication[],
     maxPerCategory: number

--- a/src/lib/bot-detection/__tests__/ua-detector.test.ts
+++ b/src/lib/bot-detection/__tests__/ua-detector.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { checkUserAgent } from '../ua-detector'
+
+describe('checkUserAgent', () => {
+  it('flags empty user agent as bot', () => {
+    expect(checkUserAgent('')).toEqual({ isBot: true, reason: 'Empty user agent' })
+    expect(checkUserAgent(null)).toEqual({ isBot: true, reason: 'Empty user agent' })
+    expect(checkUserAgent(undefined)).toEqual({ isBot: true, reason: 'Empty user agent' })
+  })
+
+  it('flags known bot patterns', () => {
+    const bots = [
+      'Googlebot/2.1 (+http://www.google.com/bot.html)',
+      'python-requests/2.28.0',
+      'curl/7.88.1',
+      'Mozilla/5.0 (compatible; Bingbot/2.0)',
+      'Barracuda/5.0',
+      'HeadlessChrome/120.0',
+    ]
+    for (const ua of bots) {
+      const result = checkUserAgent(ua)
+      expect(result.isBot, `Expected "${ua}" to be flagged as bot`).toBe(true)
+      expect(result.reason).toBeTruthy()
+    }
+  })
+
+  it('allows legitimate browser user agents', () => {
+    const browsers = [
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
+    ]
+    for (const ua of browsers) {
+      const result = checkUserAgent(ua)
+      expect(result.isBot, `Expected "${ua}" to pass as legitimate`).toBe(false)
+      expect(result.reason).toBeNull()
+    }
+  })
+
+  it('is case-insensitive', () => {
+    expect(checkUserAgent('GOOGLEBOT').isBot).toBe(true)
+    expect(checkUserAgent('Python-Requests/2.0').isBot).toBe(true)
+  })
+})

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,23 @@
+/**
+ * Centralized configuration
+ *
+ * Reads from environment variables with hardcoded fallbacks so existing
+ * deployments continue to work while new contributors can set their own values.
+ */
+
+const FALLBACK_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+
+export const PUBLICATION_ID: string = (() => {
+  const envValue = process.env.DEFAULT_PUBLICATION_ID
+  if (envValue) return envValue
+  if (process.env.NODE_ENV === 'development') {
+    console.warn(
+      '[Config] DEFAULT_PUBLICATION_ID not set — using hardcoded fallback. ' +
+      'Set it in .env.local for your own Supabase instance.'
+    )
+  }
+  return FALLBACK_PUBLICATION_ID
+})()
+
+export const SITE_BASE_URL: string =
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://aiaccountingdaily.com'

--- a/src/lib/directory.ts
+++ b/src/lib/directory.ts
@@ -1,7 +1,6 @@
 import { supabaseAdmin } from './supabase'
+import { PUBLICATION_ID } from './config'
 import type { AIApplication, AIAppCategory } from '@/types/database'
-
-const PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf' // AI Accounting Daily
 
 // Categories derived from AIAppCategory type
 const CATEGORIES: { id: string; name: AIAppCategory; slug: string; description: string }[] = [
@@ -38,7 +37,7 @@ export interface DirectoryCategory {
 /**
  * Transform AIApplication to DirectoryApp format for UI compatibility
  */
-function transformApp(app: AIApplication): DirectoryApp {
+export function transformApp(app: AIApplication): DirectoryApp {
   const category = CATEGORIES.find(c => c.name === app.category) || CATEGORIES[4] // Default to Productivity
 
   return {

--- a/src/lib/rss-processor.ts
+++ b/src/lib/rss-processor.ts
@@ -71,7 +71,7 @@ export class RSSProcessor {
    * Detect AI refusal/apology messages that should never be stored as article content.
    * Returns the matched phrase if a refusal is detected, or null if content is valid.
    */
-  private static detectAIRefusal(content: string): string | null {
+  static detectAIRefusal(content: string): string | null {
     const lower = content.toLowerCase().trim()
     for (const phrase of RSSProcessor.AI_REFUSAL_PATTERNS) {
       if (lower.includes(phrase)) {

--- a/src/lib/sparkloop-client.ts
+++ b/src/lib/sparkloop-client.ts
@@ -31,8 +31,7 @@ function normalizeGmailAddress(email: string): string {
   return email
 }
 
-// Default publication ID for AI Pro Daily
-const DEFAULT_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+import { PUBLICATION_ID } from './config'
 
 export class SparkLoopService {
   private apiKey: string
@@ -342,7 +341,7 @@ export class SparkLoopService {
    * Also fetches budget info to auto-exclude out-of-budget recommendations
    * Tracks deltas in confirms/rejections for timeframe-based RCR calculation
    */
-  async syncRecommendationsToDatabase(publicationId: string = DEFAULT_PUBLICATION_ID): Promise<{
+  async syncRecommendationsToDatabase(publicationId: string = PUBLICATION_ID): Promise<{
     synced: number
     created: number
     updated: number
@@ -598,7 +597,7 @@ export class SparkLoopService {
    * Get stored recommendations from our database
    * Falls back to API if no stored data
    */
-  async getStoredRecommendations(publicationId: string = DEFAULT_PUBLICATION_ID): Promise<StoredSparkLoopRecommendation[]> {
+  async getStoredRecommendations(publicationId: string = PUBLICATION_ID): Promise<StoredSparkLoopRecommendation[]> {
     const { data, error } = await supabaseAdmin
       .from('sparkloop_recommendations')
       .select('*')
@@ -627,7 +626,7 @@ export class SparkLoopService {
   /**
    * Increment impression count for recommendations shown in popup
    */
-  static async recordImpressions(refCodes: string[], publicationId: string = DEFAULT_PUBLICATION_ID): Promise<void> {
+  static async recordImpressions(refCodes: string[], publicationId: string = PUBLICATION_ID): Promise<void> {
     if (refCodes.length === 0) return
 
     const { error } = await supabaseAdmin.rpc('increment_sparkloop_impressions', {
@@ -645,7 +644,7 @@ export class SparkLoopService {
   /**
    * Increment selection count when user selects a recommendation
    */
-  static async recordSelections(refCodes: string[], publicationId: string = DEFAULT_PUBLICATION_ID): Promise<void> {
+  static async recordSelections(refCodes: string[], publicationId: string = PUBLICATION_ID): Promise<void> {
     if (refCodes.length === 0) return
 
     const { error } = await supabaseAdmin.rpc('increment_sparkloop_selections', {
@@ -661,7 +660,7 @@ export class SparkLoopService {
   /**
    * Increment submission count when user submits selections
    */
-  static async recordSubmissions(refCodes: string[], publicationId: string = DEFAULT_PUBLICATION_ID): Promise<void> {
+  static async recordSubmissions(refCodes: string[], publicationId: string = PUBLICATION_ID): Promise<void> {
     if (refCodes.length === 0) return
 
     const { error } = await supabaseAdmin.rpc('increment_sparkloop_submissions', {
@@ -679,7 +678,7 @@ export class SparkLoopService {
   /**
    * Record a confirmed referral (called from webhook handler)
    */
-  static async recordConfirm(refCode: string, publicationId: string = DEFAULT_PUBLICATION_ID): Promise<void> {
+  static async recordConfirm(refCode: string, publicationId: string = PUBLICATION_ID): Promise<void> {
     const { error } = await supabaseAdmin.rpc('record_sparkloop_confirm', {
       p_publication_id: publicationId,
       p_ref_code: refCode,
@@ -695,7 +694,7 @@ export class SparkLoopService {
   /**
    * Record a rejected referral (called from webhook handler)
    */
-  static async recordRejection(refCode: string, publicationId: string = DEFAULT_PUBLICATION_ID): Promise<void> {
+  static async recordRejection(refCode: string, publicationId: string = PUBLICATION_ID): Promise<void> {
     const { error } = await supabaseAdmin.rpc('record_sparkloop_rejection', {
       p_publication_id: publicationId,
       p_ref_code: refCode,
@@ -779,7 +778,7 @@ export class SparkLoopService {
   static async calculateRCRForTimeframe(
     refCode: string,
     days: number = 30,
-    publicationId: string = DEFAULT_PUBLICATION_ID
+    publicationId: string = PUBLICATION_ID
   ): Promise<number | null> {
     const since = new Date()
     since.setDate(since.getDate() - days)
@@ -820,7 +819,7 @@ export class SparkLoopService {
    */
   static async getRCRsForTimeframe(
     days: number = 30,
-    publicationId: string = DEFAULT_PUBLICATION_ID
+    publicationId: string = PUBLICATION_ID
   ): Promise<Map<string, number>> {
     const since = new Date()
     since.setDate(since.getDate() - days)
@@ -878,7 +877,7 @@ export class SparkLoopService {
    * Upserts one row per recommendation for today's date
    * Idempotent — last sync of the day wins
    */
-  async takeDailySnapshot(publicationId: string = DEFAULT_PUBLICATION_ID): Promise<number> {
+  async takeDailySnapshot(publicationId: string = PUBLICATION_ID): Promise<number> {
     const today = new Date().toISOString().split('T')[0]
 
     const { data: recs, error } = await supabaseAdmin
@@ -930,7 +929,7 @@ export class SparkLoopService {
    */
   static async calculateRollingWindowMetrics(
     windowDays: number = 14,
-    publicationId: string = DEFAULT_PUBLICATION_ID
+    publicationId: string = PUBLICATION_ID
   ): Promise<Map<string, {
     rcr: number | null
     slippage_rate: number | null
@@ -1084,7 +1083,7 @@ export class SparkLoopService {
    * Returns a map of ref_code -> metrics for use in scoring
    */
   static async getStoredMetrics(
-    publicationId: string = DEFAULT_PUBLICATION_ID
+    publicationId: string = PUBLICATION_ID
   ): Promise<Map<string, { our_cr: number | null; our_rcr: number | null }>> {
     const { data } = await supabaseAdmin
       .from('sparkloop_recommendations')

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'node',
+    include: ['src/**/__tests__/**/*.test.ts'],
+    env: {
+      // Stub values so Supabase client initializes without errors during import.
+      // Tests that actually call Supabase should mock the module instead.
+      SUPABASE_URL: 'https://test.supabase.co',
+      SUPABASE_ANON_KEY: 'test-anon-key',
+      SUPABASE_SERVICE_ROLE_KEY: 'test-service-role-key',
+      OPENAI_API_KEY: 'test-openai-key',
+    },
+  },
+})


### PR DESCRIPTION
Extract PUBLICATION_ID from 36 files into src/lib/config.ts with env var support (DEFAULT_PUBLICATION_ID, NEXT_PUBLIC_SITE_URL) so new contributors can run against their own Supabase instance. Add Vitest with 22 starter tests covering bot detection, app selector cooldown/category logic, and AI refusal detection.

## Summary

<!-- Brief description of what this PR does (1-3 bullet points) -->

-

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Testing

<!-- How did you verify this works? -->

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] `npm run type-check` passes
- [ ] Manually tested locally
- [ ] Tested against dev Supabase (not production)

## Checklist

- [ ] All database queries filter by `publication_id`
- [ ] No `SELECT *` in new/modified queries
- [ ] No hardcoded secrets or API keys
- [ ] Logging uses one-line format with prefixes (`[Workflow]`, `[RSS]`, etc.)
- [ ] Error handling includes try/catch where appropriate
- [ ] Related docs updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added environment variable configuration for publication ID and site URL, enabling flexible deployment across different environments
  * Integrated comprehensive testing framework (Vitest) with initial test coverage to improve code quality and reliability
  * Consolidated application settings into a centralized configuration module, eliminating hardcoded values for better maintainability and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->