### PR TITLE
Fix company_name resolution across all AI prompt testing paths

### DIFF
--- a/src/app/api/ai/test-prompt-multiple/route.ts
+++ b/src/app/api/ai/test-prompt-multiple/route.ts
@@ -310,6 +310,7 @@ export const POST = withApiHandler(
         source_url: string | null
         publication_date: string | null
         feed_id: string | null
+        ticker: string | null
       }>()
 
       for (const article of result.data || []) {
@@ -321,6 +322,7 @@ export const POST = withApiHandler(
           source_url: string | null
           publication_date: string | null
           feed_id: string | null
+          ticker: string | null
         } | null
 
         if (rssPost && !postsMap.has(rssPost.id)) {
@@ -341,8 +343,7 @@ export const POST = withApiHandler(
 
     console.log(`[AI Test Multiple] Testing ${posts.length} posts`)
 
-    // Resolve company names for {{company_name}} placeholder.
-    // Prefer ticker_company_names (the actual company), fall back to feed name.
+    // Resolve company names for {{company_name}} placeholder from ticker_company_names.
     const postTickers = Array.from(new Set(posts.map((p: any) => p.ticker).filter(Boolean)))
     const tickerNameMap = new Map<string, string>()
     if (postTickers.length > 0) {
@@ -355,25 +356,10 @@ export const POST = withApiHandler(
       }
     }
 
-    const feedIds = Array.from(new Set(posts.map((p: any) => p.feed_id).filter(Boolean)))
-    const feedNameMap = new Map<string, string>()
-    if (feedIds.length > 0) {
-      const { data: feeds } = await supabaseAdmin
-        .from('rss_feeds')
-        .select('id, name')
-        .in('id', feedIds)
-      for (const feed of feeds || []) {
-        feedNameMap.set(feed.id, feed.name)
-      }
-    }
-
-    // Attach company_name: prefer ticker lookup, fall back to feed name
+    // Attach company_name from ticker lookup (blank if no ticker on the post)
     for (const post of posts) {
       const ticker = ((post as any).ticker || '').toUpperCase()
-      ;(post as any).company_name =
-        tickerNameMap.get(ticker) ||
-        feedNameMap.get((post as any).feed_id) ||
-        ''
+      ;(post as any).company_name = tickerNameMap.get(ticker) || ''
     }
 
     // Process each post

--- a/src/app/api/ai/test-prompt/route.ts
+++ b/src/app/api/ai/test-prompt/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import OpenAI from 'openai'
 import Anthropic from '@anthropic-ai/sdk'
+import { supabaseAdmin } from '@/lib/supabase'
 import { TextBoxGenerator } from '@/lib/text-box-modules/text-box-generator'
 import type { TextBoxPlaceholderData } from '@/types/database'
 
@@ -78,6 +79,16 @@ export const POST = withApiHandler(
   async ({ request }) => {
     const body = await request.json()
     const { provider, promptJson, post, publication_id, isCustomFreeform } = body
+
+    // Resolve company_name from ticker_company_names if the post has a ticker
+    if (post?.ticker && !post.company_name) {
+      const { data: tickerMapping } = await supabaseAdmin
+        .from('ticker_company_names')
+        .select('company_name')
+        .eq('ticker', post.ticker.toUpperCase())
+        .maybeSingle()
+      post.company_name = tickerMapping?.company_name || ''
+    }
 
     // Validate provider matches model
     const modelName = (promptJson?.model || '').toLowerCase()

--- a/src/app/api/rss/recent-posts/route.ts
+++ b/src/app/api/rss/recent-posts/route.ts
@@ -93,7 +93,8 @@ export const GET = withApiHandler(
             description,
             full_article_text,
             source_url,
-            publication_date
+            publication_date,
+            ticker
           )
         `)
         .in('issue_id', sentIssueIds)
@@ -137,6 +138,7 @@ export const GET = withApiHandler(
         full_article_text: string | null
         source_url: string | null
         publication_date: string | null
+        ticker: string | null
         used_in_issue_date?: string
         generated_headline?: string
       }>()
@@ -149,6 +151,7 @@ export const GET = withApiHandler(
           full_article_text: string | null
           source_url: string | null
           publication_date: string | null
+          ticker: string | null
         } | null
 
         if (!rssPost) continue
@@ -213,7 +216,7 @@ export const GET = withApiHandler(
       // (Avoids stuffing thousands of IDs into a PostgREST filter which can exceed URL limits)
       const { data: rawPoolPosts, error: poolError } = await supabaseAdmin
         .from('rss_posts')
-        .select('id, title, description, full_article_text, source_url, publication_date')
+        .select('id, title, description, full_article_text, source_url, publication_date, ticker')
         .in('feed_id', pubFeedIds)
         .not('full_article_text', 'is', null)
         .gte('publication_date', cutoffDateStr)
@@ -298,7 +301,7 @@ export const GET = withApiHandler(
       // Fetch posts with their ratings via join
       const { data: rawScoredPosts, error: scoredError } = await supabaseAdmin
         .from('rss_posts')
-        .select('id, title, description, full_article_text, source_url, publication_date, post_ratings(total_score)')
+        .select('id, title, description, full_article_text, source_url, publication_date, ticker, post_ratings(total_score)')
         .in('feed_id', pubFeedIds)
         .not('full_article_text', 'is', null)
         .gte('publication_date', cutoffDateStr)
@@ -323,6 +326,7 @@ export const GET = withApiHandler(
           full_article_text: p.full_article_text,
           source_url: p.source_url,
           publication_date: p.publication_date,
+          ticker: (p as any).ticker || null,
           total_score: p.post_ratings[0]?.total_score ?? 0,
         }))
         .sort((a, b) => (b.total_score ?? 0) - (a.total_score ?? 0))

--- a/src/lib/rss-processor/scoring.ts
+++ b/src/lib/rss-processor/scoring.ts
@@ -150,8 +150,7 @@ export class Scoring {
     console.log(`[Score] Using ${criteria.length} criteria from mod ${moduleId}`)
 
     // Look up company name for {{company_name}} placeholder in AI prompts.
-    // Prefer the ticker's resolved company name from ticker_company_names,
-    // then fall back to the feed name.
+    // Uses the ticker's resolved company name from ticker_company_names.
     let companyName = ''
     const postTicker = (post as any).ticker
     if (postTicker) {
@@ -161,14 +160,6 @@ export class Scoring {
         .eq('ticker', postTicker.toUpperCase())
         .maybeSingle()
       companyName = tickerMapping?.company_name || ''
-    }
-    if (!companyName && post.feed_id) {
-      const { data: feed } = await supabaseAdmin
-        .from('rss_feeds')
-        .select('name')
-        .eq('id', post.feed_id)
-        .single()
-      companyName = feed?.name || ''
     }
 
     // Evaluate post against each enabled criterion


### PR DESCRIPTION
## Summary
Fixes `{{company_name}}` resolving to blank in AI prompt testing. The issue spanned multiple layers — the ticker field wasn't being fetched, passed through, or resolved at several points in the chain.

## Root causes (3 layers)

### 1. recent-posts API — ticker never fetched
All three post source queries (sent/pool/scored) were missing `ticker` from their selects. The frontend never received the ticker value.
- **Fix**: Added `ticker` to all three query selects + type definitions in `recent-posts/route.ts`

### 2. test-prompt-multiple — type cast dropped ticker
The scored-posts path reshapes `article.rss_posts` into a typed object that was missing the `ticker` field, so even after adding ticker to the query, the type cast silently dropped it.
- **Fix**: Added `ticker: string | null` to both `postsMap` and `rssPost` types in `test-prompt-multiple/route.ts`

### 3. Single test-prompt — no server-side resolution
The single test-prompt route received the post from the frontend and used `post.company_name` directly — but the frontend never sets it. Unlike scoring.ts and test-prompt-multiple, there was no server-side ticker→company_name lookup.
- **Fix**: Added `ticker_company_names` lookup in `test-prompt/route.ts` when `post.ticker` is set

### Also
- Removed feed name fallback from both `scoring.ts` and `test-prompt-multiple` — "Politician Trades" is not a useful company name, blank is better

## Test plan
- [ ] AI Prompt Testing → select a Trader Leak post → run test → verify `{{company_name}}` shows actual company (e.g., "Apple", "Visa")
- [ ] Test with all three post sources: From Sent Issues, From RSS Pool, From Scored Posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)