### PR TITLE
Add image_alt fields for accessible, safe newsletter alt text

### DIFF
--- a/db/migrations/add_image_alt_columns.sql
+++ b/db/migrations/add_image_alt_columns.sql
@@ -1,0 +1,24 @@
+-- Add image_alt columns for accessible alt text on newsletter images
+-- Each column is VARCHAR(200) to enforce a reasonable alt text length
+
+-- Article source images (RSS posts)
+ALTER TABLE rss_posts ADD COLUMN IF NOT EXISTS image_alt VARCHAR(200);
+
+-- Article AI images and module articles
+ALTER TABLE module_articles ADD COLUMN IF NOT EXISTS image_alt VARCHAR(200);
+
+-- Advertisement images (legacy advertorial system)
+ALTER TABLE advertisements ADD COLUMN IF NOT EXISTS image_alt VARCHAR(200);
+
+-- Text box block images (static and AI-generated)
+ALTER TABLE text_box_blocks ADD COLUMN IF NOT EXISTS image_alt VARCHAR(200);
+
+-- Per-issue text box block images (overrides)
+ALTER TABLE issue_text_box_blocks ADD COLUMN IF NOT EXISTS image_alt VARCHAR(200);
+
+-- Poll images
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS image_alt VARCHAR(200);
+
+-- AI application logos and screenshots
+ALTER TABLE ai_applications ADD COLUMN IF NOT EXISTS logo_alt VARCHAR(200);
+ALTER TABLE ai_applications ADD COLUMN IF NOT EXISTS screenshot_alt VARCHAR(200);

--- a/src/app/dashboard/[slug]/databases/ads/page.tsx
+++ b/src/app/dashboard/[slug]/databases/ads/page.tsx
@@ -1039,7 +1039,8 @@ function AddAdModal({ onClose, onSuccess, publicationId, selectedSection, sectio
   const [formData, setFormData] = useState({
     title: '',
     body: '',
-    button_url: ''
+    button_url: '',
+    image_alt: ''
   })
   const [selectedImage, setSelectedImage] = useState<string | null>(null)
   const [crop, setCrop] = useState<Crop>()
@@ -1340,6 +1341,26 @@ function AddAdModal({ onClose, onSuccess, publicationId, selectedSection, sectio
             </div>
           )}
 
+          {/* Image Alt Text */}
+          {selectedImage && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Image Alt Text
+              </label>
+              <input
+                type="text"
+                maxLength={200}
+                value={formData.image_alt}
+                onChange={(e) => setFormData(prev => ({ ...prev, image_alt: e.target.value }))}
+                placeholder="Brief image description (max 200 chars)"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                Accessible description for the ad image.
+              </p>
+            </div>
+          )}
+
           {/* URL */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -1395,6 +1416,7 @@ function EditAdModal({ ad, onClose, onSuccess, publicationId }: { ad: AdWithRela
     title: ad.title,
     body: ad.body,
     button_url: ad.button_url,
+    image_alt: ad.image_alt || '',
     status: ad.status,
     paid: ad.paid || false,
     frequency: ad.frequency || 'weekly',
@@ -1722,6 +1744,26 @@ function EditAdModal({ ad, onClose, onSuccess, publicationId }: { ad: AdWithRela
               />
               <p className="text-xs text-gray-500 mt-1">
                 Upload an image for your ad. It will be cropped to 16:9 ratio.
+              </p>
+            </div>
+          )}
+
+          {/* Image Alt Text */}
+          {(ad.image_url || selectedImage) && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Image Alt Text
+              </label>
+              <input
+                type="text"
+                maxLength={200}
+                value={formData.image_alt}
+                onChange={(e) => setFormData(prev => ({ ...prev, image_alt: e.target.value }))}
+                placeholder="Brief image description (max 200 chars)"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                Accessible description for the ad image. Keep it short and descriptive.
               </p>
             </div>
           )}

--- a/src/app/dashboard/[slug]/databases/ai-apps/page.tsx
+++ b/src/app/dashboard/[slug]/databases/ai-apps/page.tsx
@@ -499,6 +499,21 @@ export default function AIApplicationsPage() {
                   placeholder="https://example.com/logo.png"
                 />
               </div>
+              {addForm.logo_url && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Logo Alt Text
+                  </label>
+                  <input
+                    type="text"
+                    maxLength={200}
+                    value={addForm.logo_alt || ''}
+                    onChange={(e) => setAddForm({ ...addForm, logo_alt: e.target.value })}
+                    className="w-full border border-gray-300 rounded px-3 py-2"
+                    placeholder="Brief logo description (max 200 chars)"
+                  />
+                </div>
+              )}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Assign to Module

--- a/src/app/dashboard/[slug]/polls/page.tsx
+++ b/src/app/dashboard/[slug]/polls/page.tsx
@@ -28,6 +28,7 @@ export default function PollsPage() {
   const [formQuestion, setFormQuestion] = useState('')
   const [formOptions, setFormOptions] = useState<string[]>(['', '', ''])
   const [formImageUrl, setFormImageUrl] = useState('')
+  const [formImageAlt, setFormImageAlt] = useState('')
 
   // Extract publication slug from pathname and fetch publication ID
   useEffect(() => {
@@ -120,6 +121,7 @@ export default function PollsPage() {
           question: formQuestion,
           options: validOptions,
           image_url: formImageUrl || null,
+          image_alt: formImageAlt || null,
           is_active: false
         })
       })
@@ -157,7 +159,8 @@ export default function PollsPage() {
           title: formTitle,
           question: formQuestion,
           options: validOptions,
-          image_url: formImageUrl || null
+          image_url: formImageUrl || null,
+          image_alt: formImageAlt || null
         })
       })
 
@@ -239,6 +242,7 @@ export default function PollsPage() {
     setFormQuestion(poll.question)
     setFormOptions([...poll.options])
     setFormImageUrl(poll.image_url || '')
+    setFormImageAlt(poll.image_alt || '')
     setShowEditForm(true)
   }
 
@@ -390,6 +394,19 @@ export default function PollsPage() {
                   <p className="text-xs text-gray-500 mt-1">
                     Add an image to display with the poll (only shown if poll module has image block enabled)
                   </p>
+                  {formImageUrl && (
+                    <div className="mt-2">
+                      <label className="block text-sm font-medium mb-1">Image Alt Text</label>
+                      <input
+                        type="text"
+                        maxLength={200}
+                        value={formImageAlt}
+                        onChange={(e) => setFormImageAlt(e.target.value)}
+                        className="w-full border rounded px-3 py-2"
+                        placeholder="Brief image description (max 200 chars)"
+                      />
+                    </div>
+                  )}
                   {formImageUrl && (
                     <div className="mt-2">
                       <img

--- a/src/components/text-box-modules/TextBoxModuleSettings.tsx
+++ b/src/components/text-box-modules/TextBoxModuleSettings.tsx
@@ -254,6 +254,7 @@ export function TextBoxModuleSettings({
   // Image editing
   const [editImageType, setEditImageType] = useState<'static' | 'ai_generated'>('static')
   const [editAiImagePrompt, setEditAiImagePrompt] = useState('')
+  const [editImageAlt, setEditImageAlt] = useState('')
   const [selectedImage, setSelectedImage] = useState<string | null>(null)
   const [crop, setCrop] = useState<Crop>()
   const [completedCrop, setCompletedCrop] = useState<PixelCrop>()
@@ -446,6 +447,7 @@ export function TextBoxModuleSettings({
     } else if (block.block_type === 'image') {
       setEditImageType((block.image_type as any) || 'static')
       setEditAiImagePrompt(block.ai_image_prompt || '')
+      setEditImageAlt(block.image_alt || '')
       setSelectedImage(null)
       setCrop(undefined)
       setCompletedCrop(undefined)
@@ -592,6 +594,7 @@ export function TextBoxModuleSettings({
         updateData.is_italic = editIsItalic
       } else if (block.block_type === 'image') {
         updateData.image_type = editImageType
+        updateData.image_alt = editImageAlt || null
 
         if (editImageType === 'ai_generated') {
           updateData.ai_image_prompt = editAiImagePrompt
@@ -881,6 +884,18 @@ export function TextBoxModuleSettings({
                   )}
                 </div>
               )}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Image Alt Text</label>
+                <input
+                  type="text"
+                  maxLength={200}
+                  value={editImageAlt}
+                  onChange={(e) => setEditImageAlt(e.target.value)}
+                  placeholder="Brief image description (max 200 chars)"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                />
+                <p className="text-xs text-gray-500 mt-1">Accessible description for this image.</p>
+              </div>
               {editImageType === 'ai_generated' && (
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">AI Image Prompt</label>

--- a/src/lib/ad-modules/ad-renderer.ts
+++ b/src/lib/ad-modules/ad-renderer.ts
@@ -44,6 +44,7 @@ export class AdModuleRenderer {
       title: ad.title,
       body: ad.body,
       image_url: ad.image_url,
+      image_alt: (ad as any).image_alt || undefined,
       button_text: ad.button_text,
       button_url: ad.button_url,
       trackingUrl
@@ -227,6 +228,7 @@ export class AdModuleRenderer {
       title?: string
       body?: string
       image_url?: string
+      image_alt?: string | null
       button_text?: string
       button_url?: string
     },
@@ -240,6 +242,7 @@ export class AdModuleRenderer {
       title: ad.title,
       body: ad.body,
       image_url: ad.image_url,
+      image_alt: ad.image_alt || undefined,
       button_text: ad.button_text,
       button_url: ad.button_url,
       trackingUrl: linkUrl

--- a/src/lib/ai-app-modules/app-module-renderer.ts
+++ b/src/lib/ai-app-modules/app-module-renderer.ts
@@ -5,6 +5,7 @@
 
 import { wrapTrackingUrl, type LinkType } from '../url-tracking'
 import { getBusinessSettings } from '../publication-settings'
+import { sanitizeAltText } from '../utils/sanitize-alt-text'
 import type {
   AIAppModule,
   AIApplication,
@@ -167,18 +168,20 @@ export class AppModuleRenderer {
         if (!app.logo_url) return ''
         const logoStyle = this.getLogoStyle(styles)
         const borderRadius = logoStyle === 'round' ? '50%' : '8px'
+        const logoAlt = sanitizeAltText(app.logo_alt, app.app_name)
         return `<a href="${trackingUrl}">
-          <img src="${app.logo_url}" alt="${app.app_name}"
+          <img src="${app.logo_url}" alt="${logoAlt}"
             style="width: 48px; height: 48px; border-radius: ${borderRadius}; object-fit: cover; vertical-align: middle;" />
         </a>`
       }
 
       case 'image': {
         if (!app.screenshot_url) return ''
+        const screenshotAlt = sanitizeAltText(app.screenshot_alt, app.app_name)
         return `
           <div style="margin: 12px 0;">
             <a href="${trackingUrl}">
-              <img src="${app.screenshot_url}" alt="${app.app_name}"
+              <img src="${app.screenshot_url}" alt="${screenshotAlt}"
                 style="max-width: 100%; border-radius: 8px; border: 1px solid #e0e0e0;" />
             </a>
           </div>`
@@ -551,18 +554,20 @@ export class AppModuleRenderer {
           }
           case 'logo':
             if (app.logo_url) {
+              const archiveLogoAlt = sanitizeAltText((app as any).logo_alt, app.app_name)
               blocksHtml += `
                 <div style="margin: 8px 0;">
-                  <img src="${app.logo_url}" alt="${app.app_name}"
+                  <img src="${app.logo_url}" alt="${archiveLogoAlt}"
                     style="width: 48px; height: 48px; border-radius: 8px;" />
                 </div>`
             }
             break
           case 'image':
             if (app.screenshot_url) {
+              const archiveScreenshotAlt = sanitizeAltText((app as any).screenshot_alt, app.app_name)
               blocksHtml += `
                 <div style="margin: 12px 0;">
-                  <img src="${app.screenshot_url}" alt="${app.app_name}"
+                  <img src="${app.screenshot_url}" alt="${archiveScreenshotAlt}"
                     style="max-width: 100%; border-radius: 8px;" />
                 </div>`
             }

--- a/src/lib/blocks/renderers/image.ts
+++ b/src/lib/blocks/renderers/image.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BlockData, BlockStyleOptions, BlockRenderContext } from '../types'
+import { sanitizeAltText } from '../../utils/sanitize-alt-text'
 
 /**
  * Render an image block with optional link
@@ -23,7 +24,7 @@ export function renderImageBlock(
   if (!imageUrl) return ''
 
   const linkUrl = data.trackingUrl || data.button_url || '#'
-  const altText = data.title || data.headline || 'Image'
+  const altText = sanitizeAltText(data.image_alt || data.title || data.headline)
 
   const imageTag = `<img src='${imageUrl}' alt='${altText}' style='max-width: 100%; max-height: 500px; border-radius: 4px; display: block; margin: 0 auto;'>`
 

--- a/src/lib/blocks/types.ts
+++ b/src/lib/blocks/types.ts
@@ -83,6 +83,7 @@ export interface BlockData {
 
   // Media
   image_url?: string
+  image_alt?: string
 
   // Links
   button_url?: string

--- a/src/lib/newsletter-archiver.ts
+++ b/src/lib/newsletter-archiver.ts
@@ -146,7 +146,7 @@ export class NewsletterArchiver {
         if (allAppIds.length > 0) {
           const { data: apps } = await supabaseAdmin
             .from('ai_applications')
-            .select('id, app_name, tagline, description, app_url, logo_url, category, tool_type')
+            .select('id, app_name, tagline, description, app_url, logo_url, logo_alt, screenshot_url, screenshot_alt, category, tool_type')
             .in('id', allAppIds)
 
           if (apps) {

--- a/src/lib/poll-modules/poll-renderer.ts
+++ b/src/lib/poll-modules/poll-renderer.ts
@@ -7,6 +7,7 @@
 
 import { getBusinessSettings } from '../publication-settings'
 import type { BlockStyleOptions } from '../blocks'
+import { sanitizeAltText } from '../utils/sanitize-alt-text'
 import type { PollModule, Poll, PollSnapshot, PollBlockType } from '@/types/database'
 
 /**
@@ -109,7 +110,8 @@ export class PollModuleRenderer {
         blocksHtml += `<p style="margin:0 0 14px 0; font-size:16px; color:#ffffff; text-align:center;">${poll.question}</p>`
       }
       else if (blockType === 'image' && poll.image_url) {
-        blocksHtml += `<img src="${poll.image_url}" alt="${poll.title || 'Poll image'}" style="max-width:100%; height:auto; border-radius:8px; margin:0 0 14px 0;" />`
+        const pollAlt = sanitizeAltText((poll as any).image_alt || poll.title, 'Poll image')
+        blocksHtml += `<img src="${poll.image_url}" alt="${pollAlt}" style="max-width:100%; height:auto; border-radius:8px; margin:0 0 14px 0;" />`
       }
       else if (blockType === 'options' && poll.options && poll.options.length > 0) {
         // Use tertiary color for button background, primary color for text
@@ -181,7 +183,8 @@ export class PollModuleRenderer {
         blocksHtml += `<p style="margin:0 0 14px 0; font-size:16px; color:#ffffff; text-align:center;">${pollSnapshot.question}</p>`
       }
       else if (blockType === 'image' && pollSnapshot.image_url) {
-        blocksHtml += `<img src="${pollSnapshot.image_url}" alt="${pollSnapshot.title || 'Poll image'}" style="max-width:100%; height:auto; border-radius:8px; margin:0 0 14px 0;" />`
+        const archivePollAlt = sanitizeAltText((pollSnapshot as any).image_alt || pollSnapshot.title, 'Poll image')
+        blocksHtml += `<img src="${pollSnapshot.image_url}" alt="${archivePollAlt}" style="max-width:100%; height:auto; border-radius:8px; margin:0 0 14px 0;" />`
       }
       else if (blockType === 'options' && pollSnapshot.options && pollSnapshot.options.length > 0) {
         // Static options display (no clickable links for archive)

--- a/src/lib/text-box-modules/text-box-renderer.ts
+++ b/src/lib/text-box-modules/text-box-renderer.ts
@@ -7,6 +7,7 @@
 
 import { getBusinessSettings } from '../publication-settings'
 import type { BlockStyleOptions } from '../blocks'
+import { sanitizeAltText } from '../utils/sanitize-alt-text'
 import type {
   TextBoxModule,
   TextBoxBlock,
@@ -213,10 +214,11 @@ export class TextBoxModuleRenderer {
       return ''
     }
 
+    const altText = sanitizeAltText(issueBlock?.image_alt || block.image_alt)
     return `
 <tr>
   <td align="center" style="padding: 16px 10px;">
-    <img src="${imageUrl}" alt="" style="max-width: 100%; height: auto; border-radius: 8px; display: block;" />
+    <img src="${imageUrl}" alt="${altText}" style="max-width: 100%; height: auto; border-radius: 8px; display: block;" />
   </td>
 </tr>`
   }
@@ -294,6 +296,7 @@ export class TextBoxModuleRenderer {
       type: 'static_text' | 'ai_prompt' | 'image'
       content?: string
       imageUrl?: string
+      imageAlt?: string
       textSize?: TextSize
       isBold?: boolean
       isItalic?: boolean
@@ -327,10 +330,11 @@ export class TextBoxModuleRenderer {
 </tr>`
         }
       } else if (block.type === 'image' && block.imageUrl) {
+        const blockAlt = sanitizeAltText(block.imageAlt)
         blocksHtml += `
 <tr>
   <td align="center" style="padding: 16px 10px;">
-    <img src="${block.imageUrl}" alt="" style="max-width: 100%; height: auto; border-radius: 8px; display: block;" />
+    <img src="${block.imageUrl}" alt="${blockAlt}" style="max-width: 100%; height: auto; border-radius: 8px; display: block;" />
   </td>
 </tr>`
       }

--- a/src/lib/utils/sanitize-alt-text.ts
+++ b/src/lib/utils/sanitize-alt-text.ts
@@ -1,0 +1,13 @@
+/**
+ * Sanitize text for use in HTML alt attributes.
+ * Strips quotes, normalizes whitespace, and enforces 200 char limit.
+ */
+export function sanitizeAltText(text: string | null | undefined, fallback = 'Image'): string {
+  if (!text) return fallback
+  return text
+    .replace(/['"]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 200)
+    || fallback
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -53,7 +53,9 @@ export interface AIApplication {
   app_url: string
   tracked_link: string | null
   logo_url: string | null
+  logo_alt: string | null
   screenshot_url: string | null
+  screenshot_alt: string | null
   tool_type: ToolType | null
   category_priority: number
   is_featured: boolean
@@ -238,6 +240,7 @@ export interface RssPost {
   publication_date: string | null
   source_url: string | null
   image_url: string | null
+  image_alt: string | null
   processed_at: string
   breaking_news_score: number | null
   breaking_news_category: string | null
@@ -563,6 +566,7 @@ export interface Poll {
   question: string
   options: string[]
   image_url?: string
+  image_alt?: string | null
   is_active: boolean
   created_at: string
   updated_at: string
@@ -599,6 +603,7 @@ export interface PollSnapshot {
   question: string
   options: string[]
   image_url?: string
+  image_alt?: string | null
 }
 
 export interface IssuePollModule {
@@ -1183,6 +1188,7 @@ export interface Advertisement {
   button_text: string
   button_url: string
   image_url: string | null  // Optional cropped image (5:4 ratio)
+  image_alt: string | null
   frequency: AdFrequency
   times_paid: number
   times_used: number
@@ -1603,6 +1609,7 @@ export interface ModuleArticle {
   ai_summary: string | null
   ai_title: string | null
   ai_image_url: string | null
+  image_alt: string | null
   created_at: string
   updated_at: string
 }
@@ -1683,6 +1690,7 @@ export interface TextBoxBlock {
   image_type: ImageType | null
   static_image_url: string | null  // URL for static uploaded images
   ai_image_prompt: string | null  // Prompt for AI image generation
+  image_alt: string | null  // Alt text for the image (max 200 chars)
 
   // Common fields
   is_active: boolean
@@ -1714,6 +1722,7 @@ export interface IssueTextBoxBlock {
   // Manual override content (user can override AI content)
   override_content: string | null
   override_image_url: string | null
+  image_alt: string | null  // Alt text override for this issue's image
 
   // Status tracking
   generation_status: TextBoxGenerationStatus


### PR DESCRIPTION
Previously, image alt attributes used raw headlines and ad titles which were too long and contained quotes that broke HTML syntax. This adds dedicated image_alt columns (max 200 chars) to all image-bearing tables, a sanitization helper, UI inputs in dashboard management pages, and updates all renderers to use the new fields with proper fallbacks.

## Summary

<!-- Brief description of what this PR does (1-3 bullet points) -->

-

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Testing

<!-- How did you verify this works? -->

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] `npm run type-check` passes
- [ ] Manually tested locally
- [ ] Tested against dev Supabase (not production)

## Checklist

- [ ] All database queries filter by `publication_id`
- [ ] No `SELECT *` in new/modified queries
- [ ] No hardcoded secrets or API keys
- [ ] Logging uses one-line format with prefixes (`[Workflow]`, `[RSS]`, etc.)
- [ ] Error handling includes try/catch where appropriate
- [ ] Related docs updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image alt text input fields across ad, poll, and article management forms
  * Added logo and screenshot alt text inputs for AI application creation
  * Alt text now captured and displayed when rendering content in newsletters and archives
  * Alt text limited to 200 characters with built-in validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->