### PR TITLE
Fix trade card image mismatch + add rescore-module-posts debug handler

### DIFF
--- a/src/app/api/campaigns/[id]/article-modules/recheck-images/route.ts
+++ b/src/app/api/campaigns/[id]/article-modules/recheck-images/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
+import { buildTradeImageKey } from '@/lib/trade-image-key'
 
 /**
  * Refresh trade images for all module_articles in an issue.
  *
  * Resolves the current trade card image for each article by:
- *   1. Looking up the latest image_url in congress_trades matching the ticker
+ *   1. Looking up the latest image_url in congress_trades matching the
+ *      article's (ticker, member_name, transaction_type) — NOT ticker alone,
+ *      which mixed up images between different members trading the same stock
  *   2. Verifying the underlying file actually exists in Supabase storage
  *      (previously this endpoint could copy stale URLs pointing to deleted files)
  *   3. Falling back to rss_posts.image_url if no valid congress_trades image
@@ -39,7 +42,9 @@ export async function POST(
       trade_image_url,
       trade_image_alt,
       ticker,
-      rss_post:rss_posts(image_url, image_alt, ticker)
+      member_name,
+      transaction_type,
+      rss_post:rss_posts(image_url, image_alt, ticker, member_name, transaction_type)
     `)
     .eq('issue_id', issueId)
 
@@ -52,24 +57,29 @@ export async function POST(
     return NextResponse.json({ success: true, results: [], message: 'No module articles for this issue' })
   }
 
-  // Build a map of ticker → valid trade card image URL from congress_trades.
+  // Build maps of trade card image URL from congress_trades:
+  //   - validImageByKey: keyed by (ticker, member, transaction) — primary match
+  //   - unambiguousImageByTicker: fallback only when exactly one trade exists
+  //     for a ticker, so we never mix members who share a stock
   // Only include tickers whose underlying file actually exists in Supabase Storage
   // (previously this endpoint could copy stale URLs pointing to deleted files).
-  // Collect tickers from both module_articles and their linked rss_posts
+  // Collect tickers from both module_articles and their linked rss_posts.
   const tickers = Array.from(new Set(
     articles.flatMap(a => {
       const rssPost = Array.isArray((a as any).rss_post) ? (a as any).rss_post[0] : (a as any).rss_post
       return [a.ticker, rssPost?.ticker].filter(Boolean)
     })
   )) as string[]
-  const validImageByTicker = new Map<string, string>()
+  const validImageByKey = new Map<string, string>()
+  const verifiedTradesByTicker = new Map<string, number>()
+  const unambiguousImageByTicker = new Map<string, string>()
 
   if (tickers.length > 0) {
     // Fetch all congress_trades rows for these tickers with non-null image_url.
-    // Order by most recent so the first per ticker wins.
+    // Order by most recent so the first per (ticker,member,transaction) wins.
     const { data: tradeRows, error: tradeError } = await supabaseAdmin
       .from('congress_trades')
-      .select('id, ticker, image_url, quiver_upload_time')
+      .select('id, ticker, image_url, name, transaction, quiver_upload_time')
       .in('ticker', tickers)
       .not('image_url', 'is', null)
       .order('quiver_upload_time', { ascending: false, nullsFirst: false })
@@ -112,11 +122,23 @@ export async function POST(
       })
     }
 
-    // Walk rows in order — first matching ticker with a verified file wins
+    // Walk rows newest-first. First composite-key hit wins. Track whether
+    // each ticker has 1 or many verified rows for the fallback map.
     for (const row of tradeRows || []) {
-      if (validImageByTicker.has(row.ticker)) continue
-      if (existingFiles.has(`${row.id}.png`)) {
-        validImageByTicker.set(row.ticker, row.image_url)
+      if (!existingFiles.has(`${row.id}.png`)) continue
+
+      const compositeKey = buildTradeImageKey(row.ticker, row.name, row.transaction)
+      if (compositeKey && !validImageByKey.has(compositeKey)) {
+        validImageByKey.set(compositeKey, row.image_url)
+      }
+
+      const tickerKey = row.ticker.toUpperCase()
+      const nextCount = (verifiedTradesByTicker.get(tickerKey) || 0) + 1
+      verifiedTradesByTicker.set(tickerKey, nextCount)
+      if (nextCount === 1) {
+        unambiguousImageByTicker.set(tickerKey, row.image_url)
+      } else {
+        unambiguousImageByTicker.delete(tickerKey)
       }
     }
   }
@@ -137,11 +159,18 @@ export async function POST(
       ? (article as any).rss_post[0]
       : (article as any).rss_post
 
-    // Prefer a verified congress_trades image (try article ticker, then rss_post ticker),
-    // then fall back to rss_posts.image_url
-    const articleTicker = article.ticker || rssPost?.ticker || null
+    // Resolve the trade image by (ticker, member, transaction). Fall through
+    // article → rss_post → unambiguous ticker fallback → rss_post.image_url.
+    const articleTicker = (article as any).ticker || rssPost?.ticker || null
+    const memberName = (article as any).member_name || rssPost?.member_name || null
+    const transaction = (article as any).transaction_type || rssPost?.transaction_type || null
+
+    const articleCompositeKey = buildTradeImageKey(articleTicker, memberName, transaction)
+    const tickerKey = (articleTicker || '').toUpperCase()
+
     const resolvedImage =
-      (articleTicker && validImageByTicker.get(articleTicker)) ||
+      (articleCompositeKey ? validImageByKey.get(articleCompositeKey) : null) ||
+      (tickerKey ? unambiguousImageByTicker.get(tickerKey) : null) ||
       rssPost?.image_url ||
       null
 

--- a/src/app/api/debug/handlers/rss.ts
+++ b/src/app/api/debug/handlers/rss.ts
@@ -418,6 +418,162 @@ export const handlers: Record<string, { GET?: DebugHandler; POST?: DebugHandler 
     }
   },
 
+  'rescore-module-posts': {
+    GET: async ({ request }) => {
+      const { searchParams } = new URL(request.url)
+      const publicationId = searchParams.get('publication_id')
+      const days = parseInt(searchParams.get('days') || '7')
+      const minScore = parseFloat(searchParams.get('min_score') || '0')
+      const limit = parseInt(searchParams.get('limit') || '20')
+      const offset = parseInt(searchParams.get('offset') || '0')
+      const dryRun = searchParams.get('dry_run') !== 'false'
+      const articleModuleId = searchParams.get('article_module_id')
+
+      if (!publicationId) {
+        return NextResponse.json({ error: 'publication_id required' }, { status: 400 })
+      }
+
+      try {
+        const sinceIso = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+
+        const { data: feeds, error: feedsError } = await supabaseAdmin
+          .from('rss_feeds')
+          .select('id')
+          .eq('publication_id', publicationId)
+
+        if (feedsError) throw new Error(`Failed to fetch feeds: ${feedsError.message}`)
+
+        if (!feeds || feeds.length === 0) {
+          return NextResponse.json({
+            status: 'success',
+            message: 'No feeds found for publication',
+            publication_id: publicationId,
+            posts_found: 0
+          })
+        }
+
+        const feedIds = feeds.map(f => f.id)
+
+        let postsQuery = supabaseAdmin
+          .from('rss_posts')
+          .select('id, title, description, content, full_article_text, article_module_id, feed_id, ticker, publication_date, post_ratings!inner(id, total_score)')
+          .in('feed_id', feedIds)
+          .not('article_module_id', 'is', null)
+          .gte('publication_date', sinceIso)
+          .gte('post_ratings.total_score', minScore)
+          .order('publication_date', { ascending: false })
+          .range(offset, offset + limit - 1)
+
+        if (articleModuleId) {
+          postsQuery = postsQuery.eq('article_module_id', articleModuleId)
+        }
+
+        const { data: posts, error: postsError } = await postsQuery
+
+        if (postsError) throw new Error(`Failed to fetch posts: ${postsError.message}`)
+
+        if (!posts || posts.length === 0) {
+          return NextResponse.json({
+            status: 'success',
+            message: 'No posts match criteria',
+            publication_id: publicationId,
+            days,
+            min_score: minScore,
+            offset,
+            posts_found: 0
+          })
+        }
+
+        console.log(`[RESCORE-MODULE] ${dryRun ? 'DRY RUN: ' : ''}Processing ${posts.length} posts for publication ${publicationId}`)
+
+        const { Scoring } = await import('@/lib/rss-processor/scoring')
+        const scoring = new Scoring()
+
+        let successCount = 0
+        let errorCount = 0
+        const errors: Array<{ post_id: string; error: string }> = []
+
+        for (const post of posts) {
+          try {
+            const evaluation: any = await scoring.evaluatePost(
+              post as any,
+              publicationId,
+              'primary',
+              post.article_module_id
+            )
+
+            const ratingRecord: Record<string, any> = {
+              post_id: post.id,
+              interest_level: evaluation.interest_level || 0,
+              local_relevance: evaluation.local_relevance || 0,
+              community_impact: evaluation.community_impact || 0,
+              ai_reasoning: evaluation.reasoning,
+              total_score: evaluation.total_score
+            }
+
+            const criteriaScores = evaluation.criteria_scores
+            if (criteriaScores && Array.isArray(criteriaScores)) {
+              for (let k = 0; k < criteriaScores.length && k < 5; k++) {
+                const criterionNum = criteriaScores[k].criteria_number || (k + 1)
+                ratingRecord[`criteria_${criterionNum}_score`] = criteriaScores[k].score
+                ratingRecord[`criteria_${criterionNum}_reason`] = criteriaScores[k].reason
+                ratingRecord[`criteria_${criterionNum}_weight`] = criteriaScores[k].weight
+              }
+            }
+
+            if (!dryRun) {
+              const { error: deleteError } = await supabaseAdmin
+                .from('post_ratings')
+                .delete()
+                .eq('post_id', post.id)
+
+              if (deleteError) throw new Error(`Delete failed: ${deleteError.message}`)
+
+              const { error: insertError } = await supabaseAdmin
+                .from('post_ratings')
+                .insert([ratingRecord])
+
+              if (insertError) throw new Error(`Insert failed: ${insertError.message}`)
+            }
+
+            successCount++
+            await new Promise(resolve => setTimeout(resolve, 300))
+
+          } catch (error) {
+            errorCount++
+            const errorMsg = error instanceof Error ? error.message : 'Unknown error'
+            console.error(`[RESCORE-MODULE] Error for ${post.id}:`, errorMsg)
+            errors.push({ post_id: post.id, error: errorMsg })
+          }
+        }
+
+        console.log(`[RESCORE-MODULE] Complete: ${successCount} succeeded, ${errorCount} failed`)
+
+        return NextResponse.json({
+          status: 'success',
+          dry_run: dryRun,
+          publication_id: publicationId,
+          days,
+          min_score: minScore,
+          article_module_id: articleModuleId,
+          offset,
+          next_offset: posts.length === limit ? offset + limit : null,
+          posts_processed: posts.length,
+          succeeded: successCount,
+          failed: errorCount,
+          errors: errors.slice(0, 10)
+        })
+
+      } catch (error) {
+        console.error('[RESCORE-MODULE] Error:', error)
+        return NextResponse.json({
+          status: 'error',
+          error: error instanceof Error ? error.message : 'Unknown error'
+        }, { status: 500 })
+      }
+    }
+  },
+
   'rss-images': {
     GET: async ({ logger }) => {
       try {

--- a/src/lib/rss-combiner.ts
+++ b/src/lib/rss-combiner.ts
@@ -3,6 +3,7 @@ import { supabaseAdmin } from '@/lib/supabase'
 import { XMLParser } from 'fast-xml-parser'
 import { generateAndUploadTradeImage } from './trade-image-generator'
 import { normalizeTransactionType } from './transaction-type'
+import { buildTradeImageKey } from './trade-image-key'
 
 const xmlParser = new XMLParser({
   ignoreAttributes: false,
@@ -1230,26 +1231,54 @@ export async function getCombinedFeed(forceRefresh = false): Promise<string> {
     windowDays += 5
   }
 
-  // Load trade image URLs keyed by ticker
+  // Load trade card images keyed by (ticker, member, transaction).
+  // Ticker-only matching mis-assigned images when multiple members traded
+  // the same stock — every article with that ticker got whichever row
+  // Postgres happened to return last.
   const articleTickers = Array.from(new Set(articles.map((r: any) => r.ticker).filter(Boolean)))
-  const tradeImageMap = new Map<string, string>()
+  const tradeImageMap = new Map<string, string>() // composite key -> image_url
+  const tickerTradeCounts = new Map<string, number>()
+  const tickerFallbackImage = new Map<string, string>() // only retained if exactly one trade per ticker
 
   if (articleTickers.length > 0) {
     const { data: tradeImages } = await supabaseAdmin
       .from('congress_trades')
-      .select('ticker, image_url')
+      .select('ticker, image_url, name, transaction')
       .in('ticker', articleTickers)
       .not('image_url', 'is', null)
 
     for (const row of tradeImages || []) {
-      if (row.image_url) {
-        tradeImageMap.set(row.ticker.toUpperCase(), row.image_url)
+      if (!row.image_url || !row.ticker) continue
+
+      const compositeKey = buildTradeImageKey(row.ticker, row.name, row.transaction)
+      if (compositeKey) tradeImageMap.set(compositeKey, row.image_url)
+
+      const tickerKey = row.ticker.toUpperCase()
+      const nextCount = (tickerTradeCounts.get(tickerKey) || 0) + 1
+      tickerTradeCounts.set(tickerKey, nextCount)
+      if (nextCount === 1) {
+        tickerFallbackImage.set(tickerKey, row.image_url)
+      } else {
+        // Ambiguous — drop the ticker fallback so we don't mix up members.
+        tickerFallbackImage.delete(tickerKey)
       }
     }
   }
 
   // Convert DB rows to NormalizedItem format
-  const items: NormalizedItem[] = articles.map((row) => ({
+  const items: NormalizedItem[] = articles.map((row) => {
+    const compositeKey = buildTradeImageKey(
+      row.ticker,
+      row.trade_meta?.member,
+      row.transaction_type
+    )
+    const tickerKey = (row.ticker || '').toUpperCase()
+    const tradeImageUrl =
+      (compositeKey ? tradeImageMap.get(compositeKey) : null) ||
+      tickerFallbackImage.get(tickerKey) ||
+      null
+
+    return {
     title: row.article_title,
     link: row.article_url,
     description: row.article_description || '',
@@ -1258,7 +1287,7 @@ export async function getCombinedFeed(forceRefresh = false): Promise<string> {
     sourceLabel: row.company_name,
     sourceName: row.source_name || '',
     guid: row.article_url,
-    tradeImageUrl: tradeImageMap.get((row.ticker || '').toUpperCase()) || null,
+    tradeImageUrl,
     tradeMeta: {
       ticker: row.ticker,
       company_name: row.company_name,
@@ -1270,7 +1299,8 @@ export async function getCombinedFeed(forceRefresh = false): Promise<string> {
       chamber: row.trade_meta?.chamber || null,
       state: row.trade_meta?.state || null,
     },
-  }))
+  }
+  })
 
   const xml = generateCombinedFeedXml(items, feedTitle)
   cachedXml = xml

--- a/src/lib/trade-image-key.ts
+++ b/src/lib/trade-image-key.ts
@@ -1,0 +1,25 @@
+import { normalizeTransactionType } from './transaction-type'
+
+/**
+ * Build a composite key identifying a trade card image by the specific
+ * (ticker, member, transaction side) it represents.
+ *
+ * Images used to be matched by ticker alone, which mis-assigned the wrong
+ * member's photo when multiple members traded the same stock. Every lookup
+ * from articles → trade images must go through this key.
+ *
+ * Returns null if any part of the key is missing so callers can fall back
+ * explicitly rather than silently keying on an incomplete tuple.
+ */
+export function buildTradeImageKey(
+  ticker: string | null | undefined,
+  memberName: string | null | undefined,
+  transaction: string | null | undefined
+): string | null {
+  if (!ticker || !memberName) return null
+  const normalizedTicker = ticker.trim().toUpperCase()
+  const normalizedMember = memberName.trim().toLowerCase().replace(/\s+/g, ' ')
+  const normalizedTxn = normalizeTransactionType(transaction)
+  if (!normalizedTicker || !normalizedMember || !normalizedTxn) return null
+  return `${normalizedTicker}|${normalizedMember}|${normalizedTxn}`
+}


### PR DESCRIPTION
## Summary
Two unrelated changes bundled on this branch:

### 1. Trade card image mismatch (original change)
- **Root cause:** `getCombinedFeed()` and the `recheck-images` route both matched trade card images to articles by ticker alone. When two congresspeople traded the same stock, every article for that ticker got whichever `congress_trades` row Postgres happened to return last.
- **Fix:** New `src/lib/trade-image-key.ts` with `buildTradeImageKey(ticker, member, transaction)` helper. Both call sites now look up images by composite key, falling back to a ticker-only image only when exactly one trade exists for that ticker.

### 2. New debug handler: `rescore-module-posts`
- **Why:** When a publication's article-module criteria prompts are updated, previously-scored posts need to be re-evaluated with the new criteria. The existing `rescore-posts` debug handler reads the legacy `publication_settings` criteria keys, not the per-module `article_module_criteria` table that powers current scoring, so it can't be used for article-module publications.
- **What it does:** `GET /api/debug/rescore-module-posts?publication_id=...&days=7&min_score=7&limit=20&offset=0&dry_run=true` queries posts within the window whose existing `post_ratings.total_score` meets the threshold, then runs them through `Scoring.evaluatePost()` (which reads `article_module_criteria`). Returns `next_offset` for batched runs within the 600s debug route timeout.
- **Filters:** `publication_id` (required), `days` (default 7, by `publication_date`), `min_score` (default 0), optional `article_module_id`, plus `limit`, `offset`, `dry_run`.
- **Used immediately after deploy** to rescore trader-leak posts after criteria prompt updates.

## Files changed
- `src/lib/trade-image-key.ts` — new composite-key helper
- `src/lib/rss-combiner.ts` — composite-key lookup in `getCombinedFeed()`
- `src/app/api/campaigns/[id]/article-modules/recheck-images/route.ts` — composite-key lookup
- `src/app/api/debug/handlers/rss.ts` — new `rescore-module-posts` handler

## Test plan
- [ ] `npm run build` passes on PR CI
- [ ] After merge + deploy, POST `/api/campaigns/{issueId}/article-modules/recheck-images` on a trader-leak issue and confirm each article gets the correct member's trade card image
- [ ] After merge + deploy, call `/api/debug/rescore-module-posts?publication_id=8277682a-7292-4c36-bca1-a39ca420b305&days=7&min_score=7&dry_run=true` and confirm it returns ~454 posts in paginated batches

🤖 Generated with [Claude Code](https://claude.com/claude-code)