### PR TITLE
Fix email field autofill on subscribe page

### DIFF
--- a/src/app/website/subscribe/subscribe-form.tsx
+++ b/src/app/website/subscribe/subscribe-form.tsx
@@ -121,8 +121,12 @@ export function SubscribeForm() {
       <div className="space-y-4">
         <form onSubmit={handleSubmit} className="flex justify-center">
           <div className="relative w-full max-w-lg">
+            <label htmlFor="email" className="sr-only">Email address</label>
             <input
               type="email"
+              name="email"
+              id="email"
+              autoComplete="email"
               required
               value={email}
               onChange={(e) => setEmail(e.target.value)}


### PR DESCRIPTION
## Summary
- Added `name="email"`, `id="email"`, and `autoComplete="email"` attributes to the subscribe form input so browsers recognize it for autofill
- Added a visually hidden `<label>` for accessibility and as an additional autofill signal

## Test plan
- [ ] Visit /subscribe and verify browser offers email autofill suggestions
- [ ] Confirm the form still submits correctly
- [ ] Confirm no visual changes to the subscribe page


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the email subscription form with improved accessibility, including a visible field label and better form attributes for browser auto-fill support and clearer user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->