### PR TITLE
Add Beehiiv subscriber sync and per-publication website customization

### DIFF
--- a/db/migrations/20260331_seed_subscribe_page_defaults.sql
+++ b/db/migrations/20260331_seed_subscribe_page_defaults.sql
@@ -1,0 +1,23 @@
+-- Pre-populate subscribe page settings for all active publications
+-- so the Website settings tab shows filled fields instead of empty placeholders.
+-- Uses INSERT ... ON CONFLICT DO NOTHING to avoid overwriting any already-saved values.
+
+INSERT INTO publication_settings (publication_id, key, value, updated_at)
+SELECT p.id, s.key, s.value, now()
+FROM publications p
+CROSS JOIN (VALUES
+  ('subscribe_heading', 'Master AI Tools, Prompts & News'),
+  ('subscribe_heading_styled', 'in Just 3 Minutes a Day'),
+  ('subscribe_subheading', 'Join 10,000+ accounting professionals staying current as AI reshapes bookkeeping, tax, and advisory work.'),
+  ('subscribe_tagline', 'FREE FOREVER'),
+  ('subscribe_info_heading', 'One Last Step!'),
+  ('subscribe_info_heading_styled', 'Personalize Your Experience'),
+  ('subscribe_info_subheading', 'Help us tailor your newsletter to your needs.\nThis only takes 30 seconds!'),
+  ('subscribe_info_job_label', 'What best describes your role?'),
+  ('subscribe_info_job_options', '[{"value":"Partner/Owner","label":"Partner/Owner"},{"value":"CFO","label":"CFO"},{"value":"Accountant","label":"Accountant"},{"value":"Bookkeeper","label":"Bookkeeper"},{"value":"Other","label":"Other"}]'),
+  ('subscribe_info_clients_label', 'How many clients'' books/tax returns/financials do you handle yearly?'),
+  ('subscribe_info_clients_options', '[{"value":"1 (just my employer''s or my own company)","label":"1 (just my employer''s or my own company)"},{"value":"2-20","label":"2-20"},{"value":"21-100","label":"21-100"},{"value":"101-299","label":"101-299"},{"value":"300+","label":"300+"}]'),
+  ('subscribe_info_submit_text', 'Complete Sign Up')
+) AS s(key, value)
+WHERE p.is_active = true
+ON CONFLICT (publication_id, key) DO NOTHING;

--- a/src/app/api/settings/website/route.ts
+++ b/src/app/api/settings/website/route.ts
@@ -7,7 +7,26 @@ const WEBSITE_SETTINGS_KEYS = [
   'website_heading',
   'website_subheading',
   'tools_directory_enabled',
+  // Subscribe page
+  'subscribe_heading',
+  'subscribe_heading_styled',
+  'subscribe_subheading',
+  'subscribe_tagline',
+  // Subscribe info page
+  'subscribe_info_heading',
+  'subscribe_info_heading_styled',
+  'subscribe_info_subheading',
+  'subscribe_info_job_label',
+  'subscribe_info_job_options',
+  'subscribe_info_clients_label',
+  'subscribe_info_clients_options',
+  'subscribe_info_submit_text',
 ]
+
+const JSON_SETTINGS_KEYS = new Set([
+  'subscribe_info_job_options',
+  'subscribe_info_clients_options',
+])
 
 export const GET = withApiHandler(
   { authTier: 'authenticated', logContext: 'settings/website' },
@@ -35,6 +54,12 @@ export const GET = withApiHandler(
       }
       if (cleanValue === 'true' || cleanValue === 'false') {
         settingsObject[setting.key] = cleanValue === 'true'
+      } else if (JSON_SETTINGS_KEYS.has(setting.key)) {
+        try {
+          settingsObject[setting.key] = JSON.parse(cleanValue)
+        } catch {
+          settingsObject[setting.key] = cleanValue
+        }
       } else {
         settingsObject[setting.key] = cleanValue
       }
@@ -56,7 +81,14 @@ export const POST = withApiHandler(
 
     for (const key of WEBSITE_SETTINGS_KEYS) {
       if (body[key] !== undefined) {
-        const value = typeof body[key] === 'boolean' ? String(body[key]) : body[key]
+        let value: string
+        if (typeof body[key] === 'boolean') {
+          value = String(body[key])
+        } else if (JSON_SETTINGS_KEYS.has(key)) {
+          value = typeof body[key] === 'string' ? body[key] : JSON.stringify(body[key])
+        } else {
+          value = body[key]
+        }
 
         await supabaseAdmin
           .from('publication_settings')

--- a/src/app/website/subscribe/info/page.tsx
+++ b/src/app/website/subscribe/info/page.tsx
@@ -18,11 +18,41 @@ export default async function SubscribeInfoPage() {
   // Fetch settings from publication_settings
   const settings = await getPublicationSettings(publicationId, [
     'logo_url',
-    'newsletter_name'
+    'newsletter_name',
+    'subscribe_info_heading',
+    'subscribe_info_heading_styled',
+    'subscribe_info_subheading',
+    'subscribe_info_job_label',
+    'subscribe_info_job_options',
+    'subscribe_info_clients_label',
+    'subscribe_info_clients_options',
+    'subscribe_info_submit_text',
   ])
 
   const logoUrl = settings.logo_url || '/logo.png'
   const newsletterName = settings.newsletter_name || 'AI Accounting Daily'
+  const heading = settings.subscribe_info_heading || 'One Last Step!'
+  const headingStyled = settings.subscribe_info_heading_styled || 'Personalize Your Experience'
+  const subheading = settings.subscribe_info_subheading || 'Help us tailor your newsletter to your needs.\nThis only takes 30 seconds!'
+
+  // Parse JSON option arrays if stored as strings
+  let jobOptions: { value: string; label: string }[] | undefined
+  if (settings.subscribe_info_job_options) {
+    try {
+      jobOptions = typeof settings.subscribe_info_job_options === 'string'
+        ? JSON.parse(settings.subscribe_info_job_options)
+        : undefined
+    } catch { /* use defaults */ }
+  }
+
+  let clientsOptions: { value: string; label: string }[] | undefined
+  if (settings.subscribe_info_clients_options) {
+    try {
+      clientsOptions = typeof settings.subscribe_info_clients_options === 'string'
+        ? JSON.parse(settings.subscribe_info_clients_options)
+        : undefined
+    } catch { /* use defaults */ }
+  }
 
   return (
     <main className="min-h-[100dvh] bg-white px-4">
@@ -43,7 +73,7 @@ export default async function SubscribeInfoPage() {
 
             {/* Headline */}
             <h1 className="font-display text-2xl tracking-tight text-slate-900 sm:text-4xl">
-              One Last Step!
+              {heading}
               <br />
               <span className="relative whitespace-nowrap">
                 <svg
@@ -54,20 +84,26 @@ export default async function SubscribeInfoPage() {
                 >
                   <path d="M203.371.916c-26.013-2.078-76.686 1.963-124.73 9.946L67.3 12.749C35.421 18.062 18.2 21.766 6.004 25.934 1.244 27.561.828 27.778.874 28.61c.07 1.214.828 1.121 9.595-1.176 9.072-2.377 17.15-3.92 39.246-7.496C123.565 7.986 157.869 4.492 195.942 5.046c7.461.108 19.25 1.696 19.17 2.582-.107 1.183-7.874 4.31-25.75 10.366-21.992 7.45-35.43 12.534-36.701 13.884-2.173 2.308-.202 4.407 4.442 4.734 2.654.187 3.263.157 15.593-.78 35.401-2.686 57.944-3.488 88.365-3.143 46.327.526 75.721 2.23 130.788 7.584 19.787 1.924 20.814 1.98 24.557 1.332l.066-.011c1.201-.203 1.53-1.825.399-2.335-2.911-1.31-4.893-1.604-22.048-3.261-57.509-5.556-87.871-7.36-132.059-7.842-23.239-.254-33.617-.116-50.627.674-11.629.54-42.371 2.494-46.696 2.967-2.359.259 8.133-3.625 26.504-9.81 23.239-7.825 27.934-10.149 28.304-14.005.417-4.348-3.529-6-16.878-7.066Z" />
                 </svg>
-                <span className="relative bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text text-transparent">Personalize Your Experience</span>
+                <span className="relative bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text text-transparent">{headingStyled}</span>
               </span>
             </h1>
 
             {/* Subheadline */}
             <p className="mt-4 sm:mt-6 text-base sm:text-lg tracking-tight text-slate-700">
-              Help us tailor your newsletter to your needs.
-              <br />
-              This only takes 30 seconds!
+              {subheading.split('\n').map((line, i) => (
+                <span key={i}>{i > 0 && <br />}{line}</span>
+              ))}
             </p>
 
             {/* Personalization Form */}
             <div className="mt-6 sm:mt-10">
-              <PersonalizationForm />
+              <PersonalizationForm
+                jobLabel={settings.subscribe_info_job_label || undefined}
+                jobOptions={jobOptions}
+                clientsLabel={settings.subscribe_info_clients_label || undefined}
+                clientsOptions={clientsOptions}
+                submitText={settings.subscribe_info_submit_text || undefined}
+              />
             </div>
           </div>
         </Container>

--- a/src/app/website/subscribe/info/page.tsx
+++ b/src/app/website/subscribe/info/page.tsx
@@ -1,19 +1,13 @@
 import { Container } from "@/components/salient/Container"
 import { SubscribeProgressBar } from '@/components/SubscribeProgressBar'
 import { PersonalizationForm } from "./personalization-form"
-import { headers } from 'next/headers'
-import { getPublicationByDomain, getPublicationSettings } from '@/lib/publication-settings'
+import { resolvePublicationFromRequest, getPublicationSettings } from '@/lib/publication-settings'
 
 // Force dynamic rendering to fetch fresh data
 export const dynamic = 'force-dynamic'
 
 export default async function SubscribeInfoPage() {
-  // Get domain from headers (Next.js 15 requires await)
-  const headersList = await headers()
-  const host = headersList.get('x-forwarded-host') || headersList.get('host') || 'aiaccountingdaily.com'
-
-  // Get publication ID from domain
-  const publicationId = await getPublicationByDomain(host) || 'accounting'
+  const { publicationId } = await resolvePublicationFromRequest()
 
   // Fetch settings from publication_settings
   const settings = await getPublicationSettings(publicationId, [

--- a/src/app/website/subscribe/info/page.tsx
+++ b/src/app/website/subscribe/info/page.tsx
@@ -35,22 +35,24 @@ export default async function SubscribeInfoPage() {
   const headingStyled = settings.subscribe_info_heading_styled || 'Personalize Your Experience'
   const subheading = settings.subscribe_info_subheading || 'Help us tailor your newsletter to your needs.\nThis only takes 30 seconds!'
 
-  // Parse JSON option arrays if stored as strings
+  // Parse JSON option arrays (stored as JSON strings in publication_settings)
   let jobOptions: { value: string; label: string }[] | undefined
   if (settings.subscribe_info_job_options) {
     try {
-      jobOptions = typeof settings.subscribe_info_job_options === 'string'
+      const parsed = typeof settings.subscribe_info_job_options === 'string'
         ? JSON.parse(settings.subscribe_info_job_options)
-        : undefined
+        : settings.subscribe_info_job_options
+      if (Array.isArray(parsed)) jobOptions = parsed
     } catch { /* use defaults */ }
   }
 
   let clientsOptions: { value: string; label: string }[] | undefined
   if (settings.subscribe_info_clients_options) {
     try {
-      clientsOptions = typeof settings.subscribe_info_clients_options === 'string'
+      const parsed = typeof settings.subscribe_info_clients_options === 'string'
         ? JSON.parse(settings.subscribe_info_clients_options)
-        : undefined
+        : settings.subscribe_info_clients_options
+      if (Array.isArray(parsed)) clientsOptions = parsed
     } catch { /* use defaults */ }
   }
 

--- a/src/app/website/subscribe/info/personalization-form.tsx
+++ b/src/app/website/subscribe/info/personalization-form.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react"
 import { useSearchParams } from "next/navigation"
 
-const JOB_TYPE_OPTIONS = [
+const DEFAULT_JOB_OPTIONS = [
   { value: 'partner_owner', label: 'Partner/Owner' },
   { value: 'cfo', label: 'CFO' },
   { value: 'accountant', label: 'Accountant' },
@@ -11,7 +11,7 @@ const JOB_TYPE_OPTIONS = [
   { value: 'other', label: 'Other' },
 ]
 
-const YEARLY_CLIENTS_OPTIONS = [
+const DEFAULT_CLIENTS_OPTIONS = [
   { value: '1', label: '1 (just my employer\'s or my own company)' },
   { value: '2-20', label: '2-20' },
   { value: '21-100', label: '21-100' },
@@ -19,7 +19,21 @@ const YEARLY_CLIENTS_OPTIONS = [
   { value: '300+', label: '300+' },
 ]
 
-export function PersonalizationForm() {
+interface PersonalizationFormProps {
+  jobLabel?: string
+  jobOptions?: { value: string; label: string }[]
+  clientsLabel?: string
+  clientsOptions?: { value: string; label: string }[]
+  submitText?: string
+}
+
+export function PersonalizationForm({
+  jobLabel = 'What best describes your role?',
+  jobOptions = DEFAULT_JOB_OPTIONS,
+  clientsLabel = "How many clients' books/tax returns/financials do you handle yearly?",
+  clientsOptions = DEFAULT_CLIENTS_OPTIONS,
+  submitText = 'Complete Sign Up',
+}: PersonalizationFormProps) {
   const searchParams = useSearchParams()
   const urlEmail = searchParams.get('email') || ''
 
@@ -174,7 +188,7 @@ export function PersonalizationForm() {
         {/* Job Type Dropdown */}
         <div>
           <label htmlFor="jobType" className="block text-sm font-medium text-slate-700 text-left mb-1">
-            What best describes your role? <span className="text-red-500">*</span>
+            {jobLabel} <span className="text-red-500">*</span>
           </label>
           <select
             id="jobType"
@@ -185,7 +199,7 @@ export function PersonalizationForm() {
             className="w-full rounded-lg border-0 bg-white px-4 py-3 text-slate-900 shadow-lg ring-1 ring-inset ring-slate-200 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm"
           >
             <option value="">Select your role...</option>
-            {JOB_TYPE_OPTIONS.map((option) => (
+            {jobOptions.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
               </option>
@@ -196,7 +210,7 @@ export function PersonalizationForm() {
         {/* Yearly Clients Dropdown */}
         <div>
           <label htmlFor="yearlyClients" className="block text-sm font-medium text-slate-700 text-left mb-1">
-            How many clients&apos; books/tax returns/financials do you handle yearly? <span className="text-red-500">*</span>
+            {clientsLabel} <span className="text-red-500">*</span>
           </label>
           <select
             id="yearlyClients"
@@ -207,7 +221,7 @@ export function PersonalizationForm() {
             className="w-full rounded-lg border-0 bg-white px-4 py-3 text-slate-900 shadow-lg ring-1 ring-inset ring-slate-200 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm"
           >
             <option value="">Select an option...</option>
-            {YEARLY_CLIENTS_OPTIONS.map((option) => (
+            {clientsOptions.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
               </option>
@@ -221,7 +235,7 @@ export function PersonalizationForm() {
           disabled={isSubmitting || !email}
           className="w-full rounded-full bg-blue-600 px-6 py-4 text-base font-semibold text-white shadow-lg hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
-          {isSubmitting ? 'Submitting...' : 'Complete Sign Up'}
+          {isSubmitting ? 'Submitting...' : submitText}
         </button>
       </form>
 

--- a/src/app/website/subscribe/page.tsx
+++ b/src/app/website/subscribe/page.tsx
@@ -17,11 +17,19 @@ export default async function SubscribePage() {
   // Fetch settings from publication_settings
   const settings = await getPublicationSettings(publicationId, [
     'logo_url',
-    'newsletter_name'
+    'newsletter_name',
+    'subscribe_heading',
+    'subscribe_heading_styled',
+    'subscribe_subheading',
+    'subscribe_tagline',
   ])
 
   const logoUrl = settings.logo_url || '/logo.png'
   const newsletterName = settings.newsletter_name || 'AI Accounting Daily'
+  const heading = settings.subscribe_heading || 'Master AI Tools, Prompts & News'
+  const headingStyled = settings.subscribe_heading_styled || 'in Just 3 Minutes a Day'
+  const subheading = settings.subscribe_subheading || 'Join 10,000+ accounting professionals staying current as AI reshapes bookkeeping, tax, and advisory work.'
+  const tagline = settings.subscribe_tagline || 'FREE FOREVER'
 
   return (
     <main className="min-h-[100dvh] bg-white px-4">
@@ -40,7 +48,7 @@ export default async function SubscribePage() {
 
             {/* Headline */}
             <h1 className="font-display text-2xl tracking-tight text-slate-900 sm:text-4xl">
-              Master AI Tools, Prompts & News
+              {heading}
               <br />
               <span className="relative whitespace-nowrap">
                 <svg
@@ -51,19 +59,18 @@ export default async function SubscribePage() {
                 >
                   <path d="M203.371.916c-26.013-2.078-76.686 1.963-124.73 9.946L67.3 12.749C35.421 18.062 18.2 21.766 6.004 25.934 1.244 27.561.828 27.778.874 28.61c.07 1.214.828 1.121 9.595-1.176 9.072-2.377 17.15-3.92 39.246-7.496C123.565 7.986 157.869 4.492 195.942 5.046c7.461.108 19.25 1.696 19.17 2.582-.107 1.183-7.874 4.31-25.75 10.366-21.992 7.45-35.43 12.534-36.701 13.884-2.173 2.308-.202 4.407 4.442 4.734 2.654.187 3.263.157 15.593-.78 35.401-2.686 57.944-3.488 88.365-3.143 46.327.526 75.721 2.23 130.788 7.584 19.787 1.924 20.814 1.98 24.557 1.332l.066-.011c1.201-.203 1.53-1.825.399-2.335-2.911-1.31-4.893-1.604-22.048-3.261-57.509-5.556-87.871-7.36-132.059-7.842-23.239-.254-33.617-.116-50.627.674-11.629.54-42.371 2.494-46.696 2.967-2.359.259 8.133-3.625 26.504-9.81 23.239-7.825 27.934-10.149 28.304-14.005.417-4.348-3.529-6-16.878-7.066Z" />
                 </svg>
-                <span className="relative bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text text-transparent">in Just 3 Minutes a Day</span>
+                <span className="relative bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text text-transparent">{headingStyled}</span>
               </span>
             </h1>
 
             {/* Subheadline */}
             <p className="mt-4 sm:mt-6 text-base sm:text-lg tracking-tight text-slate-700">
-              Join 10,000+ accounting professionals staying current
-              as AI reshapes bookkeeping, tax, and advisory work.
+              {subheading}
             </p>
 
             {/* Subscribe Form */}
             <div className="mt-6 sm:mt-10">
-              <SubscribeForm />
+              <SubscribeForm newsletterName={newsletterName} tagline={tagline} />
             </div>
           </div>
         </Container>

--- a/src/app/website/subscribe/page.tsx
+++ b/src/app/website/subscribe/page.tsx
@@ -1,18 +1,12 @@
 import { Container } from "@/components/salient/Container"
 import { SubscribeForm } from "./subscribe-form"
-import { headers } from 'next/headers'
-import { getPublicationByDomain, getPublicationSettings } from '@/lib/publication-settings'
+import { resolvePublicationFromRequest, getPublicationSettings } from '@/lib/publication-settings'
 
 // Force dynamic rendering to fetch fresh data
 export const dynamic = 'force-dynamic'
 
 export default async function SubscribePage() {
-  // Get domain from headers (Next.js 15 requires await)
-  const headersList = await headers()
-  const host = headersList.get('x-forwarded-host') || headersList.get('host') || 'aiaccountingdaily.com'
-
-  // Get publication ID from domain
-  const publicationId = await getPublicationByDomain(host) || 'accounting'
+  const { publicationId } = await resolvePublicationFromRequest()
 
   // Fetch settings from publication_settings
   const settings = await getPublicationSettings(publicationId, [

--- a/src/app/website/subscribe/subscribe-form.tsx
+++ b/src/app/website/subscribe/subscribe-form.tsx
@@ -58,7 +58,7 @@ function generateAfterOffersClickId() {
   return `ao_${Date.now()}_${randomPart}`
 }
 
-export function SubscribeForm() {
+export function SubscribeForm({ newsletterName = 'AI Accounting Daily', tagline = 'FREE FOREVER' }: { newsletterName?: string; tagline?: string }) {
   const [email, setEmail] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState('')
@@ -195,9 +195,9 @@ export function SubscribeForm() {
           </div>
         )}
 
-        {!error && (
+        {!error && tagline && (
           <p className="text-lg font-bold text-slate-600 tracking-wide">
-            FREE FOREVER
+            {tagline}
           </p>
         )}
       </div>
@@ -208,7 +208,7 @@ export function SubscribeForm() {
         onClose={handleModalClose}
         subscriberEmail={subscribedEmail}
         onSubscribeComplete={handleSubscribeComplete}
-        publicationName="AI Accounting Daily"
+        publicationName={newsletterName}
       />
     </>
   )

--- a/src/components/settings/EmailSettings.tsx
+++ b/src/components/settings/EmailSettings.tsx
@@ -798,9 +798,9 @@ export default function EmailSettings({ publicationId }: { publicationId: string
           </div>
         </div>
 
-        <div className="mt-4 p-3 bg-amber-50 border border-amber-200 rounded text-sm text-amber-800">
-          <strong>Required custom fields in Beehiiv:</strong> Create these custom fields in your Beehiiv publication settings before enabling: first_name, last_name, job_type, yearly_clients, fbp, fbc, fb_pixel_timestamp, fb_pixel_event_source_url, fb_pixel_user_agent, fb_pixel_ip, kb_status, kb_reason, kb_sendex, kb_free_email, kb_disposable, kb_role, kb_validation_timestamp.
-        </div>
+        <p className="mt-3 text-sm text-gray-500">
+          Beehiiv handles subscriber management only. Newsletter sending still uses MailerLite, so keep your MailerLite group IDs configured above.
+        </p>
       </div>
 
       {/* Automated Publication Review Schedule */}

--- a/src/components/settings/WebsiteSettings.tsx
+++ b/src/components/settings/WebsiteSettings.tsx
@@ -289,24 +289,12 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
             <div key={i} className="flex items-center gap-2 mb-2">
               <input
                 type="text"
-                value={opt.value}
-                onChange={(e) => {
-                  const updated = [...settings.subscribe_info_job_options]
-                  updated[i] = { ...updated[i], value: e.target.value }
-                  setSettings(prev => ({ ...prev, subscribe_info_job_options: updated }))
-                }}
-                placeholder="Stored value"
-                className="w-32 border rounded-md px-3 py-1.5 text-sm text-gray-500 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <input
-                type="text"
                 value={opt.label}
                 onChange={(e) => {
                   const updated = [...settings.subscribe_info_job_options]
-                  updated[i] = { ...updated[i], label: e.target.value }
+                  updated[i] = { value: e.target.value, label: e.target.value }
                   setSettings(prev => ({ ...prev, subscribe_info_job_options: updated }))
                 }}
-                placeholder="Display label"
                 className="flex-1 border rounded-md px-3 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
               <button
@@ -353,24 +341,12 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
             <div key={i} className="flex items-center gap-2 mb-2">
               <input
                 type="text"
-                value={opt.value}
-                onChange={(e) => {
-                  const updated = [...settings.subscribe_info_clients_options]
-                  updated[i] = { ...updated[i], value: e.target.value }
-                  setSettings(prev => ({ ...prev, subscribe_info_clients_options: updated }))
-                }}
-                placeholder="Stored value"
-                className="w-32 border rounded-md px-3 py-1.5 text-sm text-gray-500 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <input
-                type="text"
                 value={opt.label}
                 onChange={(e) => {
                   const updated = [...settings.subscribe_info_clients_options]
-                  updated[i] = { ...updated[i], label: e.target.value }
+                  updated[i] = { value: e.target.value, label: e.target.value }
                   setSettings(prev => ({ ...prev, subscribe_info_clients_options: updated }))
                 }}
-                placeholder="Display label"
                 className="flex-1 border rounded-md px-3 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
               <button

--- a/src/components/settings/WebsiteSettings.tsx
+++ b/src/components/settings/WebsiteSettings.tsx
@@ -3,11 +3,41 @@
 import { useState, useEffect } from 'react'
 
 export default function WebsiteSettings({ publicationId }: { publicationId: string }) {
+  const DEFAULT_JOB_OPTIONS = [
+    { value: 'partner_owner', label: 'Partner/Owner' },
+    { value: 'cfo', label: 'CFO' },
+    { value: 'accountant', label: 'Accountant' },
+    { value: 'bookkeeper', label: 'Bookkeeper' },
+    { value: 'other', label: 'Other' },
+  ]
+
+  const DEFAULT_CLIENTS_OPTIONS = [
+    { value: '1', label: "1 (just my employer's or my own company)" },
+    { value: '2-20', label: '2-20' },
+    { value: '21-100', label: '21-100' },
+    { value: '101-299', label: '101-299' },
+    { value: '300+', label: '300+' },
+  ]
+
   const [settings, setSettings] = useState({
     website_callout_text: '',
     website_heading: '',
     website_subheading: '',
     tools_directory_enabled: true,
+    // Subscribe page
+    subscribe_heading: '',
+    subscribe_heading_styled: '',
+    subscribe_subheading: '',
+    subscribe_tagline: '',
+    // Subscribe info page
+    subscribe_info_heading: '',
+    subscribe_info_heading_styled: '',
+    subscribe_info_subheading: '',
+    subscribe_info_job_label: '',
+    subscribe_info_job_options: DEFAULT_JOB_OPTIONS as { value: string; label: string }[],
+    subscribe_info_clients_label: '',
+    subscribe_info_clients_options: DEFAULT_CLIENTS_OPTIONS as { value: string; label: string }[],
+    subscribe_info_submit_text: '',
   })
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -142,6 +172,168 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
               }`}
             />
           </button>
+        </div>
+      </div>
+
+      {/* Subscribe Page */}
+      <div className="border rounded-lg p-4 space-y-4">
+        <h3 className="font-medium text-gray-900">Subscribe Page (/subscribe)</h3>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Heading</label>
+          <input
+            type="text"
+            value={settings.subscribe_heading}
+            onChange={(e) => setSettings(prev => ({ ...prev, subscribe_heading: e.target.value }))}
+            placeholder="Master AI Tools, Prompts & News"
+            className="w-full border rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Heading (Styled Line)</label>
+          <input
+            type="text"
+            value={settings.subscribe_heading_styled}
+            onChange={(e) => setSettings(prev => ({ ...prev, subscribe_heading_styled: e.target.value }))}
+            placeholder="in Just 3 Minutes a Day"
+            className="w-full border rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <p className="text-xs text-gray-400 mt-1">This line appears with the gradient underline style.</p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Subheadline</label>
+          <textarea
+            value={settings.subscribe_subheading}
+            onChange={(e) => setSettings(prev => ({ ...prev, subscribe_subheading: e.target.value }))}
+            placeholder="Join 10,000+ accounting professionals staying current as AI reshapes bookkeeping, tax, and advisory work."
+            rows={2}
+            className="w-full border rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Tagline</label>
+          <input
+            type="text"
+            value={settings.subscribe_tagline}
+            onChange={(e) => setSettings(prev => ({ ...prev, subscribe_tagline: e.target.value }))}
+            placeholder="FREE FOREVER"
+            className="w-full border rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <p className="text-xs text-gray-400 mt-1">Shown below the subscribe form. Leave empty to hide.</p>
+        </div>
+      </div>
+
+      {/* Subscribe Info Page */}
+      <div className="border rounded-lg p-4 space-y-4">
+        <h3 className="font-medium text-gray-900">Subscribe Info Page (/subscribe/info)</h3>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Heading</label>
+          <input
+            type="text"
+            value={settings.subscribe_info_heading}
+            onChange={(e) => setSettings(prev => ({ ...prev, subscribe_info_heading: e.target.value }))}
+            placeholder="One Last Step!"
+            className="w-full border rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Heading (Styled Line)</label>
+          <input
+            type="text"
+            value={settings.subscribe_info_heading_styled}
+            onChange={(e) => setSettings(prev => ({ ...prev, subscribe_info_heading_styled: e.target.value }))}
+            placeholder="Personalize Your Experience"
+            className="w-full border rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Subheadline</label>
+          <textarea
+            value={settings.subscribe_info_subheading}
+            onChange={(e) => setSettings(prev => ({ ...prev, subscribe_info_subheading: e.target.value }))}
+            placeholder="Help us tailor your newsletter to your needs. This only takes 30 seconds!"
+            rows={2}
+            className="w-full border rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Job Type Question Label</label>
+          <input
+            type="text"
+            value={settings.subscribe_info_job_label}
+            onChange={(e) => setSettings(prev => ({ ...prev, subscribe_info_job_label: e.target.value }))}
+            placeholder="What best describes your role?"
+            className="w-full border rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Job Type Option Labels</label>
+          <p className="text-xs text-gray-400 mb-2">Edit the display labels for each option. The stored values remain the same.</p>
+          {settings.subscribe_info_job_options.map((opt, i) => (
+            <div key={opt.value} className="flex items-center gap-2 mb-2">
+              <span className="text-xs text-gray-400 w-28 shrink-0">{opt.value}</span>
+              <input
+                type="text"
+                value={opt.label}
+                onChange={(e) => {
+                  const updated = [...settings.subscribe_info_job_options]
+                  updated[i] = { ...updated[i], label: e.target.value }
+                  setSettings(prev => ({ ...prev, subscribe_info_job_options: updated }))
+                }}
+                className="flex-1 border rounded-md px-3 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+          ))}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Yearly Clients Question Label</label>
+          <input
+            type="text"
+            value={settings.subscribe_info_clients_label}
+            onChange={(e) => setSettings(prev => ({ ...prev, subscribe_info_clients_label: e.target.value }))}
+            placeholder="How many clients' books/tax returns/financials do you handle yearly?"
+            className="w-full border rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Yearly Clients Option Labels</label>
+          <p className="text-xs text-gray-400 mb-2">Edit the display labels for each option. The stored values remain the same.</p>
+          {settings.subscribe_info_clients_options.map((opt, i) => (
+            <div key={opt.value} className="flex items-center gap-2 mb-2">
+              <span className="text-xs text-gray-400 w-28 shrink-0">{opt.value}</span>
+              <input
+                type="text"
+                value={opt.label}
+                onChange={(e) => {
+                  const updated = [...settings.subscribe_info_clients_options]
+                  updated[i] = { ...updated[i], label: e.target.value }
+                  setSettings(prev => ({ ...prev, subscribe_info_clients_options: updated }))
+                }}
+                className="flex-1 border rounded-md px-3 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+          ))}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Submit Button Text</label>
+          <input
+            type="text"
+            value={settings.subscribe_info_submit_text}
+            onChange={(e) => setSettings(prev => ({ ...prev, subscribe_info_submit_text: e.target.value }))}
+            placeholder="Complete Sign Up"
+            className="w-full border rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
         </div>
       </div>
 

--- a/src/components/settings/WebsiteSettings.tsx
+++ b/src/components/settings/WebsiteSettings.tsx
@@ -105,7 +105,10 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
 
       {/* Home Page Hero Section */}
       <div className="border rounded-lg p-4 space-y-4">
-        <h3 className="font-medium text-gray-900">Home Page Hero</h3>
+        <div className="flex items-center justify-between">
+          <h3 className="font-medium text-gray-900">Home Page Hero</h3>
+          <a href="/" target="_blank" rel="noopener noreferrer" className="text-xs text-blue-600 hover:text-blue-800">View Page &rarr;</a>
+        </div>
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -177,7 +180,10 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
 
       {/* Subscribe Page */}
       <div className="border rounded-lg p-4 space-y-4">
-        <h3 className="font-medium text-gray-900">Subscribe Page (/subscribe)</h3>
+        <div className="flex items-center justify-between">
+          <h3 className="font-medium text-gray-900">Subscribe Page</h3>
+          <a href="/subscribe" target="_blank" rel="noopener noreferrer" className="text-xs text-blue-600 hover:text-blue-800">View Page &rarr;</a>
+        </div>
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">Heading</label>
@@ -228,7 +234,10 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
 
       {/* Subscribe Info Page */}
       <div className="border rounded-lg p-4 space-y-4">
-        <h3 className="font-medium text-gray-900">Subscribe Info Page (/subscribe/info)</h3>
+        <div className="flex items-center justify-between">
+          <h3 className="font-medium text-gray-900">Subscribe Info Page</h3>
+          <a href="/subscribe/info" target="_blank" rel="noopener noreferrer" className="text-xs text-blue-600 hover:text-blue-800">View Page &rarr;</a>
+        </div>
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">Heading</label>
@@ -264,7 +273,7 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Job Type Question Label</label>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Question 1 Label</label>
           <input
             type="text"
             value={settings.subscribe_info_job_label}
@@ -275,11 +284,20 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Job Type Option Labels</label>
-          <p className="text-xs text-gray-400 mb-2">Edit the display labels for each option. The stored values remain the same.</p>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Question 1 Options</label>
           {settings.subscribe_info_job_options.map((opt, i) => (
-            <div key={opt.value} className="flex items-center gap-2 mb-2">
-              <span className="text-xs text-gray-400 w-28 shrink-0">{opt.value}</span>
+            <div key={i} className="flex items-center gap-2 mb-2">
+              <input
+                type="text"
+                value={opt.value}
+                onChange={(e) => {
+                  const updated = [...settings.subscribe_info_job_options]
+                  updated[i] = { ...updated[i], value: e.target.value }
+                  setSettings(prev => ({ ...prev, subscribe_info_job_options: updated }))
+                }}
+                placeholder="Stored value"
+                className="w-32 border rounded-md px-3 py-1.5 text-sm text-gray-500 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
               <input
                 type="text"
                 value={opt.label}
@@ -288,14 +306,38 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
                   updated[i] = { ...updated[i], label: e.target.value }
                   setSettings(prev => ({ ...prev, subscribe_info_job_options: updated }))
                 }}
+                placeholder="Display label"
                 className="flex-1 border rounded-md px-3 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
+              <button
+                type="button"
+                onClick={() => {
+                  const updated = settings.subscribe_info_job_options.filter((_, idx) => idx !== i)
+                  setSettings(prev => ({ ...prev, subscribe_info_job_options: updated }))
+                }}
+                className="text-red-400 hover:text-red-600 text-sm px-1"
+                title="Remove option"
+              >
+                &times;
+              </button>
             </div>
           ))}
+          <button
+            type="button"
+            onClick={() => {
+              setSettings(prev => ({
+                ...prev,
+                subscribe_info_job_options: [...prev.subscribe_info_job_options, { value: '', label: '' }]
+              }))
+            }}
+            className="text-xs text-blue-600 hover:text-blue-800 mt-1"
+          >
+            + Add option
+          </button>
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Yearly Clients Question Label</label>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Question 2 Label</label>
           <input
             type="text"
             value={settings.subscribe_info_clients_label}
@@ -306,11 +348,20 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Yearly Clients Option Labels</label>
-          <p className="text-xs text-gray-400 mb-2">Edit the display labels for each option. The stored values remain the same.</p>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Question 2 Options</label>
           {settings.subscribe_info_clients_options.map((opt, i) => (
-            <div key={opt.value} className="flex items-center gap-2 mb-2">
-              <span className="text-xs text-gray-400 w-28 shrink-0">{opt.value}</span>
+            <div key={i} className="flex items-center gap-2 mb-2">
+              <input
+                type="text"
+                value={opt.value}
+                onChange={(e) => {
+                  const updated = [...settings.subscribe_info_clients_options]
+                  updated[i] = { ...updated[i], value: e.target.value }
+                  setSettings(prev => ({ ...prev, subscribe_info_clients_options: updated }))
+                }}
+                placeholder="Stored value"
+                className="w-32 border rounded-md px-3 py-1.5 text-sm text-gray-500 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
               <input
                 type="text"
                 value={opt.label}
@@ -319,10 +370,34 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
                   updated[i] = { ...updated[i], label: e.target.value }
                   setSettings(prev => ({ ...prev, subscribe_info_clients_options: updated }))
                 }}
+                placeholder="Display label"
                 className="flex-1 border rounded-md px-3 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
+              <button
+                type="button"
+                onClick={() => {
+                  const updated = settings.subscribe_info_clients_options.filter((_, idx) => idx !== i)
+                  setSettings(prev => ({ ...prev, subscribe_info_clients_options: updated }))
+                }}
+                className="text-red-400 hover:text-red-600 text-sm px-1"
+                title="Remove option"
+              >
+                &times;
+              </button>
             </div>
           ))}
+          <button
+            type="button"
+            onClick={() => {
+              setSettings(prev => ({
+                ...prev,
+                subscribe_info_clients_options: [...prev.subscribe_info_clients_options, { value: '', label: '' }]
+              }))
+            }}
+            className="text-xs text-blue-600 hover:text-blue-800 mt-1"
+          >
+            + Add option
+          </button>
         </div>
 
         <div>

--- a/src/lib/publication-settings.ts
+++ b/src/lib/publication-settings.ts
@@ -401,11 +401,13 @@ export async function getEmailProviderSettings(publicationId: string): Promise<{
   const provider = (settings.email_provider || 'mailerlite') as 'mailerlite' | 'sendgrid' | 'beehiiv'
 
   if (provider === 'beehiiv') {
+    // Beehiiv handles subscribers only — sending still uses MailerLite,
+    // so we pass through the MailerLite group IDs for send routes.
     return {
       provider: 'beehiiv',
-      reviewGroupId: '',
-      mainGroupId: '',
-      secondaryGroupId: '',
+      reviewGroupId: settings.mailerlite_review_group_id || settings.email_reviewGroupId || '',
+      mainGroupId: settings.mailerlite_main_group_id || settings.mailerlite_group_id || '',
+      secondaryGroupId: settings.mailerlite_secondary_group_id || '',
       beehiivPublicationId: settings.beehiiv_publication_id || '',
       beehiivApiKey: settings.beehiiv_api_key || '',
     }


### PR DESCRIPTION
## Summary
- Add Beehiiv as third email provider for subscriber management (subscribe, personalize, SparkLoop, AfterOffers, field update cron)
- Per-publication API key and publication ID in settings; sending continues via MailerLite
- Per-publication customization for /subscribe and /subscribe/info pages (headings, subheadline, tagline, form questions with add/remove options)
- Settings UI under Website tab with "View Page" links
- Fix SparkLoopModal hardcoded publicationName to use newsletter_name setting
- Fix subscribe pages using slug fallback instead of publication UUID
- Migration to pre-populate default settings for all active publications

## Test plan
- [ ] Set publication to Beehiiv provider, verify subscriber creation via /subscribe
- [ ] Verify personalization fields sync to Beehiiv via /subscribe/info
- [ ] Verify MailerLite/SendGrid flows still work when selected
- [ ] Customize /subscribe page text in Website settings, verify changes render
- [ ] Add/remove question options, verify /subscribe/info form updates
- [ ] Run seed migration, verify settings tab shows pre-filled defaults
- [ ] Verify SparkLoopModal shows correct publication name

🤖 Generated with [Claude Code](https://claude.com/claude-code)