### PR TITLE
Fix ad image_alt not persisting on save

### DIFF
--- a/src/app/api/ad-modules/[id]/companies/route.ts
+++ b/src/app/api/ad-modules/[id]/companies/route.ts
@@ -107,7 +107,7 @@ export async function GET(
     // Fetch all active ads for this module grouped by advertiser
     const { data: ads, error: adsError } = await supabaseAdmin
       .from('advertisements')
-      .select('id, title, advertiser_id, display_order, status, times_used, last_used_date, paid, frequency, times_paid, image_url, body, button_url, priority')
+      .select('id, title, advertiser_id, display_order, status, times_used, last_used_date, paid, frequency, times_paid, image_url, image_alt, body, button_url, priority')
       .eq('ad_module_id', moduleId)
       .eq('publication_id', adModule.publication_id)
       .eq('status', 'active')

--- a/src/app/api/ads/route.ts
+++ b/src/app/api/ads/route.ts
@@ -191,6 +191,7 @@ export async function POST(request: NextRequest) {
         payment_status: body.payment_status || 'paid',
         paid: body.paid !== undefined ? body.paid : true,
         image_url: body.image_url || null,
+        image_alt: body.image_alt || null,
         submission_date: new Date().toISOString(),
         publication_id: newsletterId, // Associate ad with newsletter
         ad_module_id: body.ad_module_id || null, // Optional ad module assignment


### PR DESCRIPTION
## Summary
- **Bug:** Editing an ad's Image Alt Text in the dashboard appeared to save successfully, but the value was lost on page refresh.
- **Root cause:** The company groups API endpoint (\/api/ad-modules/[id]/companies\) explicitly listed select columns for advertisements but omitted \image_alt\. When the active tab re-fetched ads through this endpoint, the field was missing, so the edit modal initialized with an empty string.
- **Fix:** Added \image_alt\ to the select list in the company groups API, and also added it to the POST insert for new ad creation.

## Test plan
- [ ] Edit an existing ad's Image Alt Text, save, refresh page, and verify the value persists
- [ ] Create a new ad with an image and alt text, verify alt text is saved
- [ ] Verify other ad fields still save correctly after the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image alt text support added for advertisements - users can now provide and retrieve image alternative text when creating and managing advertisements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->