### PR TITLE
Add click_id→email mapping for AfterOffers conversions

### DIFF
--- a/db/migrations/add_afteroffers_click_mappings.sql
+++ b/db/migrations/add_afteroffers_click_mappings.sql
@@ -1,0 +1,30 @@
+-- Maps AfterOffers click_id to subscriber email at subscribe time.
+-- Used to attribute postback conversions when email is not included.
+
+create table if not exists public.afteroffers_click_mappings (
+  id uuid primary key default gen_random_uuid(),
+  publication_id text not null,
+  click_id text not null,
+  email text not null,
+  created_at timestamptz not null default now()
+);
+
+-- One mapping per click_id per publication
+alter table public.afteroffers_click_mappings
+  add constraint afteroffers_click_mappings_pub_click_unique
+  unique (publication_id, click_id);
+
+-- Fast lookup by email (e.g. find all click_ids for a subscriber)
+create index if not exists afteroffers_click_mappings_pub_email_idx
+  on public.afteroffers_click_mappings (publication_id, email);
+
+-- RLS: service role only
+alter table public.afteroffers_click_mappings enable row level security;
+
+revoke all on public.afteroffers_click_mappings from anon, authenticated;
+
+create policy "Service role full access on afteroffers_click_mappings"
+  on public.afteroffers_click_mappings
+  for all
+  using (true)
+  with check (true);

--- a/src/app/api/afteroffers/map-click/route.ts
+++ b/src/app/api/afteroffers/map-click/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withApiHandler } from '@/lib/api-handler'
+import { supabaseAdmin } from '@/lib/supabase'
+import { PUBLICATION_ID } from '@/lib/config'
+
+const inputSchema = z.object({
+  email: z.string().email(),
+  click_id: z.string().min(1),
+})
+
+export const POST = withApiHandler(
+  { authTier: 'public', inputSchema, logContext: 'afteroffers/map-click' },
+  async ({ input, logger }) => {
+    const { email, click_id } = input
+
+    const { error } = await supabaseAdmin
+      .from('afteroffers_click_mappings')
+      .upsert(
+        {
+          publication_id: PUBLICATION_ID,
+          click_id,
+          email,
+        },
+        { onConflict: 'publication_id,click_id' }
+      )
+
+    if (error) {
+      logger.error({ err: error, click_id }, 'Failed to store click mapping')
+      throw new Error(`Database error: ${error.message}`)
+    }
+
+    logger.info({ click_id }, 'Stored AfterOffers click mapping')
+    return NextResponse.json({ success: true })
+  }
+)

--- a/src/app/api/webhooks/afteroffers/postback/route.ts
+++ b/src/app/api/webhooks/afteroffers/postback/route.ts
@@ -33,7 +33,7 @@ async function handlePostback(request: Request, logger: ReturnType<typeof import
 
   const clickId = String(merged.click_id || '') || ''
   const revenueRaw = merged.revenue != null ? String(merged.revenue) : null
-  const email = String(merged.email || '') || undefined
+  let email: string | undefined = String(merged.email || '') || undefined
   const eventParam = String(merged.event || merged.action || '') || undefined
 
   if (!clickId) {
@@ -41,6 +41,21 @@ async function handlePostback(request: Request, logger: ReturnType<typeof import
       { error: 'click_id is required' },
       { status: 400 }
     )
+  }
+
+  // If email missing, look up from click mapping table
+  if (!email && clickId) {
+    const { data: mapping } = await supabaseAdmin
+      .from('afteroffers_click_mappings')
+      .select('email')
+      .eq('publication_id', PUBLICATION_ID)
+      .eq('click_id', clickId)
+      .maybeSingle()
+
+    if (mapping?.email) {
+      email = mapping.email
+      logger.info({ clickId }, 'Resolved email from click mapping')
+    }
   }
 
   const eventType = eventParam && eventParam.trim() !== '' ? eventParam : 'conversion'

--- a/src/app/website/subscribe/subscribe-form.tsx
+++ b/src/app/website/subscribe/subscribe-form.tsx
@@ -85,6 +85,13 @@ export function SubscribeForm() {
       // Ignore storage errors
     }
 
+    // Fire-and-forget: map click_id to email for postback attribution
+    fetch('/api/afteroffers/map-click', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: subscribedEmail, click_id: clickId }),
+    }).catch(() => { /* non-critical */ })
+
     window.location.href = `/subscribe/offers?email=${encodeURIComponent(subscribedEmail)}&click_id=${encodeURIComponent(clickId)}`
   }, [subscribedEmail])
 


### PR DESCRIPTION
## Summary
- Adds `afteroffers_click_mappings` table to store click_id→email at subscribe time
- New `POST /api/afteroffers/map-click` endpoint called fire-and-forget from the subscribe form
- Postback handler falls back to mapping table when email is missing from the callback

## Why
AfterOffers postbacks often arrive without an email param — only a `click_id`. Without a server-side mapping, these conversions can't be attributed to a subscriber. This bridges that gap.

## Files Changed
| File | Change |
|------|--------|
| `db/migrations/add_afteroffers_click_mappings.sql` | New table with RLS, unique constraint, index |
| `src/app/api/afteroffers/map-click/route.ts` | New public endpoint with Zod validation |
| `src/app/website/subscribe/subscribe-form.tsx` | Fire-and-forget fetch in `handleSubscribeComplete` |
| `src/app/api/webhooks/afteroffers/postback/route.ts` | Fallback email lookup when missing |

## Test plan
- [x] `POST /api/afteroffers/map-click` returns `{"success": true}` and row appears in DB
- [x] Postback without email resolves email from mapping table
- [x] `afteroffers_events` row has correct resolved email, revenue, event_type
- [x] Migration applied to Supabase
- [x] `npm run build` passes
- [ ] Manual: subscribe on staging, verify `map-click` request in Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Enhanced AfterOffers campaign attribution: Promotional clicks are now accurately mapped and linked to subscriber signups, providing complete visibility into campaign performance even when initial subscriber information is unavailable. This enables more accurate ROI measurement, improved attribution analysis, and comprehensive campaign performance analytics, delivering better insights for optimizing promotional campaigns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->