### PR TITLE
Phase 2-3: Newsletter renderer optimization + foundation layer + auth bypass removal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,15 +36,18 @@ CRON_SECRET=generate-random-32-char-string
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=generate-random-32-char-string
 
-# Google OAuth (Required for admin authentication)
+# Google OAuth (Required for admin authentication on staging/production)
 GOOGLE_CLIENT_ID=your-google-oauth-client-id
 GOOGLE_CLIENT_SECRET=your-google-oauth-client-secret
+
+# Auth Bypass (LOCAL DEVELOPMENT ONLY — never set on Vercel)
+# Set to 'true' to skip Google OAuth and use a mock admin session locally
+ALLOW_AUTH_BYPASS=true
 
 # Admin Access Control (Required in production)
 # Comma-separated list of email addresses allowed to access admin dashboard
 # Example: admin@example.com,user@example.com
-# IMPORTANT: If this is empty or not set, all access will be BLOCKED in production
-# Staging/preview environments bypass this check automatically
+# IMPORTANT: If this is empty or not set, all access will be BLOCKED
 ALLOWED_ADMIN_EMAILS=
 
 # Vercel API (Optional - for deployment management)

--- a/src/app/api/tools/admin/delete/route.ts
+++ b/src/app/api/tools/admin/delete/route.ts
@@ -4,23 +4,12 @@ import { authOptions } from '@/lib/auth'
 import { deleteTool } from '@/app/tools/actions'
 
 export async function POST(request: NextRequest) {
-  // Check if staging environment (bypass auth)
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    // Check admin authentication in production
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   const { toolId } = await request.json()

--- a/src/app/api/tools/admin/reject/route.ts
+++ b/src/app/api/tools/admin/reject/route.ts
@@ -4,23 +4,12 @@ import { authOptions } from '@/lib/auth'
 import { rejectTool } from '@/app/tools/actions'
 
 export async function POST(request: NextRequest) {
-  // Check if staging environment (bypass auth)
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    // Check admin authentication in production
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   const { toolId, reason } = await request.json()

--- a/src/app/api/tools/admin/route.ts
+++ b/src/app/api/tools/admin/route.ts
@@ -21,23 +21,12 @@ const CATEGORIES = [
 ]
 
 export async function GET(request: NextRequest) {
-  // Check if staging environment (bypass auth)
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    // Check admin authentication in production
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   const status = request.nextUrl.searchParams.get('status') || 'pending'

--- a/src/app/api/tools/admin/toggle-featured/route.ts
+++ b/src/app/api/tools/admin/toggle-featured/route.ts
@@ -4,23 +4,12 @@ import { authOptions } from '@/lib/auth'
 import { toggleFeatured } from '@/app/tools/actions'
 
 export async function POST(request: NextRequest) {
-  // Check if staging environment (bypass auth)
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    // Check admin authentication in production
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   const { toolId, isFeatured } = await request.json()

--- a/src/app/api/tools/admin/update/route.ts
+++ b/src/app/api/tools/admin/update/route.ts
@@ -4,23 +4,12 @@ import { authOptions } from '@/lib/auth'
 import { updateTool } from '@/app/tools/actions'
 
 export async function POST(request: NextRequest) {
-  // Check if staging environment (bypass auth)
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    // Check admin authentication in production
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   const { toolId, data, listingImageFileName, logoImageFileName } = await request.json()

--- a/src/app/api/tools/entitlements/[id]/route.ts
+++ b/src/app/api/tools/entitlements/[id]/route.ts
@@ -50,21 +50,12 @@ export async function PUT(
 ) {
   const { id } = await params
 
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   try {
@@ -136,21 +127,12 @@ export async function DELETE(
 ) {
   const { id } = await params
 
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   try {

--- a/src/app/api/tools/packages/[id]/route.ts
+++ b/src/app/api/tools/packages/[id]/route.ts
@@ -41,21 +41,12 @@ export async function PUT(
 ) {
   const { id } = await params
 
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   try {
@@ -112,21 +103,12 @@ export async function DELETE(
 ) {
   const { id } = await params
 
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   try {

--- a/src/app/api/tools/packages/route.ts
+++ b/src/app/api/tools/packages/route.ts
@@ -6,22 +6,12 @@ import { PUBLICATION_ID } from '@/lib/config'
 
 // GET - Fetch all sponsorship packages
 export async function GET(request: NextRequest) {
-  // Check if staging environment (bypass auth for read operations)
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   try {
@@ -46,21 +36,12 @@ export async function GET(request: NextRequest) {
 
 // POST - Create a new sponsorship package
 export async function POST(request: NextRequest) {
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   try {

--- a/src/app/api/tools/settings/route.ts
+++ b/src/app/api/tools/settings/route.ts
@@ -13,23 +13,12 @@ const DEFAULT_SETTINGS = {
 
 // GET - Fetch directory pricing settings
 export async function GET(request: NextRequest) {
-  // Check if staging environment (bypass auth)
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    // Check admin authentication in production
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   try {
@@ -69,23 +58,12 @@ export async function GET(request: NextRequest) {
 
 // POST - Update directory pricing settings
 export async function POST(request: NextRequest) {
-  // Check if staging environment (bypass auth)
-  const host = request.headers.get('host') || ''
-  const isStaging = host.includes('localhost') ||
-                    host.includes('staging') ||
-                    process.env.VERCEL_GIT_COMMIT_REF === 'staging'
-
-  if (!isStaging) {
-    // Check admin authentication in production
-    const session = await getServerSession(authOptions)
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const allowedEmails = process.env.ALLOWED_ADMIN_EMAILS?.split(',') || []
-    if (!allowedEmails.includes(session.user.email)) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if ((session.user as any).role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   try {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -15,26 +15,15 @@ export default function Layout({ children }: LayoutProps) {
   const { data: session, status } = useSession()
   const router = useRouter()
   const pathname = usePathname()
-  const [isStaging, setIsStaging] = useState(false)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const [newsletter, setNewsletter] = useState<Newsletter | null>(null)
   const [newsletterSlug, setNewsletterSlug] = useState<string | null>(null)
   const [pendingToolsCount, setPendingToolsCount] = useState(0)
   const [unreadFeedbackCount, setUnreadFeedbackCount] = useState(0)
 
+  const isDevMode = session?.user?.email === 'dev@localhost'
+
   useEffect(() => {
-    // Check if we're in staging environment
-    const hostname = window.location.hostname
-    const staging = hostname.includes('staging') ||
-                    hostname.includes('git-staging') ||
-                    hostname.includes('localhost')
-    setIsStaging(staging)
-
-    if (staging) {
-      console.log('[Layout] Staging environment detected - auth bypass active')
-      return
-    }
-
     if (status === 'loading') return
     if (!session) {
       router.push('/auth/signin')
@@ -93,101 +82,6 @@ export default function Layout({ children }: LayoutProps) {
       console.error('Error fetching newsletter:', error)
       setNewsletter(null)
     }
-  }
-
-  // In staging, skip loading state and show content immediately
-  if (isStaging) {
-    const dashboardUrl = newsletterSlug ? `/dashboard/${newsletterSlug}` : '/dashboard'
-    const campaignsUrl = newsletterSlug ? `/dashboard/${newsletterSlug}/issues` : '/dashboard/issues'
-    const analyticsUrl = newsletterSlug ? `/dashboard/${newsletterSlug}/analytics` : '/dashboard/analytics'
-    const databasesUrl = newsletterSlug ? `/dashboard/${newsletterSlug}/databases` : '/dashboard/databases'
-    const feedbackUrl = newsletterSlug ? `/dashboard/${newsletterSlug}/feedback` : '/dashboard/feedback'
-    const settingsUrl = newsletterSlug ? `/dashboard/${newsletterSlug}/settings` : '/dashboard/settings'
-    const toolsAdminUrl = newsletterSlug ? `/dashboard/${newsletterSlug}/tools-admin` : '/dashboard/tools-admin'
-
-    return (
-      <div className="min-h-screen bg-gray-50 flex flex-col">
-        <nav className="bg-white shadow-sm border-b">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex justify-between h-16">
-              <div className="flex items-center space-x-8">
-                <Link href="/dashboard" className="flex items-center">
-                  <h1 className="text-xl font-bold text-brand-primary">
-                    {newsletter?.name || 'AI Pro Daily'}
-                  </h1>
-                </Link>
-                {newsletterSlug && (
-                  <nav className="hidden md:flex space-x-8">
-                    <Link href={dashboardUrl} className="text-gray-900 hover:text-brand-primary px-3 py-2 text-sm font-medium">
-                      Dashboard
-                    </Link>
-                    <Link href={campaignsUrl} className="text-gray-900 hover:text-brand-primary px-3 py-2 text-sm font-medium">
-                      Issues
-                    </Link>
-                    <Link href={analyticsUrl} className="text-gray-900 hover:text-brand-primary px-3 py-2 text-sm font-medium">
-                      Analytics
-                    </Link>
-                    <Link href={databasesUrl} className="text-gray-900 hover:text-brand-primary px-3 py-2 text-sm font-medium">
-                      Databases
-                    </Link>
-                    <Link href={settingsUrl} className="text-gray-900 hover:text-brand-primary px-3 py-2 text-sm font-medium">
-                      Settings
-                    </Link>
-                    <Link href={feedbackUrl} className="text-gray-900 hover:text-brand-primary px-3 py-2 text-sm font-medium relative">
-                      Feedback
-                      {unreadFeedbackCount > 0 && (
-                        <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full h-5 w-5 flex items-center justify-center">
-                          {unreadFeedbackCount > 9 ? '9+' : unreadFeedbackCount}
-                        </span>
-                      )}
-                    </Link>
-                    <Link href={toolsAdminUrl} className="text-gray-900 hover:text-brand-primary px-3 py-2 text-sm font-medium relative">
-                      Tools
-                      {pendingToolsCount > 0 && (
-                        <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full h-5 w-5 flex items-center justify-center">
-                          {pendingToolsCount > 9 ? '9+' : pendingToolsCount}
-                        </span>
-                      )}
-                    </Link>
-                  </nav>
-                )}
-              </div>
-              <div className="flex items-center space-x-4">
-                <span className="hidden sm:inline text-sm text-gray-700">
-                  Staging Test User
-                </span>
-                <span className="bg-yellow-100 text-yellow-800 px-3 py-1 rounded text-xs font-medium">
-                  STAGING MODE
-                </span>
-                <button
-                  onClick={() => setIsMobileMenuOpen(true)}
-                  className="md:hidden p-2 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-primary"
-                  aria-label="Open menu"
-                  aria-expanded={isMobileMenuOpen}
-                >
-                  <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </nav>
-        <MobileMenu
-          isOpen={isMobileMenuOpen}
-          onClose={() => setIsMobileMenuOpen(false)}
-          userDisplay="Staging Test User"
-          dashboardUrl={dashboardUrl}
-          campaignsUrl={campaignsUrl}
-          analyticsUrl={analyticsUrl}
-          databasesUrl={databasesUrl}
-          settingsUrl={settingsUrl}
-        />
-        <main className="flex-1 max-w-7xl w-full mx-auto py-6 sm:px-6 lg:px-8">
-          {children}
-        </main>
-      </div>
-    )
   }
 
   if (status === 'loading') {
@@ -261,12 +155,19 @@ export default function Layout({ children }: LayoutProps) {
               <span className="hidden sm:inline text-sm text-gray-700">
                 {session.user?.name || session.user?.email}
               </span>
-              <button
-                onClick={() => signOut()}
-                className="hidden md:inline-flex bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-2 rounded text-sm font-medium"
-              >
-                Sign Out
-              </button>
+              {isDevMode && (
+                <span className="bg-yellow-100 text-yellow-800 px-3 py-1 rounded text-xs font-medium">
+                  DEV MODE
+                </span>
+              )}
+              {!isDevMode && (
+                <button
+                  onClick={() => signOut()}
+                  className="hidden md:inline-flex bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-2 rounded text-sm font-medium"
+                >
+                  Sign Out
+                </button>
+              )}
               <button
                 onClick={() => setIsMobileMenuOpen(true)}
                 className="md:hidden p-2 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-primary"
@@ -284,7 +185,7 @@ export default function Layout({ children }: LayoutProps) {
       <MobileMenu
         isOpen={isMobileMenuOpen}
         onClose={() => setIsMobileMenuOpen(false)}
-        onSignOut={() => signOut()}
+        onSignOut={isDevMode ? undefined : () => signOut()}
         userDisplay={session.user?.name || session.user?.email || ''}
         dashboardUrl={dashboardUrl}
         campaignsUrl={campaignsUrl}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,33 +26,6 @@ async function customMiddleware(request: NextRequest): Promise<NextResponse> {
   const hostname = request.headers.get('host') || ''
   const url = request.nextUrl
 
-  // Detect staging environment - VERY strict, only for actual staging deployments
-  // NEVER treat production domains as staging
-  const isProductionDomain = hostname === 'aiprodaily.com' ||
-                             hostname === 'www.aiprodaily.com' ||
-                             hostname === 'aiaccountingdaily.com' ||
-                             hostname === 'www.aiaccountingdaily.com'
-
-  const isStaging = !isProductionDomain && (
-    process.env.VERCEL_GIT_COMMIT_REF === 'staging' ||
-    hostname.includes('git-staging') ||
-    hostname.includes('-staging-')
-  )
-
-  // Skip authentication for staging environment
-  if (isStaging) {
-    console.log('[Middleware] Staging environment detected - authentication bypassed', {
-      vercelEnv: process.env.VERCEL_ENV,
-      gitRef: process.env.VERCEL_GIT_COMMIT_REF,
-      hostname
-    })
-    // Redirect signin page to dashboard when in staging mode
-    if (url.pathname === '/auth/signin') {
-      return NextResponse.redirect(new URL('/dashboard', request.url))
-    }
-    return NextResponse.next()
-  }
-
   // Check if this is a newsletter website domain (takes priority over subdomain logic)
   const newsletterSlug = NEWSLETTER_DOMAINS[hostname]
 


### PR DESCRIPTION
## Summary

- **IssueSnapshot & parallel data fetching**: Pre-fetch all newsletter content into a snapshot object, eliminating ~15-20 DB calls during render with parallel fetching and per-fetch error isolation
- **Header/footer settings**: Moved into IssueSnapshot to eliminate 2 more DB calls during render
- **Module renderers**: Thread businessSettings from snapshot into all module renderers, eliminating ~6 redundant DB calls
- **Foundation layer (Phase 2.1)**: Structured pino logger with correlation IDs, AuthTier type system, `withApiHandler()` wrapper, Issues DAL with 12 methods
- **Auth bypass removal (Phase 3.1)**: Replace hostname/env-sniffing staging bypass with explicit `ALLOW_AUTH_BYPASS` env var for local dev only. Removes bypass from auth-bypass.ts, auth.ts, middleware.ts, Layout.tsx, and 11 tools API routes
- **Content flow cleanup**: Remove Breaking News / Beyond the Feed from active flows

## Test plan

- [ ] Local dev with `ALLOW_AUTH_BYPASS=true`: dashboard loads, tools admin works, DEV MODE badge shows
- [ ] Local dev without env var: redirects to sign-in page
- [x] Staging with Google OAuth configured: sign-in works, real user name displays, email allowlist enforced
- [ ] Tools admin API endpoints return data with real admin session (not 401/403)
- [x] Newsletter render performance: confirm reduced DB calls in Vercel logs
- [x] Cron routes unaffected (use CRON_SECRET, not session auth)
- [x] `npm run build` passes
- [x] `npm run type-check` passes

### Prerequisites before merging
- Configure Google OAuth credentials on Vercel staging
- Add staging URL to Google OAuth authorized redirect URIs
- Set `ALLOWED_ADMIN_EMAILS` on staging
- Confirm `ALLOW_AUTH_BYPASS` is NOT set on any Vercel environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)