### PR TITLE
Add build-time column validation tests

### DIFF
--- a/src/app/api/ai-apps/route.ts
+++ b/src/app/api/ai-apps/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const APP_COLS = 'id, publication_id, app_name, tagline, description, category, app_url, logo_url, logo_alt, screenshot_url, screenshot_alt, tool_type, category_priority, pinned_position, is_active, is_featured, is_paid_placement, is_affiliate, ai_app_module_id, times_used, last_used_date, created_at, updated_at'
+import { APP_COLS } from '@/lib/column-constants'
 
 /**
  * GET /api/ai-apps - List AI applications

--- a/src/app/api/prompt-ideas/route.ts
+++ b/src/app/api/prompt-ideas/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const PROMPT_COLS = 'id, publication_id, prompt_module_id, title, prompt_text, category, use_case, suggested_model, difficulty_level, is_featured, is_active, display_order, priority, times_used, created_at, updated_at'
+import { PROMPT_COLS } from '@/lib/column-constants'
 
 // GET - List all prompt ideas
 export const GET = withApiHandler(

--- a/src/app/api/settings/newsletter-sections/route.ts
+++ b/src/app/api/settings/newsletter-sections/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { supabaseAdmin } from '@/lib/supabase'
-
-const SECTION_COLS = 'id, newsletter_id, name, display_order, is_active, section_type, description, created_at'
+import { SECTION_COLS } from '@/lib/column-constants'
 
 export const GET = withApiHandler(
   { authTier: 'authenticated', logContext: 'settings/newsletter-sections' },

--- a/src/lib/__tests__/column-validation.test.ts
+++ b/src/lib/__tests__/column-validation.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Column Validation Tests
+ *
+ * Validates that every *_COLS constant string references only real database columns.
+ * This catches typos like `times_shown` instead of `times_used` at build time,
+ * preventing 500 errors in production.
+ *
+ * Valid column sets are derived from TypeScript interfaces in src/types/database.ts
+ * plus known DB-only columns not reflected in TS interfaces.
+ */
+import { describe, test, expect } from 'vitest'
+
+// --- Import COLS constants from their source files ---
+import { ISSUE_COLUMNS, ISSUE_COLUMNS_BRIEF } from '@/lib/dal/issues'
+import { EVENT_COLS, ISSUE_EVENT_COLS } from '@/lib/rss-processor/utils'
+import {
+  NEWSLETTER_SECTION_COLS,
+  AD_MODULE_COLS,
+  POLL_MODULE_COLS,
+  PROMPT_MODULE_COLS,
+  ARTICLE_MODULE_COLS,
+  TEXT_BOX_MODULE_COLS,
+  TEXT_BOX_BLOCK_COLS,
+  FEEDBACK_MODULE_COLS,
+} from '@/lib/newsletter-templates/build-snapshot'
+import { APP_COLS, PROMPT_COLS, SECTION_COLS } from '@/lib/column-constants'
+
+// --- Helper ---
+
+/** Split a comma-separated column string into trimmed column names */
+function parseColumns(colString: string): string[] {
+  return colString
+    .split(',')
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0)
+}
+
+// --- Valid column sets per table ---
+// Derived from TypeScript interfaces in src/types/database.ts.
+// DB-only columns (present in migrations but not in TS interfaces) are noted inline.
+
+const VALID_COLUMNS: Record<string, Set<string>> = {
+  ai_applications: new Set([
+    'id', 'publication_id', 'app_name', 'tagline', 'description', 'category',
+    'app_url', 'tracked_link', 'logo_url', 'logo_alt', 'screenshot_url', 'screenshot_alt',
+    'tool_type', 'category_priority', 'is_featured', 'is_paid_placement', 'is_affiliate',
+    'is_active', 'display_order', 'last_used_date', 'times_used', 'created_at', 'updated_at',
+    'clerk_user_id', 'submitter_email', 'submitter_name', 'submitter_image_url',
+    'submission_status', 'rejection_reason', 'approved_by', 'approved_at',
+    'plan', 'stripe_payment_id', 'stripe_subscription_id', 'stripe_customer_id',
+    'sponsor_start_date', 'sponsor_end_date', 'view_count', 'click_count',
+    'ai_app_module_id', 'priority', 'pinned_position', 'button_text',
+  ]),
+
+  prompt_ideas: new Set([
+    'id', 'publication_id', 'title', 'prompt_text', 'category', 'use_case',
+    'suggested_model', 'difficulty_level', 'estimated_time', 'is_featured', 'is_active',
+    'display_order', 'last_used_date', 'times_used', 'prompt_module_id', 'priority',
+    'created_at', 'updated_at',
+  ]),
+
+  // NewsletterSection TS interface is minimal; newsletter_id and description are DB-only columns
+  newsletter_sections: new Set([
+    'id', 'newsletter_id', 'name', 'display_order', 'is_active', 'section_type',
+    'description', 'created_at',
+  ]),
+
+  publication_issues: new Set([
+    'id', 'publication_id', 'date', 'status',
+    'subject_line', 'welcome_intro', 'welcome_tagline', 'welcome_summary',
+    'review_sent_at', 'final_sent_at',
+    'last_action', 'last_action_at', 'last_action_by',
+    'status_before_send', 'metrics',
+    'workflow_state', 'workflow_state_started_at', 'workflow_error',
+    'poll_id', 'poll_snapshot',
+    'mailerlite_issue_id', 'failure_alerted_at',
+    'created_at', 'updated_at',
+  ]),
+
+  events: new Set([
+    'id', 'external_id', 'title', 'description', 'event_summary',
+    'start_date', 'end_date', 'venue', 'address', 'url', 'website',
+    'image_url', 'original_image_url', 'cropped_image_url',
+    'featured', 'paid_placement', 'active',
+    'submission_status', 'payment_status', 'payment_intent_id', 'payment_amount',
+    'submitter_name', 'submitter_email', 'submitter_phone',
+    'reviewed_by', 'reviewed_at', 'raw_data',
+    'created_at', 'updated_at',
+  ]),
+
+  issue_events: new Set([
+    'id', 'issue_id', 'event_id', 'event_date',
+    'is_selected', 'is_featured', 'display_order', 'created_at',
+  ]),
+
+  ad_modules: new Set([
+    'id', 'publication_id', 'name', 'display_order', 'is_active',
+    'selection_mode', 'block_order', 'config', 'next_position',
+    'created_at', 'updated_at',
+  ]),
+
+  poll_modules: new Set([
+    'id', 'publication_id', 'name', 'display_order', 'is_active',
+    'block_order', 'config', 'created_at', 'updated_at',
+  ]),
+
+  prompt_modules: new Set([
+    'id', 'publication_id', 'name', 'display_order', 'is_active',
+    'selection_mode', 'block_order', 'config', 'next_position',
+    'created_at', 'updated_at',
+  ]),
+
+  article_modules: new Set([
+    'id', 'publication_id', 'name', 'display_order', 'is_active',
+    'selection_mode', 'block_order', 'config',
+    'articles_count', 'lookback_hours', 'ai_image_prompt',
+    'created_at', 'updated_at',
+  ]),
+
+  text_box_modules: new Set([
+    'id', 'publication_id', 'name', 'display_order', 'is_active',
+    'show_name', 'config', 'created_at', 'updated_at',
+  ]),
+
+  text_box_blocks: new Set([
+    'id', 'text_box_module_id', 'block_type', 'display_order',
+    'static_content', 'text_size', 'ai_prompt_json', 'generation_timing',
+    'image_type', 'static_image_url', 'ai_image_prompt', 'image_alt',
+    'is_active', 'is_bold', 'is_italic',
+    'created_at', 'updated_at',
+  ]),
+
+  feedback_modules: new Set([
+    'id', 'publication_id', 'name', 'display_order', 'is_active',
+    'show_name', 'config', 'created_at', 'updated_at',
+    // Legacy fields (still present in DB and used by FEEDBACK_MODULE_COLS)
+    'block_order', 'title_text', 'body_text', 'body_is_italic',
+    'sign_off_text', 'sign_off_is_italic', 'vote_options', 'team_photos',
+  ]),
+}
+
+// --- Tests ---
+
+describe('Column validation: COLS constants match database schema', () => {
+  // Helper to run a single column validation
+  function expectColumnsValid(
+    constantName: string,
+    colString: string,
+    tableName: string
+  ) {
+    test(`${constantName} matches ${tableName} table`, () => {
+      const cols = parseColumns(colString)
+      const validSet = VALID_COLUMNS[tableName]
+
+      expect(validSet).toBeDefined()
+      expect(cols.length).toBeGreaterThan(0)
+
+      const invalid = cols.filter((c) => !validSet!.has(c))
+      if (invalid.length > 0) {
+        // Provide a helpful error message
+        expect(invalid).toEqual(
+          expect.objectContaining({
+            length: 0,
+          })
+        )
+      }
+      expect(invalid).toEqual([])
+    })
+  }
+
+  // ai_applications
+  expectColumnsValid('APP_COLS', APP_COLS, 'ai_applications')
+
+  // prompt_ideas
+  expectColumnsValid('PROMPT_COLS', PROMPT_COLS, 'prompt_ideas')
+
+  // newsletter_sections (from settings route)
+  expectColumnsValid('SECTION_COLS', SECTION_COLS, 'newsletter_sections')
+
+  // publication_issues
+  expectColumnsValid('ISSUE_COLUMNS', ISSUE_COLUMNS, 'publication_issues')
+  expectColumnsValid('ISSUE_COLUMNS_BRIEF', ISSUE_COLUMNS_BRIEF, 'publication_issues')
+
+  // events
+  expectColumnsValid('EVENT_COLS', EVENT_COLS, 'events')
+
+  // issue_events
+  expectColumnsValid('ISSUE_EVENT_COLS', ISSUE_EVENT_COLS, 'issue_events')
+
+  // Module config tables (from build-snapshot.ts)
+  expectColumnsValid('NEWSLETTER_SECTION_COLS', NEWSLETTER_SECTION_COLS, 'newsletter_sections')
+  expectColumnsValid('AD_MODULE_COLS', AD_MODULE_COLS, 'ad_modules')
+  expectColumnsValid('POLL_MODULE_COLS', POLL_MODULE_COLS, 'poll_modules')
+  expectColumnsValid('PROMPT_MODULE_COLS', PROMPT_MODULE_COLS, 'prompt_modules')
+  expectColumnsValid('ARTICLE_MODULE_COLS', ARTICLE_MODULE_COLS, 'article_modules')
+  expectColumnsValid('TEXT_BOX_MODULE_COLS', TEXT_BOX_MODULE_COLS, 'text_box_modules')
+  expectColumnsValid('TEXT_BOX_BLOCK_COLS', TEXT_BOX_BLOCK_COLS, 'text_box_blocks')
+  expectColumnsValid('FEEDBACK_MODULE_COLS', FEEDBACK_MODULE_COLS, 'feedback_modules')
+})

--- a/src/lib/column-constants.ts
+++ b/src/lib/column-constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared column-list constants for Supabase queries.
+ *
+ * Extracted here so both API route files (which cannot export custom names)
+ * and the column-validation test can reference the same strings.
+ */
+
+// ai_applications columns used by /api/ai-apps
+export const APP_COLS = 'id, publication_id, app_name, tagline, description, category, app_url, logo_url, logo_alt, screenshot_url, screenshot_alt, tool_type, category_priority, pinned_position, is_active, is_featured, is_paid_placement, is_affiliate, ai_app_module_id, times_used, last_used_date, created_at, updated_at'
+
+// prompt_ideas columns used by /api/prompt-ideas
+export const PROMPT_COLS = 'id, publication_id, prompt_module_id, title, prompt_text, category, use_case, suggested_model, difficulty_level, is_featured, is_active, display_order, priority, times_used, created_at, updated_at'
+
+// newsletter_sections columns used by /api/settings/newsletter-sections
+export const SECTION_COLS = 'id, newsletter_id, name, display_order, is_active, section_type, description, created_at'

--- a/src/lib/dal/issues.ts
+++ b/src/lib/dal/issues.ts
@@ -16,7 +16,7 @@ const log = createLogger({ module: 'dal:issues' })
 
 // Column sets for consistent select lists (only columns that exist on publication_issues)
 // Note: mailerlite_issue_id lives in email_metrics; not on publication_issues
-const ISSUE_COLUMNS = `
+export const ISSUE_COLUMNS = `
   id, publication_id, date, status,
   subject_line, welcome_intro, welcome_tagline, welcome_summary,
   review_sent_at, final_sent_at,
@@ -28,7 +28,7 @@ const ISSUE_COLUMNS = `
   created_at, updated_at
 ` as const
 
-const ISSUE_COLUMNS_BRIEF = `
+export const ISSUE_COLUMNS_BRIEF = `
   id, publication_id, date, status,
   subject_line, workflow_state, workflow_error,
   review_sent_at, final_sent_at,

--- a/src/lib/newsletter-templates/build-snapshot.ts
+++ b/src/lib/newsletter-templates/build-snapshot.ts
@@ -5,14 +5,14 @@ import { fetchBusinessSettings } from './helpers'
 import type { IssueSnapshot, SectionItem } from './types'
 
 // Explicit column lists for module config tables (no select('*'))
-const NEWSLETTER_SECTION_COLS = `id, newsletter_id, name, display_order, is_active, section_type, description, created_at`
-const AD_MODULE_COLS = `id, publication_id, name, display_order, is_active, selection_mode, block_order, config, next_position, created_at, updated_at`
-const POLL_MODULE_COLS = `id, publication_id, name, display_order, is_active, block_order, config, created_at, updated_at`
-const PROMPT_MODULE_COLS = `id, publication_id, name, display_order, is_active, selection_mode, block_order, config, next_position, created_at, updated_at`
-const ARTICLE_MODULE_COLS = `id, publication_id, name, display_order, is_active, selection_mode, block_order, config, articles_count, lookback_hours, ai_image_prompt, created_at, updated_at`
-const TEXT_BOX_MODULE_COLS = `id, publication_id, name, display_order, is_active, show_name, config, created_at, updated_at`
-const TEXT_BOX_BLOCK_COLS = `id, text_box_module_id, block_type, display_order, static_content, text_size, ai_prompt_json, generation_timing, image_type, static_image_url, ai_image_prompt, is_active, is_bold, is_italic, created_at, updated_at`
-const FEEDBACK_MODULE_COLS = `id, publication_id, name, display_order, is_active, block_order, title_text, body_text, body_is_italic, sign_off_text, sign_off_is_italic, vote_options, team_photos, config, show_name, created_at, updated_at`
+export const NEWSLETTER_SECTION_COLS = `id, newsletter_id, name, display_order, is_active, section_type, description, created_at`
+export const AD_MODULE_COLS = `id, publication_id, name, display_order, is_active, selection_mode, block_order, config, next_position, created_at, updated_at`
+export const POLL_MODULE_COLS = `id, publication_id, name, display_order, is_active, block_order, config, created_at, updated_at`
+export const PROMPT_MODULE_COLS = `id, publication_id, name, display_order, is_active, selection_mode, block_order, config, next_position, created_at, updated_at`
+export const ARTICLE_MODULE_COLS = `id, publication_id, name, display_order, is_active, selection_mode, block_order, config, articles_count, lookback_hours, ai_image_prompt, created_at, updated_at`
+export const TEXT_BOX_MODULE_COLS = `id, publication_id, name, display_order, is_active, show_name, config, created_at, updated_at`
+export const TEXT_BOX_BLOCK_COLS = `id, text_box_module_id, block_type, display_order, static_content, text_size, ai_prompt_json, generation_timing, image_type, static_image_url, ai_image_prompt, is_active, is_bold, is_italic, created_at, updated_at`
+export const FEEDBACK_MODULE_COLS = `id, publication_id, name, display_order, is_active, block_order, title_text, body_text, body_is_italic, sign_off_text, sign_off_is_italic, vote_options, team_photos, config, show_name, created_at, updated_at`
 
 /**
  * Build an IssueSnapshot by fetching all module configs and business settings in parallel.

--- a/src/lib/rss-processor/utils.ts
+++ b/src/lib/rss-processor/utils.ts
@@ -4,8 +4,8 @@ import { getNewsletterIdFromIssue, logInfo, logError, formatError } from './shar
 
 // Explicit column lists (no select('*'))
 const ISSUE_COLS_FOR_EVENTS = `id, publication_id, date`
-const EVENT_COLS = `id, title, description, event_summary, start_date, end_date, venue, address, url, website, image_url, original_image_url, cropped_image_url, featured, paid_placement, active, created_at`
-const ISSUE_EVENT_COLS = `id, issue_id, event_id, event_date, is_selected, is_featured, display_order, created_at`
+export const EVENT_COLS = `id, title, description, event_summary, start_date, end_date, venue, address, url, website, image_url, original_image_url, cropped_image_url, featured, paid_placement, active, created_at`
+export const ISSUE_EVENT_COLS = `id, issue_id, event_id, event_date, is_selected, is_featured, display_order, created_at`
 
 /**
  * Utility methods module.


### PR DESCRIPTION
## Summary
- Add 15 Vitest tests that validate every `*_COLS` constant string against known valid database columns, catching typos before deployment
- Extract `APP_COLS`, `PROMPT_COLS`, `SECTION_COLS` into shared `src/lib/column-constants.ts` (Next.js route files cannot export custom names)
- Export COLS constants from `build-snapshot.ts`, `dal/issues.ts`, and `rss-processor/utils.ts`

## Test plan
- [x] `npm run test:run` — all 276 tests pass (15 new)
- [x] `npx tsc --noEmit` — no TypeScript errors
- [ ] Intentionally break a column name → confirm test fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized database column definitions into a shared module to reduce duplication and improve maintainability across API routes.

* **Tests**
  * Added comprehensive validation tests to ensure column definitions align with database schemas, improving data consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->