### PR TITLE
Fix honeypot link to use homepage instead of example.com

### DIFF
--- a/src/lib/bot-detection/constants.ts
+++ b/src/lib/bot-detection/constants.ts
@@ -91,6 +91,4 @@ export const VELOCITY_THRESHOLD = {
 export const HONEYPOT_CONFIG = {
   /** Section name used for honeypot links */
   SECTION_NAME: 'Honeypot',
-  /** Dummy URL used for honeypot links (never actually visited) */
-  DUMMY_URL: 'https://example.com/hp'
 }

--- a/src/lib/newsletter-templates.ts
+++ b/src/lib/newsletter-templates.ts
@@ -1833,7 +1833,7 @@ export async function generateNewsletterFooter(issueDate?: string, issueId?: str
 
   // Generate honeypot link for bot detection (disguised as comma in address)
   const honeypotUrl = issueDate
-    ? wrapTrackingUrl(HONEYPOT_CONFIG.DUMMY_URL, HONEYPOT_CONFIG.SECTION_NAME, issueDate, issueId)
+    ? wrapTrackingUrl(websiteUrl, HONEYPOT_CONFIG.SECTION_NAME, issueDate, issueId)
     : null
 
   // Split address at "Saint Joseph," to embed honeypot as the comma


### PR DESCRIPTION
## Summary
- Honeypot bot detection link was hardcoded to `example.com/hp` — now redirects to the publication's homepage URL
- Removed unused `DUMMY_URL` constant from bot-detection config

## Test plan
- [ ] `npm run build` passes
- [ ] Preview a newsletter email and inspect the honeypot link in the footer (hidden comma link) — should point to homepage via tracking URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected honeypot tracking configuration to use actual website URLs instead of placeholder values, improving bot detection accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->