### PR TITLE
Add rated_before filter to rescore-module-posts handler

### DIFF
--- a/src/app/api/debug/handlers/rss.ts
+++ b/src/app/api/debug/handlers/rss.ts
@@ -428,6 +428,7 @@ export const handlers: Record<string, { GET?: DebugHandler; POST?: DebugHandler 
       const offset = parseInt(searchParams.get('offset') || '0')
       const dryRun = searchParams.get('dry_run') !== 'false'
       const articleModuleId = searchParams.get('article_module_id')
+      const ratedBefore = searchParams.get('rated_before')
 
       if (!publicationId) {
         return NextResponse.json({ error: 'publication_id required' }, { status: 400 })
@@ -456,7 +457,7 @@ export const handlers: Record<string, { GET?: DebugHandler; POST?: DebugHandler 
 
         let postsQuery = supabaseAdmin
           .from('rss_posts')
-          .select('id, title, description, content, full_article_text, article_module_id, feed_id, ticker, publication_date, post_ratings!inner(id, total_score)')
+          .select('id, title, description, content, full_article_text, article_module_id, feed_id, ticker, publication_date, post_ratings!inner(id, total_score, created_at)')
           .in('feed_id', feedIds)
           .not('article_module_id', 'is', null)
           .gte('publication_date', sinceIso)
@@ -466,6 +467,10 @@ export const handlers: Record<string, { GET?: DebugHandler; POST?: DebugHandler 
 
         if (articleModuleId) {
           postsQuery = postsQuery.eq('article_module_id', articleModuleId)
+        }
+
+        if (ratedBefore) {
+          postsQuery = postsQuery.lt('post_ratings.created_at', ratedBefore)
         }
 
         const { data: posts, error: postsError } = await postsQuery
@@ -556,6 +561,7 @@ export const handlers: Record<string, { GET?: DebugHandler; POST?: DebugHandler 
           days,
           min_score: minScore,
           article_module_id: articleModuleId,
+          rated_before: ratedBefore,
           offset,
           next_offset: posts.length === limit ? offset + limit : null,
           posts_processed: posts.length,


### PR DESCRIPTION
## Summary
Follow-up to PR #201. Adds a `rated_before` query parameter to `/api/debug/rescore-module-posts` so the endpoint can be safely run in batched offset=0 loops.

## Why
Without this filter, re-running the endpoint with `offset=0` can pick up the same posts that were just rescored if their new `total_score` still meets `min_score`, causing an infinite reprocessing loop. Pass `rated_before=<ISO timestamp of the run start>` and each call naturally excludes any rating whose `created_at` is newer than that timestamp — i.e. rows already processed in the current run.

## Files changed
- `src/app/api/debug/handlers/rss.ts` — add `rated_before` param, include `post_ratings.created_at` in the select, `.lt('post_ratings.created_at', ratedBefore)` when param is set, echo `rated_before` in response.

## Test plan
- [ ] `npm run type-check` passes locally
- [ ] After deploy, call `/api/debug/rescore-module-posts?publication_id=8277682a-7292-4c36-bca1-a39ca420b305&days=7&min_score=7&limit=25&rated_before=<past-iso>&dry_run=true` and confirm it returns posts
- [ ] Run the trader-leak rescore operation in batches and confirm it terminates (all posts eventually excluded via the filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Internal Improvements**
  * Enhanced debug API handlers with improved filtering capabilities for post rating queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->