### PR TITLE
Change 'Manage Preferences' to 'Get Fewer Emails' in footer

### DIFF
--- a/src/lib/newsletter-templates.ts
+++ b/src/lib/newsletter-templates.ts
@@ -1842,7 +1842,7 @@ ${socialMediaSection}
     <td style="font-family: Arial, sans-serif; font-size: 12px; color: #777; text-align: center; padding: 20px 10px; border-top: 1px solid #ccc; background-color: #ffffff;">
       <p style="margin: 0;text-align: center;">You're receiving this email because you subscribed to <strong>${newsletterName}</strong>.</p>
       <p style="margin: 5px 0 0;text-align: center;">
-        <a href="${websiteUrl}/unsubscribe?email={$email}" style='text-decoration: underline;'>Manage Preferences</a> | <a href="${websiteUrl}/unsubscribe?email={$email}" style='text-decoration: underline;'>Unsubscribe</a>
+        <a href="${websiteUrl}/unsubscribe?email={$email}" style='text-decoration: underline;'>Get Fewer Emails</a> | <a href="${websiteUrl}/unsubscribe?email={$email}" style='text-decoration: underline;'>Unsubscribe</a>
       </p>
       <p style="margin: 5px 0 0;text-align: center;">©${currentYear} {$account}, all rights reserved</p>
       <p style="margin: 2px 0 0;text-align: center;">${businessAddress}</p>


### PR DESCRIPTION
## Summary
- Changes the newsletter footer link text from "Manage Preferences" to "Get Fewer Emails"
- Clearer CTA that communicates subscribers can reduce email frequency

## Test plan
- [ ] Verify newsletter preview shows "Get Fewer Emails" in footer
- [ ] Verify the link still points to the unsubscribe/preferences page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the text for the unsubscribe preference link in newsletter footers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->