### PR TITLE
Release: Multi-tenant, foundation layer, and issue date fix

### DIFF
--- a/src/app/api/cron/create-campaign/route.ts
+++ b/src/app/api/cron/create-campaign/route.ts
@@ -20,13 +20,16 @@ async function handleCreateCampaign(logger: Logger) {
 
   logger.info({ count: newsletters.length }, '=== AUTOMATED issue CREATION CHECK ===')
 
-  // Use Central Time + 12 hours for consistent date calculations (shared across pubs)
-  const nowCentral = new Date().toLocaleString("en-US", {timeZone: "America/Chicago"})
-  const centralDate = new Date(nowCentral)
-  centralDate.setHours(centralDate.getHours() + 12)
-  const issueDate = centralDate.toISOString().split('T')[0]
+  // Always target tomorrow in Central Time (matches send-review logic)
+  const ctParts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+    year: 'numeric', month: '2-digit', day: '2-digit'
+  }).format(new Date())
+  const [ctYear, ctMonth, ctDay] = ctParts.split('-').map(Number)
+  const tomorrowDate = new Date(ctYear, ctMonth - 1, ctDay + 1)
+  const issueDate = `${tomorrowDate.getFullYear()}-${String(tomorrowDate.getMonth() + 1).padStart(2, '0')}-${String(tomorrowDate.getDate()).padStart(2, '0')}`
 
-  logger.info({ issueDate, centralTime: nowCentral }, 'issue date calculation: Current CT time + 12 hours')
+  logger.info({ issueDate, centralTime: ctParts }, 'issue date calculation: tomorrow in Central Time')
 
   const results: Array<{ pubId: string; slug: string; success: boolean; skipped?: boolean; message?: string; error?: string }> = []
 

--- a/src/lib/rss-processor/issue-lifecycle.ts
+++ b/src/lib/rss-processor/issue-lifecycle.ts
@@ -53,10 +53,13 @@ export class IssueLifecycle {
       // STEP 1: Create NEW issue
       console.log('[Step 1/10] Creating new issue...')
 
-      const nowCentral = new Date().toLocaleString("en-US", { timeZone: "America/Chicago" })
-      const centralDate = new Date(nowCentral)
-      centralDate.setHours(centralDate.getHours() + 12)
-      const issueDate = centralDate.toISOString().split('T')[0]
+      const ctParts = new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'America/Chicago',
+        year: 'numeric', month: '2-digit', day: '2-digit'
+      }).format(new Date())
+      const [ctYear, ctMonth, ctDay] = ctParts.split('-').map(Number)
+      const tomorrowDate = new Date(ctYear, ctMonth - 1, ctDay + 1)
+      const issueDate = `${tomorrowDate.getFullYear()}-${String(tomorrowDate.getMonth() + 1).padStart(2, '0')}-${String(tomorrowDate.getDate()).padStart(2, '0')}`
 
       const { data: newissue, error: createError } = await supabaseAdmin
         .from('publication_issues')
@@ -192,10 +195,13 @@ export class IssueLifecycle {
    * Get or create today's issue
    */
   async getOrCreateTodaysIssue(): Promise<string> {
-    const nowCentral = new Date().toLocaleString("en-US", { timeZone: "America/Chicago" })
-    const centralDate = new Date(nowCentral)
-    centralDate.setHours(centralDate.getHours() + 12)
-    const issueDate = centralDate.toISOString().split('T')[0]
+    const ctParts = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'America/Chicago',
+      year: 'numeric', month: '2-digit', day: '2-digit'
+    }).format(new Date())
+    const [ctYear, ctMonth, ctDay] = ctParts.split('-').map(Number)
+    const tomorrowDate = new Date(ctYear, ctMonth - 1, ctDay + 1)
+    const issueDate = `${tomorrowDate.getFullYear()}-${String(tomorrowDate.getMonth() + 1).padStart(2, '0')}-${String(tomorrowDate.getDate()).padStart(2, '0')}`
 
     const { data: existing, error: existingError } = await supabaseAdmin
       .from('publication_issues')

--- a/src/lib/workflows/process-rss-workflow.ts
+++ b/src/lib/workflows/process-rss-workflow.ts
@@ -91,11 +91,14 @@ async function setupIssue(newsletterId: string): Promise<{ issueId: string; modu
 
       console.log(`[Workflow Step 1] Using newsletter: ${newsletter.name} (${newsletter.id})`)
 
-      // Calculate issue date (Central Time + 12 hours)
-      const nowCentral = new Date().toLocaleString("en-US", {timeZone: "America/Chicago"})
-      const centralDate = new Date(nowCentral)
-      centralDate.setHours(centralDate.getHours() + 12)
-      const issueDate = centralDate.toISOString().split('T')[0]
+      // Always target tomorrow in Central Time (matches send-review logic)
+      const ctParts = new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'America/Chicago',
+        year: 'numeric', month: '2-digit', day: '2-digit'
+      }).format(new Date())
+      const [ctYear, ctMonth, ctDay] = ctParts.split('-').map(Number)
+      const tomorrowDate = new Date(ctYear, ctMonth - 1, ctDay + 1)
+      const issueDate = `${tomorrowDate.getFullYear()}-${String(tomorrowDate.getMonth() + 1).padStart(2, '0')}-${String(tomorrowDate.getDate()).padStart(2, '0')}`
 
       // Create new issue via DAL (dynamic import: pino uses Node.js modules not available in workflow context)
       const { createIssue } = await import('@/lib/dal')


### PR DESCRIPTION
## Summary

- **Foundation layer**: Structured logging (pino), auth tiers, `withApiHandler()` wrapper, Issues DAL with explicit column selection
- **Newsletter rendering**: IssueSnapshot pre-fetches all content to eliminate ~15-20 DB calls during render; parallel data fetching
- **API hardening**: Migrate ~430 routes to `withApiHandler`, enforce system auth on cron routes, remove pervasive auth bypass, webhook replay protection
- **RSSProcessor refactor**: Split 4,354-line god file into 13 focused modules
- **Multi-tenant readiness**: Dynamic domain routing, publication provisioning script, cron jobs loop all active publications, resolve publications from host
- **Issue date fix**: Replace CT+12h calculation with explicit "tomorrow in Central Time" logic matching send-review, fixing missed review emails
- **Testing**: 173 unit tests across 6 modules, Zod-validated schedule settings, issue status state machine
- **Cleanup**: Delete 47 dead debug routes, remove Breaking News/Beyond the Feed from active flows, fix CodeQL findings

## Key commits
- `dc2e027` Foundation layer (logging, auth, API handler, DAL)
- `2c0d463` Split RSSProcessor into 13 modules
- `ce1cd07` Migrate ~430 routes to withApiHandler
- `0bb52ed` Admin UI for publication creation
- `8dde151` Multi-tenant: resolve publications from host
- `cc02fad` Fix issue date logic: always use tomorrow in CT

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm run test:run` — 236 tests pass
- [ ] Verify staging deployment healthy before merge
- [ ] Smoke test cron jobs post-merge (trigger-workflow, create-campaign, send-review)
- [ ] Confirm issue dates resolve to tomorrow in CT at various times of day

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated issue date calculations to consistently use tomorrow's date in Central Time, replacing the previous 12-hour offset approach for more predictable campaign scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->