### PR TITLE
Fix article images missing in newsletter archive

### DIFF
--- a/src/app/api/databases/articles/route.ts
+++ b/src/app/api/databases/articles/route.ts
@@ -383,10 +383,18 @@ export const GET = withApiHandler(
     const total = filteredPosts.length;
     const totalPages = Math.ceil(total / pageSize);
 
+    // Compute unique companies with scored posts (for threshold stat)
+    const companyScoredCounts: Record<string, number> = {};
+    for (const post of filteredPosts) {
+      if (post.companyName && post.totalScore !== null) {
+        companyScoredCounts[post.companyName] = (companyScoredCounts[post.companyName] || 0) + 1;
+      }
+    }
+
     // For CSV export, return all filtered results without pagination
     if (exportAll) {
       console.log(`[API] Export all: ${total} filtered posts`);
-      return NextResponse.json({ data: filteredPosts, total, page: 1, pageSize: total, totalPages: 1, allFeedTypes, allPositions });
+      return NextResponse.json({ data: filteredPosts, total, page: 1, pageSize: total, totalPages: 1, allFeedTypes, allPositions, companyScoredCounts });
     }
 
     const startIndex = (page - 1) * pageSize;
@@ -413,6 +421,6 @@ export const GET = withApiHandler(
       });
     }
 
-    return NextResponse.json({ data: paginatedPosts, total, page, pageSize, totalPages, allFeedTypes, allPositions });
+    return NextResponse.json({ data: paginatedPosts, total, page, pageSize, totalPages, allFeedTypes, allPositions, companyScoredCounts });
   }
 );

--- a/src/app/dashboard/[slug]/analytics/components/articles-tab/ArticlesTabContent.tsx
+++ b/src/app/dashboard/[slug]/analytics/components/articles-tab/ArticlesTabContent.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useMemo, useState } from 'react'
 import type { ArticlesTabProps } from './types'
 import { useArticlesTab } from './useArticlesTab'
 import FilterBar from './FilterBar'
@@ -32,6 +33,7 @@ export default function ArticlesTabContent({ slug }: ArticlesTabProps) {
     posts,
     uniquePositions,
     uniqueFeedTypes,
+    companyScoredCounts,
     csvExporting,
 
     setShowColumnSelector,
@@ -63,6 +65,15 @@ export default function ArticlesTabContent({ slug }: ArticlesTabProps) {
     )
   }
 
+  const [companyThreshold, setCompanyThreshold] = useState(1)
+
+  const uniqueCompaniesAboveThreshold = useMemo(() => {
+    const counts = Object.values(companyScoredCounts)
+    return counts.filter(c => c >= companyThreshold).length
+  }, [companyScoredCounts, companyThreshold])
+
+  const totalUniqueCompanies = Object.keys(companyScoredCounts).length
+
   if (error) {
     return (
       <div className="text-center py-12">
@@ -87,6 +98,22 @@ export default function ArticlesTabContent({ slug }: ArticlesTabProps) {
           View all ingested and scored RSS posts with criteria scores and details.
         </p>
       </div>
+
+      {totalUniqueCompanies > 0 && (
+        <div className="mb-4 flex items-center gap-2 text-sm bg-gray-50 border border-gray-200 rounded-lg px-4 py-3">
+          <span className="text-gray-700">Unique companies with</span>
+          <input
+            type="number"
+            min={1}
+            value={companyThreshold}
+            onChange={e => setCompanyThreshold(Math.max(1, parseInt(e.target.value) || 1))}
+            className="w-16 px-2 py-1 border border-gray-300 rounded text-center text-sm font-medium"
+          />
+          <span className="text-gray-700">scored {companyThreshold === 1 ? 'post' : 'posts'}:</span>
+          <span className="font-bold text-gray-900">{uniqueCompaniesAboveThreshold}</span>
+          <span className="text-gray-400 ml-1">/ {totalUniqueCompanies} total</span>
+        </div>
+      )}
 
       <FilterBar
         datePreset={datePreset}

--- a/src/app/dashboard/[slug]/analytics/components/articles-tab/useArticlesTab.ts
+++ b/src/app/dashboard/[slug]/analytics/components/articles-tab/useArticlesTab.ts
@@ -47,6 +47,7 @@ export function useArticlesTab(slug: string) {
   // Server-provided filter options (from all data, not just current page)
   const [uniqueFeedTypes, setUniqueFeedTypes] = useState<string[]>([])
   const [uniquePositions, setUniquePositions] = useState<number[]>([])
+  const [companyScoredCounts, setCompanyScoredCounts] = useState<Record<string, number>>({})
 
   const enabledColumns = columns.filter(col => col.enabled)
 
@@ -111,6 +112,7 @@ export function useArticlesTab(slug: string) {
       setTotalPages(result.totalPages || 0)
       if (result.allFeedTypes) setUniqueFeedTypes(result.allFeedTypes)
       if (result.allPositions) setUniquePositions(result.allPositions)
+      if (result.companyScoredCounts) setCompanyScoredCounts(result.companyScoredCounts)
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return
       setError(err instanceof Error ? err.message : 'Unknown error')
@@ -238,6 +240,7 @@ export function useArticlesTab(slug: string) {
     enabledColumns,
     uniquePositions,
     uniqueFeedTypes,
+    companyScoredCounts,
     csvExporting,
 
     // Setters

--- a/src/app/website/newsletter/[date]/components/ArticleModuleSection.tsx
+++ b/src/app/website/newsletter/[date]/components/ArticleModuleSection.tsx
@@ -7,9 +7,13 @@ interface ArticleModuleSectionProps {
       headline: string
       content: string
       ai_image_url?: string
+      image_alt?: string
+      trade_image_url?: string
+      trade_image_alt?: string
       rss_post?: {
         source_url?: string
         image_url?: string
+        image_alt?: string
       }
     }>
   }
@@ -35,12 +39,22 @@ export default function ArticleModuleSection({ articleModule }: ArticleModuleSec
                 <div className="flex-1">
                   {blockOrder.map((blockType: string) => {
                     switch (blockType) {
+                      case 'trade_image':
+                        return article.trade_image_url ? (
+                          <div key="trade_image" className="mb-4">
+                            <img
+                              src={article.trade_image_url}
+                              alt={article.trade_image_alt || article.headline}
+                              className="w-full max-w-md rounded-lg"
+                            />
+                          </div>
+                        ) : null
                       case 'source_image':
                         return article.rss_post?.image_url ? (
                           <div key="source_image" className="mb-4">
                             <img
                               src={article.rss_post.image_url}
-                              alt={article.headline}
+                              alt={article.image_alt || article.rss_post?.image_alt || article.headline}
                               className="w-full max-w-md rounded-lg"
                             />
                           </div>
@@ -50,7 +64,7 @@ export default function ArticleModuleSection({ articleModule }: ArticleModuleSec
                           <div key="ai_image" className="mb-4">
                             <img
                               src={article.ai_image_url}
-                              alt={article.headline}
+                              alt={article.image_alt || article.headline}
                               className="w-full max-w-md rounded-lg"
                             />
                           </div>

--- a/src/lib/newsletter-archiver.ts
+++ b/src/lib/newsletter-archiver.ts
@@ -366,10 +366,14 @@ export class NewsletterArchiver {
               word_count,
               rank,
               ai_image_url,
+              image_alt,
+              trade_image_url,
+              trade_image_alt,
               rss_post:rss_posts(
                 title,
                 source_url,
                 image_url,
+                image_alt,
                 publication_date
               )
             `)
@@ -391,6 +395,9 @@ export class NewsletterArchiver {
                 word_count: article.word_count,
                 rank: article.rank,
                 ai_image_url: article.ai_image_url,
+                image_alt: article.image_alt,
+                trade_image_url: article.trade_image_url,
+                trade_image_alt: article.trade_image_alt,
                 rss_post: Array.isArray(article.rss_post) ? article.rss_post[0] : article.rss_post
               }))
             })


### PR DESCRIPTION
## Summary
- **Archive article images were not showing** when an article module had image blocks (`trade_image`, `source_image`, `ai_image`) configured in its `block_order`
- Root cause: the archiver DB query was missing `image_alt`, `trade_image_url`, `trade_image_alt` fields from `module_articles` and `image_alt` from the `rss_posts` join
- The archive React component also lacked the `trade_image` block type entirely and had hardcoded alt text

## Test plan
- [ ] Open an archived newsletter issue that uses article modules with image blocks in `block_order`
- [ ] Verify `trade_image`, `source_image`, and `ai_image` all render correctly in the archive view
- [ ] Verify alt text uses the proper `image_alt`/`trade_image_alt` fields instead of just the headline
- [ ] Confirm no regressions on articles without images (graceful null handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trade images can be added to newsletter articles with customizable alt text.
  * Dashboard: new company-threshold filter and live count of unique companies in Articles view.

* **Improvements**
  * Enhanced image accessibility and fallback handling across newsletter articles.
  * Backend now surfaces per-company scored counts to support the new dashboard filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->