### PR TITLE
Alert on Firecrawl 402 quota exhaustion + backfill script

### DIFF
--- a/scripts/reextract-firecrawl-402.ts
+++ b/scripts/reextract-firecrawl-402.ts
@@ -1,0 +1,253 @@
+/**
+ * Backfill script: re-extract + re-score posts that failed with Firecrawl HTTP 402.
+ *
+ * Targets posts where extraction hit the Firecrawl payment-required error,
+ * which strands them without post_ratings (all criteria show N/A in UI).
+ * After Firecrawl credits are topped up, run this to recover them:
+ *
+ *   npx tsx scripts/reextract-firecrawl-402.ts
+ *   npx tsx scripts/reextract-firecrawl-402.ts --since=2026-04-11
+ *   npx tsx scripts/reextract-firecrawl-402.ts --dry-run
+ *   npx tsx scripts/reextract-firecrawl-402.ts --limit=50
+ */
+import * as dotenv from 'dotenv'
+dotenv.config({ path: '.env.local' })
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  console.error('Missing env vars: SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY')
+  process.exit(1)
+}
+
+const args = process.argv.slice(2)
+const dryRun = args.includes('--dry-run')
+const sinceArg = args.find(a => a.startsWith('--since='))?.split('=')[1]
+const limitArg = args.find(a => a.startsWith('--limit='))?.split('=')[1]
+const SINCE_DATE = sinceArg || '2026-04-11'
+const LIMIT = limitArg ? parseInt(limitArg, 10) : 500
+const BATCH_SIZE = 5
+const DELAY_BETWEEN_BATCHES_MS = 3000
+
+type Post = {
+  id: string
+  source_url: string | null
+  title: string | null
+  article_module_id: string | null
+  feed_id: string
+  ticker: string | null
+  description: string | null
+  content: string | null
+  rss_feeds: { publication_id: string | null } | null
+}
+
+// Dynamic imports: env vars must be loaded before src/lib/supabase.ts evaluates.
+// Populated inside run() before any module usage.
+let supabase: any
+let extractor: any
+let scoring: any
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function getNewsletterIdForPost(publicationId: string | null): Promise<string | null> {
+  if (!publicationId) return null
+  const { data } = await supabase
+    .from('publications')
+    .select('id')
+    .eq('id', publicationId)
+    .maybeSingle()
+  return data?.id ?? null
+}
+
+async function scorePost(post: Post, newsletterId: string): Promise<'scored' | 'skipped' | 'failed'> {
+  if (!post.article_module_id) return 'skipped'
+
+  try {
+    const evaluation: any = await scoring.evaluatePost(
+      post as any,
+      newsletterId,
+      'primary',
+      post.article_module_id
+    )
+
+    if (
+      typeof evaluation.interest_level !== 'number' ||
+      typeof evaluation.local_relevance !== 'number' ||
+      typeof evaluation.community_impact !== 'number'
+    ) {
+      return 'failed'
+    }
+
+    const ratingRecord: any = {
+      post_id: post.id,
+      interest_level: evaluation.interest_level,
+      local_relevance: evaluation.local_relevance,
+      community_impact: evaluation.community_impact,
+      ai_reasoning: evaluation.reasoning,
+      total_score:
+        evaluation.total_score ||
+        ((evaluation.interest_level + evaluation.local_relevance + evaluation.community_impact) / 30) * 100,
+    }
+
+    const criteriaScores = evaluation.criteria_scores
+    if (Array.isArray(criteriaScores)) {
+      for (let k = 0; k < criteriaScores.length && k < 5; k++) {
+        const n = criteriaScores[k].criteria_number || k + 1
+        ratingRecord[`criteria_${n}_score`] = criteriaScores[k].score
+        ratingRecord[`criteria_${n}_reason`] = criteriaScores[k].reason
+        ratingRecord[`criteria_${n}_weight`] = criteriaScores[k].weight
+      }
+    }
+
+    const { error } = await supabase.from('post_ratings').insert([ratingRecord])
+    if (error) {
+      console.log(`    rating insert failed: ${error.message}`)
+      return 'failed'
+    }
+    return 'scored'
+  } catch (err) {
+    console.log(`    scoring threw: ${err instanceof Error ? err.message : 'Unknown'}`)
+    return 'failed'
+  }
+}
+
+async function run() {
+  // Load supabase-dependent modules AFTER dotenv has run.
+  const { createClient } = await import('@supabase/supabase-js')
+  const { ArticleExtractor } = await import('../src/lib/article-extractor')
+  const { Scoring } = await import('../src/lib/rss-processor/scoring')
+
+  supabase = createClient(supabaseUrl!, supabaseServiceKey!)
+  extractor = new ArticleExtractor()
+  scoring = new Scoring()
+
+  console.log(`\n=== Firecrawl 402 backfill ===`)
+  console.log(`Since: ${SINCE_DATE}`)
+  console.log(`Limit: ${LIMIT}`)
+  console.log(`Dry run: ${dryRun}`)
+
+  const { data: posts, error } = await supabase
+    .from('rss_posts')
+    .select(
+      'id, source_url, title, article_module_id, feed_id, ticker, description, content, ' +
+        'rss_feeds!inner(publication_id)'
+    )
+    .eq('extraction_status', 'failed')
+    .ilike('extraction_error', '%Firecrawl HTTP 402%')
+    .gte('processed_at', SINCE_DATE)
+    .not('source_url', 'is', null)
+    .order('processed_at', { ascending: false })
+    .limit(LIMIT)
+
+  if (error) {
+    console.error('Failed to fetch posts:', error.message)
+    process.exit(1)
+  }
+
+  const typed = (posts || []) as unknown as Post[]
+  console.log(`\nFound ${typed.length} stranded posts to process`)
+
+  if (dryRun) {
+    for (const p of typed.slice(0, 10)) {
+      console.log(`  [${p.id}] ${p.title?.substring(0, 70)}`)
+    }
+    if (typed.length > 10) console.log(`  ... and ${typed.length - 10} more`)
+    return
+  }
+
+  let extracted = 0
+  let extractFailed = 0
+  let scored = 0
+  let scoreFailed = 0
+  let scoreSkipped = 0
+
+  for (let i = 0; i < typed.length; i += BATCH_SIZE) {
+    const batch = typed.slice(i, i + BATCH_SIZE)
+    const batchNum = Math.floor(i / BATCH_SIZE) + 1
+    const totalBatches = Math.ceil(typed.length / BATCH_SIZE)
+    console.log(`\n--- Batch ${batchNum}/${totalBatches} (${batch.length} posts) ---`)
+
+    for (const post of batch) {
+      if (!post.source_url) continue
+      console.log(`\n[${post.id.substring(0, 8)}] ${post.title?.substring(0, 60)}`)
+
+      const result = await extractor.extractArticle(post.source_url)
+
+      if (result.success && result.fullText) {
+        const { error: updateError } = await supabase
+          .from('rss_posts')
+          .update({
+            full_article_text: result.fullText,
+            extraction_status: 'success',
+            extraction_error: null,
+          })
+          .eq('id', post.id)
+
+        if (updateError) {
+          console.log(`  DB update failed: ${updateError.message}`)
+          extractFailed++
+          continue
+        }
+
+        extracted++
+        console.log(`  extracted ${result.fullText.length} chars`)
+
+        const newsletterId = await getNewsletterIdForPost(post.rss_feeds?.publication_id ?? null)
+        if (!newsletterId) {
+          scoreSkipped++
+          console.log(`  scoring skipped: no publication_id`)
+          continue
+        }
+
+        const postForScoring: Post = {
+          ...post,
+          content: result.fullText,
+        }
+        ;(postForScoring as any).full_article_text = result.fullText
+
+        const scoreResult = await scorePost(postForScoring, newsletterId)
+        if (scoreResult === 'scored') {
+          scored++
+          console.log(`  scored`)
+        } else if (scoreResult === 'skipped') {
+          scoreSkipped++
+          console.log(`  scoring skipped`)
+        } else {
+          scoreFailed++
+        }
+      } else {
+        await supabase
+          .from('rss_posts')
+          .update({
+            extraction_status: result.status,
+            extraction_error: result.error?.substring(0, 500) ?? null,
+          })
+          .eq('id', post.id)
+
+        extractFailed++
+        console.log(`  still failed: ${result.status} - ${result.error?.substring(0, 80)}`)
+      }
+    }
+
+    if (i + BATCH_SIZE < typed.length) {
+      console.log(`\nWaiting ${DELAY_BETWEEN_BATCHES_MS}ms before next batch...`)
+      await sleep(DELAY_BETWEEN_BATCHES_MS)
+    }
+  }
+
+  console.log(`\n=== COMPLETE ===`)
+  console.log(`Extracted: ${extracted}`)
+  console.log(`Extract failed: ${extractFailed}`)
+  console.log(`Scored: ${scored}`)
+  console.log(`Score failed: ${scoreFailed}`)
+  console.log(`Score skipped: ${scoreSkipped}`)
+  console.log(`Total: ${typed.length}`)
+}
+
+run().catch(err => {
+  console.error('Fatal:', err)
+  process.exit(1)
+})

--- a/src/lib/monitoring/firecrawl-monitor.ts
+++ b/src/lib/monitoring/firecrawl-monitor.ts
@@ -1,0 +1,67 @@
+import { supabaseAdmin } from '../supabase'
+import { SlackNotificationService } from '../slack'
+import type { ArticleExtractionResult } from '../article-extractor'
+
+const LOG_SOURCE = 'firecrawl_monitor'
+const ALERT_COOLDOWN_MINUTES = 60
+
+/**
+ * Scans extraction results for Firecrawl HTTP 402 (Payment Required) errors
+ * and sends a debounced Slack alert.
+ *
+ * Debounced via system_logs: alerts at most once per ALERT_COOLDOWN_MINUTES
+ * window. Callers should invoke this after every extractBatch() — cost of
+ * a no-op call (no 402s) is a single SELECT.
+ */
+export async function alertOnFirecrawl402(
+  results: Map<string, ArticleExtractionResult>,
+  context?: { feedName?: string }
+): Promise<void> {
+  let errorCount = 0
+  results.forEach(result => {
+    if (!result.success && result.error?.includes('Firecrawl HTTP 402')) {
+      errorCount++
+    }
+  })
+
+  if (errorCount === 0) return
+
+  try {
+    const cooldownCutoff = new Date(Date.now() - ALERT_COOLDOWN_MINUTES * 60 * 1000).toISOString()
+    const { data: recent } = await supabaseAdmin
+      .from('system_logs')
+      .select('id')
+      .eq('source', LOG_SOURCE)
+      .eq('level', 'error')
+      .gte('timestamp', cooldownCutoff)
+      .limit(1)
+
+    if (recent && recent.length > 0) {
+      return
+    }
+
+    const feedLabel = context?.feedName ? ` (feed: ${context.feedName})` : ''
+    const message =
+      `Firecrawl quota exhausted — HTTP 402 on ${errorCount} URL${errorCount === 1 ? '' : 's'}${feedLabel}. ` +
+      `Top up credits at https://www.firecrawl.dev/app/billing. ` +
+      `Article extraction success rate will stay degraded until resolved.`
+
+    const slack = new SlackNotificationService()
+    await slack.sendAlert(message, 'error', 'system_errors')
+
+    await supabaseAdmin
+      .from('system_logs')
+      .insert([{
+        level: 'error',
+        message,
+        source: LOG_SOURCE,
+        context: { errorCount, feedName: context?.feedName ?? null },
+        timestamp: new Date().toISOString(),
+      }])
+  } catch (err) {
+    console.error(
+      '[firecrawl-monitor] Failed to send 402 alert:',
+      err instanceof Error ? err.message : 'Unknown'
+    )
+  }
+}

--- a/src/lib/rss-processor/feed-ingestion.ts
+++ b/src/lib/rss-processor/feed-ingestion.ts
@@ -1,6 +1,7 @@
 import Parser from 'rss-parser'
 import { supabaseAdmin } from '../supabase'
 import { getExcludedRssSources, getBlockedDomains } from '../publication-settings'
+import { alertOnFirecrawl402 } from '../monitoring/firecrawl-monitor'
 import type { RSSProcessorContext } from './shared-context'
 import { isFbcdnUrl } from './shared-context'
 import { Scoring } from './scoring'
@@ -203,6 +204,7 @@ export class FeedIngestion {
 
         try {
           const extractionResults = await this.ctx.articleExtractor.extractBatch(urls, 10)
+          await alertOnFirecrawl402(extractionResults, { feedName: feed.name })
 
           for (const post of newPosts) {
             if (!post.source_url) continue
@@ -292,6 +294,7 @@ export class FeedIngestion {
         const pendingUrls = pendingPosts.filter(p => p.source_url).map(p => p.source_url)
         try {
           const catchupResults = await this.ctx.articleExtractor.extractBatch(pendingUrls, 3)
+          await alertOnFirecrawl402(catchupResults, { feedName: feed.name })
 
           for (const post of pendingPosts) {
             if (!post.source_url) continue


### PR DESCRIPTION
## Summary
Detects Firecrawl HTTP 402 (Payment Required) errors during article extraction and alerts Slack so quota exhaustion is noticed within minutes instead of days.

## Context
Firecrawl credits ran out on 2026-04-11, stranding 185 posts with \`extraction_status='failed'\` across April 11-13. Scoring silently skipped them (\`feed-ingestion.ts:235-246\` only scores posts where \`extraction_status='success'\`), so they showed in the Articles analytics tab with all criteria \"N/A\" — no surface signal until a user reported it. The stranded posts have been recovered via a one-off SQL reset to \`pending\` (existing catch-up path handles them from there).

## Changes
- **\`src/lib/monitoring/firecrawl-monitor.ts\`** (new) — \`alertOnFirecrawl402()\` scans an extraction results map for \`Firecrawl HTTP 402\` errors and sends a debounced Slack alert. Debounced via \`system_logs\` (at most once per 60 minutes) so a cron hitting multiple feeds in one run emits a single alert. Fails quiet if the DB/Slack call throws — never breaks ingestion.
- **\`src/lib/rss-processor/feed-ingestion.ts\`** — calls the monitor after both \`extractBatch()\` sites (primary ingest path + catch-up path for retrying stale pending posts).
- **\`scripts/reextract-firecrawl-402.ts\`** (new) — standalone backfill script for future incidents where a targeted re-extract + re-score makes sense. Supports \`--dry-run\`, \`--since=YYYY-MM-DD\`, \`--limit=N\`. Re-extracts posts whose \`extraction_error\` contains the 402 signature and inserts fresh \`post_ratings\` rows.

## Test plan
- [x] \`npm run type-check\` — clean
- [x] Pre-push lint + bug-pattern checks — clean
- [x] Dry-run against production: \`npx tsx scripts/reextract-firecrawl-402.ts --dry-run --limit=5\` — finds the correct stranded posts
- [ ] After deploy, wait for next 402 event (or trigger a test by temporarily invalidating the key in staging) to confirm Slack alert fires and debounce works
- [ ] Confirm existing ingest success rates stay at ~99% on production post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)