### PR TITLE
Multi-tenant infrastructure: per-pub URLs, cron loops, snapshots, DAL

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -19,7 +19,8 @@ export const PUBLICATION_ID: string = (() => {
   return FALLBACK_PUBLICATION_ID
 })()
 
-// SITE_BASE_URL is for background jobs, cron, and build-time contexts only.
+// SITE_BASE_URL is the default-publication fallback for background jobs, cron, and build-time contexts.
+// Newsletter rendering uses businessSettings.websiteUrl per publication.
 // Website pages should use the request host via resolvePublicationFromRequest().
 export const SITE_BASE_URL: string =
   process.env.NEXT_PUBLIC_SITE_URL || 'https://aiaccountingdaily.com'

--- a/src/lib/newsletter-templates/layout.ts
+++ b/src/lib/newsletter-templates/layout.ts
@@ -48,7 +48,7 @@ export async function generateNewsletterHeader(formattedDate: string, issueDate?
 
   // Add tracking to Sign Up link if issue info available
   const signUpUrl = issueDate
-    ? wrapTrackingUrl(websiteUrl, 'Header', issueDate, issueId)
+    ? wrapTrackingUrl(websiteUrl, 'Header', issueDate, issueId, undefined, undefined, websiteUrl)
     : websiteUrl
 
   // Build preheader hidden div (shown in email client preview text)
@@ -226,7 +226,7 @@ export async function generateNewsletterFooter(issueDate?: string, issueId?: str
 
   // Facebook
   if (fbEnabled && fbUrl) {
-    const trackedUrl = issueDate ? wrapTrackingUrl(fbUrl, 'Footer', issueDate, issueId) : fbUrl
+    const trackedUrl = issueDate ? wrapTrackingUrl(fbUrl, 'Footer', issueDate, issueId, undefined, undefined, websiteUrl) : fbUrl
     socialIcons.push(`
       <td style="padding: 0 8px;">
         <a href="${trackedUrl}" target="_blank">
@@ -237,7 +237,7 @@ export async function generateNewsletterFooter(issueDate?: string, issueId?: str
 
   // Twitter/X
   if (twEnabled && twUrl) {
-    const trackedUrl = issueDate ? wrapTrackingUrl(twUrl, 'Footer', issueDate, issueId) : twUrl
+    const trackedUrl = issueDate ? wrapTrackingUrl(twUrl, 'Footer', issueDate, issueId, undefined, undefined, websiteUrl) : twUrl
     socialIcons.push(`
       <td style="padding: 0 8px;">
         <a href="${trackedUrl}" target="_blank">
@@ -248,7 +248,7 @@ export async function generateNewsletterFooter(issueDate?: string, issueId?: str
 
   // LinkedIn
   if (liEnabled && liUrl) {
-    const trackedUrl = issueDate ? wrapTrackingUrl(liUrl, 'Footer', issueDate, issueId) : liUrl
+    const trackedUrl = issueDate ? wrapTrackingUrl(liUrl, 'Footer', issueDate, issueId, undefined, undefined, websiteUrl) : liUrl
     socialIcons.push(`
       <td style="padding: 0 8px;">
         <a href="${trackedUrl}" target="_blank">
@@ -259,7 +259,7 @@ export async function generateNewsletterFooter(issueDate?: string, issueId?: str
 
   // Instagram
   if (igEnabled && igUrl) {
-    const trackedUrl = issueDate ? wrapTrackingUrl(igUrl, 'Footer', issueDate, issueId) : igUrl
+    const trackedUrl = issueDate ? wrapTrackingUrl(igUrl, 'Footer', issueDate, issueId, undefined, undefined, websiteUrl) : igUrl
     socialIcons.push(`
       <td style="padding: 0 8px;">
         <a href="${trackedUrl}" target="_blank">
@@ -284,7 +284,7 @@ export async function generateNewsletterFooter(issueDate?: string, issueId?: str
 
   // Generate honeypot link for bot detection (disguised as comma in address)
   const honeypotUrl = issueDate
-    ? wrapTrackingUrl(websiteUrl, HONEYPOT_CONFIG.SECTION_NAME, issueDate, issueId)
+    ? wrapTrackingUrl(websiteUrl, HONEYPOT_CONFIG.SECTION_NAME, issueDate, issueId, undefined, undefined, websiteUrl)
     : null
 
   // Split address at "Saint Joseph," to embed honeypot as the comma

--- a/src/lib/newsletter-templates/sections.ts
+++ b/src/lib/newsletter-templates/sections.ts
@@ -66,8 +66,8 @@ export async function generatePollSection(issue: { id: string; publication_id: s
   try {
     // Fetch colors and website URL from business settings (use passed-in settings if available)
     const { primaryColor, tertiaryColor } = businessSettings || await fetchBusinessSettings(issue.publication_id)
-    // Use the main app domain for poll responses (where the poll pages are hosted)
-    const baseUrl = process.env.NEXTAUTH_URL || 'https://www.aiprodaily.com'
+    // Use per-publication domain for poll responses, with env var fallback
+    const baseUrl = businessSettings?.websiteUrl || process.env.NEXTAUTH_URL || 'https://www.aiprodaily.com'
 
     let pollData = null
 
@@ -194,7 +194,7 @@ export async function generatePollModulesSection(
       selection.poll_module,
       selection.poll,
       issue.publication_id,
-      { issueId: issue.id },
+      { issueId: issue.id, baseUrl: businessSettings?.websiteUrl },
       businessSettings
     )
 
@@ -571,7 +571,7 @@ export async function generateFeedbackModuleSection(
     const result = await FeedbackModuleRenderer.renderFeedbackModule(
       mod,
       issue.publication_id,
-      { issueId: issue.id },
+      { issueId: issue.id, baseUrl: businessSettings?.websiteUrl },
       businessSettings
     )
 

--- a/src/lib/url-tracking.ts
+++ b/src/lib/url-tracking.ts
@@ -18,6 +18,7 @@ export type LinkType = 'ad' | 'ai_app'
  * @param mailerliteIssueId - Optional MailerLite campaign ID
  * @param dbIssueId - Optional database issue ID (for MailerLite field updates)
  * @param linkType - Optional link type for field updates ('ad' | 'ai_app')
+ * @param pubBaseUrl - Optional per-publication base URL (from businessSettings.websiteUrl)
  * @returns Tracking URL that redirects to destination
  */
 export function wrapTrackingUrl(
@@ -26,9 +27,10 @@ export function wrapTrackingUrl(
   issueDate: string,
   mailerliteIssueId?: string,
   dbIssueId?: string,
-  linkType?: LinkType
+  linkType?: LinkType,
+  pubBaseUrl?: string
 ): string {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://www.aiaccountingdaily.com'
+  const baseUrl = pubBaseUrl || process.env.NEXT_PUBLIC_APP_URL || 'https://www.aiaccountingdaily.com'
 
   const params = new URLSearchParams({
     url: url,


### PR DESCRIPTION
## Summary
- **Per-publication base URL resolution**: Newsletter tracking, poll, feedback, and honeypot URLs now use each publication's `websiteUrl` instead of a single global env var
- **Multi-tenant cron jobs**: All cron jobs loop over active publications instead of using a hardcoded publication ID
- **IssueSnapshot system**: Pre-fetches all newsletter content in parallel, eliminating ~15-20 redundant DB calls during render
- **Foundation layer**: Structured logging (pino), auth tiers, `withApiHandler()` wrapper, Issues DAL
- **API route hardening**: ~430 routes migrated to `withApiHandler`, webhook replay protection, system auth on cron routes
- **RSSProcessor refactor**: Split 4,354-line god file into 13 focused modules
- **Publication provisioning**: CLI script + admin UI for creating new publications
- **173 unit tests** added across 6 modules
- **47 dead debug routes** deleted after triage
- **CodeQL fixes**: Image preview URL guard, code quality improvements

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Unit tests pass (`npm run test:run`)
- [ ] Verify single-pub newsletters render identically (tracking URLs unchanged when websiteUrl matches env var)
- [ ] Verify cron jobs process all active publications in staging logs
- [ ] Smoke test dashboard, poll responses, and feedback on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed newsletter tracking and poll URLs to now correctly use publication-specific website URLs instead of fixed default domains, ensuring proper tracking and link resolution across multi-publication environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->