### PR TITLE
Add MailerLite field update on AfterOffers conversion postback

### DIFF
--- a/src/app/api/webhooks/afteroffers/postback/route.ts
+++ b/src/app/api/webhooks/afteroffers/postback/route.ts
@@ -58,7 +58,7 @@ async function handlePostback(request: Request, logger: ReturnType<typeof import
     }
   }
 
-  const eventType = eventParam && eventParam.trim() !== '' ? eventParam : 'conversion'
+  const eventType = eventParam && eventParam.trim() !== '' ? eventParam.trim().toLowerCase() : 'conversion'
 
   let revenue: number | null = null
   if (revenueRaw != null) {
@@ -137,8 +137,9 @@ async function handlePostback(request: Request, logger: ReturnType<typeof import
       } else {
         logger.warn({ error: result.error }, 'Failed to update MailerLite afteroffers_conversion field')
       }
-    } catch (mlError) {
-      logger.error({ err: mlError }, 'MailerLite afteroffers_conversion update error (non-fatal)')
+    } catch (mlError: unknown) {
+      const errMsg = mlError instanceof Error ? mlError.message : 'Unknown error'
+      logger.error({ error: errMsg, clickId, maskedEmail: maskEmail(email) }, 'MailerLite afteroffers_conversion update error (non-fatal)')
     }
   }
 


### PR DESCRIPTION
## Summary
- When an AfterOffers conversion postback is received, sets `afteroffers_conversion` custom field to `'true'` on the subscriber in MailerLite
- Mirrors the existing SparkLoop pattern with retry logic for subscriber-not-found timing issues
- Non-fatal: postback still returns success even if MailerLite update fails

## Test plan
- [ ] Simulate a conversion postback with a known subscriber email and verify `afteroffers_conversion` field is set in MailerLite
- [ ] Test with a non-conversion event (e.g., `event=click`) and confirm MailerLite update is skipped
- [ ] Test without email parameter — should skip MailerLite update gracefully
- [ ] Test idempotency — same postback twice should succeed without error
- [ ] Verify `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic conversion-event handling for email subscribers: events are now normalized (case-insensitive) and default to "conversion" when unspecified.
  * When a conversion email is present, the system updates subscriber conversion status in the mailing service and retries once after a short delay if the subscriber isn't found; failures are logged and do not affect the main response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->