### PR TITLE
Fix React error #310 on analytics articles tab

### DIFF
--- a/src/app/dashboard/[slug]/analytics/components/articles-tab/ArticlesTabContent.tsx
+++ b/src/app/dashboard/[slug]/analytics/components/articles-tab/ArticlesTabContent.tsx
@@ -57,14 +57,6 @@ export default function ArticlesTabContent({ slug }: ArticlesTabProps) {
     fetchPosts,
   } = useArticlesTab(slug)
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-primary"></div>
-      </div>
-    )
-  }
-
   const [companyThreshold, setCompanyThreshold] = useState(1)
 
   const uniqueCompaniesAboveThreshold = useMemo(() => {
@@ -73,6 +65,14 @@ export default function ArticlesTabContent({ slug }: ArticlesTabProps) {
   }, [companyScoredCounts, companyThreshold])
 
   const totalUniqueCompanies = Object.keys(companyScoredCounts).length
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-primary"></div>
+      </div>
+    )
+  }
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary
- Moved `useState` and `useMemo` hooks in `ArticlesTabContent` above the `loading`/`error` early returns
- Fixes React error #310 (\"Rendered more hooks than during the previous render\") when the analytics articles tab transitions from loading → loaded

## Root cause
`if (loading) return ...` was executed *before* `useState(companyThreshold)` and `useMemo(uniqueCompaniesAboveThreshold)` were called. On the first render the hook count was N; once loading flipped to false, two additional hooks appeared, violating the Rules of Hooks.

## Test plan
- [ ] Load `/dashboard/{slug}/analytics` and switch to the Articles tab — page renders without \"Something went wrong\"
- [ ] \"Unique companies with N scored posts\" stat renders and the threshold input works
- [ ] Toggle filters / refresh to confirm no hook-order warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization in the analytics section to optimize calculation timing during loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->