### PR TITLE
Retry storage uploads + reduce image gen concurrency

### DIFF
--- a/src/lib/rss-combiner.ts
+++ b/src/lib/rss-combiner.ts
@@ -741,11 +741,17 @@ export async function runIngestion(): Promise<IngestionResult> {
   // 4b. Generate trade card images for trades missing image_url
   // Runs in parallel batches to fit within Vercel's function timeout.
   // Uses resolved company names from ticker_company_names table.
-  const IMAGE_BATCH_SIZE = 10
+  // Batch size is 5 + 500ms inter-batch delay to avoid overwhelming
+  // Supabase Storage / Tinify (which returned HTML error pages under load).
+  const IMAGE_BATCH_SIZE = 5
+  const IMAGE_BATCH_DELAY_MS = 500
   const tradesNeedingImages = tradesWithNames.filter((t) => !t.image_url)
   let imagesGenerated = 0
 
   for (let i = 0; i < tradesNeedingImages.length; i += IMAGE_BATCH_SIZE) {
+    if (i > 0) {
+      await new Promise((r) => setTimeout(r, IMAGE_BATCH_DELAY_MS))
+    }
     const batch = tradesNeedingImages.slice(i, i + IMAGE_BATCH_SIZE)
     const results = await Promise.allSettled(
       batch.map((trade) =>
@@ -1097,10 +1103,14 @@ export async function runIngestion(): Promise<IngestionResult> {
           ticker: row.ticker,
         }))
 
-        // Generate in parallel batches
-        const FEED_IMAGE_BATCH_SIZE = 10
+        // Generate in parallel batches with delay to avoid overwhelming storage
+        const FEED_IMAGE_BATCH_SIZE = 5
+        const FEED_IMAGE_DELAY_MS = 500
         let feedImagesGenerated = 0
         for (let i = 0; i < tradesToGenerate.length; i += FEED_IMAGE_BATCH_SIZE) {
+          if (i > 0) {
+            await new Promise((r) => setTimeout(r, FEED_IMAGE_DELAY_MS))
+          }
           const batch = tradesToGenerate.slice(i, i + FEED_IMAGE_BATCH_SIZE)
           const results = await Promise.allSettled(batch.map(t => generateAndUploadTradeImage(t)))
           for (const result of results) {

--- a/src/lib/supabase-image-storage.ts
+++ b/src/lib/supabase-image-storage.ts
@@ -180,7 +180,11 @@ export class SupabaseImageStorage {
     return (data?.length ?? 0) > 0
   }
 
-  /** Upload buffer to Supabase Storage and return the public URL */
+  /**
+   * Upload buffer to Supabase Storage and return the public URL.
+   * Retries with exponential backoff when the storage API returns transient
+   * errors (gateway timeouts, HTML error pages from CDN, JSON parse failures).
+   */
   private async uploadToStorage(
     objectPath: string,
     buffer: Buffer,
@@ -194,23 +198,72 @@ export class SupabaseImageStorage {
       }
     }
 
-    const { error } = await supabaseAdmin.storage
-      .from(BUCKET)
-      .upload(objectPath, buffer, {
-        contentType,
-        cacheControl: '31536000',
-        upsert,
-      })
+    const MAX_ATTEMPTS = 3
+    let lastError: string | undefined
 
-    if (error) {
-      if (error.message?.includes('already exists') || error.message?.includes('Duplicate')) {
-        return `${STORAGE_PUBLIC_URL}/${BUCKET}/${objectPath}`
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      if (attempt > 1) {
+        // Exponential backoff: 1s, 2s
+        await new Promise((resolve) => setTimeout(resolve, 1000 * (attempt - 1)))
       }
-      console.error(`[SupabaseImageStorage] Upload failed for ${objectPath}:`, error.message)
-      return null
+
+      try {
+        const { error } = await supabaseAdmin.storage
+          .from(BUCKET)
+          .upload(objectPath, buffer, {
+            contentType,
+            cacheControl: '31536000',
+            upsert,
+          })
+
+        if (!error) {
+          return `${STORAGE_PUBLIC_URL}/${BUCKET}/${objectPath}`
+        }
+
+        // Already-exists is success
+        if (error.message?.includes('already exists') || error.message?.includes('Duplicate')) {
+          return `${STORAGE_PUBLIC_URL}/${BUCKET}/${objectPath}`
+        }
+
+        lastError = error.message
+        const isTransient =
+          error.message?.includes('Unexpected token') ||       // HTML error page parsed as JSON
+          error.message?.includes('fetch failed') ||
+          error.message?.includes('ECONNRESET') ||
+          error.message?.includes('ETIMEDOUT') ||
+          error.message?.includes('502') ||
+          error.message?.includes('503') ||
+          error.message?.includes('504')
+
+        if (!isTransient || attempt === MAX_ATTEMPTS) {
+          console.error(
+            `[SupabaseImageStorage] Upload failed for ${objectPath} (attempt ${attempt}/${MAX_ATTEMPTS}):`,
+            error.message
+          )
+          return null
+        }
+
+        console.warn(
+          `[SupabaseImageStorage] Transient upload error for ${objectPath} (attempt ${attempt}/${MAX_ATTEMPTS}), retrying:`,
+          error.message
+        )
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : 'Unknown error'
+        if (attempt === MAX_ATTEMPTS) {
+          console.error(
+            `[SupabaseImageStorage] Upload threw for ${objectPath} (attempt ${attempt}/${MAX_ATTEMPTS}):`,
+            lastError
+          )
+          return null
+        }
+        console.warn(
+          `[SupabaseImageStorage] Upload threw for ${objectPath} (attempt ${attempt}/${MAX_ATTEMPTS}), retrying:`,
+          lastError
+        )
+      }
     }
 
-    return `${STORAGE_PUBLIC_URL}/${BUCKET}/${objectPath}`
+    return null
   }
 }
 

--- a/src/lib/workflows/rss-combiner-ingestion-workflow.ts
+++ b/src/lib/workflows/rss-combiner-ingestion-workflow.ts
@@ -350,9 +350,16 @@ async function feedWindowImageGeneration(): Promise<void> {
       ticker: row.ticker,
     }))
 
-    const BATCH_SIZE = 10
+    // Smaller batch size + inter-batch delay to avoid overwhelming
+    // Supabase Storage / Tinify with 80+ concurrent uploads (caused 502/504
+    // gateway errors returned as HTML that failed JSON parsing).
+    const BATCH_SIZE = 5
+    const BATCH_DELAY_MS = 500
     let feedImagesGenerated = 0
     for (let i = 0; i < tradesToGenerate.length; i += BATCH_SIZE) {
+      if (i > 0) {
+        await new Promise((r) => setTimeout(r, BATCH_DELAY_MS))
+      }
       const batch = tradesToGenerate.slice(i, i + BATCH_SIZE)
       const results = await Promise.allSettled(
         batch.map((t) => generateAndUploadTradeImage(t))


### PR DESCRIPTION
## Summary
Fixes 'Unexpected token <, "<html>..." is not valid JSON' errors seen during the feedWindowImageGeneration workflow step. Supabase Storage was returning HTML (502/504 gateway) pages when 87 trade card images uploaded in parallel batches of 10 overwhelmed the storage API.

## Fixes

### 1. Retry logic in uploadToStorage
- 3 attempts with exponential backoff (1s, 2s between retries)
- Retries only on transient errors (HTML JSON parse failures, 502/503/504, ECONNRESET, ETIMEDOUT, fetch failed)
- Non-transient errors fail immediately as before

### 2. Reduced image generation concurrency
Batch size 10 → 5 and added 500ms inter-batch delay. Applied to all three image generation loops:
- Workflow step feedWindowImageGeneration
- runIngestion step 4b (primary image gen)
- runIngestion step 8 (feed-window image gen)

For 87 trades: 18 batches × 5 parallel = ~87 images, total ~2-5 minutes (vs. trying to slam all 87 at once).

## Test plan
- [x] TypeScript: 0 errors
- [x] Lint passing
- [ ] Run workflow and verify all 87 images generate without upload errors
- [ ] Verify retry logic fires if any transient errors occur (check logs for "Transient upload error")

🤖 Generated with [Claude Code](https://claude.com/claude-code)