### PR TITLE
Fix MailerLite main group ID not saving

### DIFF
--- a/src/app/api/settings/email/route.ts
+++ b/src/app/api/settings/email/route.ts
@@ -79,8 +79,14 @@ export async function GET(request: NextRequest) {
           'mailerlite_group_id': 'mailerliteMainGroupId'
         }
         const uiKey = keyMap[row.key] || row.key.replace('mailerlite_', 'mailerlite')
-        // Don't overwrite if we already have a value (prefer new key over legacy)
-        if (!savedSettings[uiKey]) {
+        const isLegacyKey = row.key === 'mailerlite_group_id'
+        if (isLegacyKey) {
+          // Legacy key - only use as fallback if new key hasn't set this yet
+          if (!savedSettings[uiKey]) {
+            savedSettings[uiKey] = cleanValue
+          }
+        } else {
+          // New key - always use (overwrite legacy value if present)
           savedSettings[uiKey] = cleanValue
         }
       } else if (row.key.startsWith('email_')) {


### PR DESCRIPTION
## Summary
- Legacy `mailerlite_group_id` key was overriding the new `mailerlite_main_group_id` value when loading settings due to alphabetical DB row ordering
- New keys now always take precedence, with legacy keys used only as fallbacks

## Test plan
- [ ] Change Main Group ID in Settings > Email > MailerLite Configuration
- [ ] Click Save Email & Schedule Settings
- [ ] Reload page and verify the new value persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced MailerLite configuration settings to properly prioritize newer values while maintaining backward compatibility with legacy settings as fallback options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->