### PR TITLE
Add RSS Output (Sent) feed variant for article modules

### DIFF
--- a/src/app/api/feeds/module/[moduleId]/sent/route.ts
+++ b/src/app/api/feeds/module/[moduleId]/sent/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ModuleFeedGenerator } from '@/lib/article-modules/feed-generator'
+
+export const maxDuration = 30
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ moduleId: string }> }
+) {
+  const { moduleId } = await params
+  const token = request.nextUrl.searchParams.get('token')
+
+  if (!token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { valid, publicationId } = await ModuleFeedGenerator.validateFeedToken(moduleId, token, 'sent')
+
+  if (!valid || !publicationId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const forceRefresh = request.nextUrl.searchParams.get('refresh') === 'true'
+
+  try {
+    const xml = await ModuleFeedGenerator.generateFeed(moduleId, publicationId, forceRefresh, 'sent')
+
+    return new NextResponse(xml, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/rss+xml; charset=utf-8',
+        'Cache-Control': 'public, max-age=900',
+      },
+    })
+  } catch (error) {
+    console.error('[Module Feed Sent] Generation failed:', error)
+    return NextResponse.json(
+      { error: 'Failed to generate module feed' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/components/article-modules/ArticleModuleGeneralTab.tsx
+++ b/src/components/article-modules/ArticleModuleGeneralTab.tsx
@@ -207,12 +207,10 @@ function RssOutputSection({ module, onUpdate, disabled, saving, setSaving, varia
                   <button onClick={() => { navigator.clipboard.writeText(feedUrl); setCopied(true); setTimeout(() => setCopied(false), 2000) }} className="px-3 py-1.5 text-xs font-medium text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-lg hover:bg-emerald-100">{copied ? 'Copied!' : 'Copy'}</button>
                 </div>
               </div>
-              {!isSent && (
-                <div className="pt-2 border-t border-gray-100">
-                  <button onClick={() => { if (confirm('Regenerating the token will break any existing RSS consumers using the old URL, including both the draft and sent feeds. Continue?')) updateRssConfig({ feed_token: generateToken() }) }} disabled={disabled || saving} className="text-xs text-red-600 hover:text-red-700 disabled:opacity-50">Regenerate Token</button>
-                  <p className="text-xs text-gray-400 mt-1">This will invalidate both the draft and sent feed URLs.</p>
-                </div>
-              )}
+              <div className="pt-2 border-t border-gray-100">
+                <button onClick={() => { if (confirm('Regenerating the token will break any existing RSS consumers using the old URL, including both the draft and sent feeds. Continue?')) updateRssConfig({ feed_token: generateToken() }) }} disabled={disabled || saving} className="text-xs text-red-600 hover:text-red-700 disabled:opacity-50">Regenerate Token</button>
+                <p className="text-xs text-gray-400 mt-1">This will invalidate both the draft and sent feed URLs.</p>
+              </div>
             </>
           )}
         </div>

--- a/src/components/article-modules/ArticleModuleGeneralTab.tsx
+++ b/src/components/article-modules/ArticleModuleGeneralTab.tsx
@@ -127,7 +127,8 @@ export default function ArticleModuleGeneralTab({ module, onUpdate, disabled = f
         </div>
       </div>
 
-      <RssOutputSection module={module} onUpdate={onUpdate} disabled={isDisabled} saving={saving} setSaving={setSaving} />
+      <RssOutputSection module={module} onUpdate={onUpdate} disabled={isDisabled} saving={saving} setSaving={setSaving} variant="draft" />
+      <RssOutputSection module={module} onUpdate={onUpdate} disabled={isDisabled} saving={saving} setSaving={setSaving} variant="sent" />
 
       {saving && (
         <div className="fixed bottom-4 right-4 bg-emerald-600 text-white px-4 py-2 rounded-lg shadow-lg flex items-center gap-2 z-50">
@@ -148,15 +149,23 @@ function generateToken(): string {
   return token
 }
 
-function RssOutputSection({ module, onUpdate, disabled, saving, setSaving }: { module: ArticleModule; onUpdate: (updates: Partial<ArticleModule>) => Promise<void>; disabled: boolean; saving: boolean; setSaving: (v: boolean) => void }) {
+type RssVariant = 'draft' | 'sent'
+
+function RssOutputSection({ module, onUpdate, disabled, saving, setSaving, variant }: { module: ArticleModule; onUpdate: (updates: Partial<ArticleModule>) => Promise<void>; disabled: boolean; saving: boolean; setSaving: (v: boolean) => void; variant: RssVariant }) {
   const [open, setOpen] = useState(false)
   const [copied, setCopied] = useState(false)
 
   const config = (module.config as Record<string, any>) || {}
   const rssConfig = config.rss_output || {}
-  const enabled = !!rssConfig.enabled
+
+  const isSent = variant === 'sent'
+  const enabledKey = isSent ? 'enabled_sent' : 'enabled'
+
+  const enabled = !!rssConfig[enabledKey]
   const feedToken = rssConfig.feed_token || ''
-  const feedUrl = feedToken ? `${typeof window !== 'undefined' ? window.location.origin : ''}/api/feeds/module/${module.id}?token=${feedToken}` : ''
+  const feedUrl = feedToken
+    ? `${typeof window !== 'undefined' ? window.location.origin : ''}/api/feeds/module/${module.id}${isSent ? '/sent' : ''}?token=${feedToken}`
+    : ''
 
   const updateRssConfig = useCallback(async (updates: Record<string, any>) => {
     setSaving(true)
@@ -171,17 +180,21 @@ function RssOutputSection({ module, onUpdate, disabled, saving, setSaving }: { m
     <div className="border border-gray-200 rounded-lg overflow-hidden">
       <button onClick={() => setOpen(!open)} className="w-full flex items-center justify-between p-4 bg-gray-50 hover:bg-gray-100 transition-colors">
         <div className="flex items-center gap-2">
-          <span className="font-medium text-gray-700">RSS Output</span>
+          <span className="font-medium text-gray-700">{isSent ? 'RSS Output (Sent)' : 'RSS Output'}</span>
           <span className={`text-xs px-2 py-0.5 rounded-full ${enabled ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-200 text-gray-500'}`}>{enabled ? 'Enabled' : 'Disabled'}</span>
         </div>
         <svg className={`w-5 h-5 text-gray-500 transition-transform ${open ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
       </button>
       {open && (
         <div className="p-4 space-y-4 border-t border-gray-100">
-          <p className="text-xs text-gray-500">Generates an RSS feed from this module&apos;s articles for use with Beehiiv or other RSS consumers.</p>
+          <p className="text-xs text-gray-500">
+            {isSent
+              ? 'Generates an RSS feed from the most recently sent issue’s articles for use with Beehiiv or other RSS consumers.'
+              : 'Generates an RSS feed from this module’s articles for use with Beehiiv or other RSS consumers.'}
+          </p>
           <div className="flex items-center justify-between">
             <label className="text-sm font-medium text-gray-700">Enable RSS Feed</label>
-            <button type="button" onClick={() => updateRssConfig(enabled ? { enabled: false } : { enabled: true, feed_token: feedToken || generateToken() })} disabled={disabled || saving} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${enabled ? 'bg-emerald-500' : 'bg-gray-300'} ${disabled || saving ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}`}>
+            <button type="button" onClick={() => updateRssConfig(enabled ? { [enabledKey]: false } : { [enabledKey]: true, feed_token: feedToken || generateToken() })} disabled={disabled || saving} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${enabled ? 'bg-emerald-500' : 'bg-gray-300'} ${disabled || saving ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}`}>
               <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${enabled ? 'translate-x-6' : 'translate-x-1'}`} />
             </button>
           </div>
@@ -194,10 +207,12 @@ function RssOutputSection({ module, onUpdate, disabled, saving, setSaving }: { m
                   <button onClick={() => { navigator.clipboard.writeText(feedUrl); setCopied(true); setTimeout(() => setCopied(false), 2000) }} className="px-3 py-1.5 text-xs font-medium text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-lg hover:bg-emerald-100">{copied ? 'Copied!' : 'Copy'}</button>
                 </div>
               </div>
-              <div className="pt-2 border-t border-gray-100">
-                <button onClick={() => { if (confirm('Regenerating the token will break any existing RSS consumers using the old URL. Continue?')) updateRssConfig({ feed_token: generateToken() }) }} disabled={disabled || saving} className="text-xs text-red-600 hover:text-red-700 disabled:opacity-50">Regenerate Token</button>
-                <p className="text-xs text-gray-400 mt-1">This will invalidate the current feed URL.</p>
-              </div>
+              {!isSent && (
+                <div className="pt-2 border-t border-gray-100">
+                  <button onClick={() => { if (confirm('Regenerating the token will break any existing RSS consumers using the old URL, including both the draft and sent feeds. Continue?')) updateRssConfig({ feed_token: generateToken() }) }} disabled={disabled || saving} className="text-xs text-red-600 hover:text-red-700 disabled:opacity-50">Regenerate Token</button>
+                  <p className="text-xs text-gray-400 mt-1">This will invalidate both the draft and sent feed URLs.</p>
+                </div>
+              )}
             </>
           )}
         </div>

--- a/src/lib/article-modules/feed-generator.ts
+++ b/src/lib/article-modules/feed-generator.ts
@@ -4,11 +4,17 @@ import { htmlToText } from 'html-to-text'
 import { supabaseAdmin } from '../supabase'
 import { normalizeTransactionType } from '../transaction-type'
 import { wrapTrackingUrl } from '../url-tracking'
+import type { IssueStatus } from '@/types/database'
 
-// Module-level cache keyed by moduleId:publicationId
+// Module-level cache keyed by moduleId:publicationId:variant
 const feedCache = new Map<string, { xml: string; cachedAt: number }>()
 const CACHE_TTL_MS = 15 * 60 * 1000 // 15 minutes
 const MAX_CACHE_ENTRIES = 100
+
+export type FeedVariant = 'draft' | 'sent'
+
+// Statuses considered "in-flight" for the draft feed (not yet sent)
+const DRAFT_STATUSES: readonly IssueStatus[] = ['draft', 'in_review']
 
 /**
  * Generates RSS 2.0 feeds from module articles for use with
@@ -18,13 +24,18 @@ export class ModuleFeedGenerator {
   /**
    * Generate RSS 2.0 XML for a module's latest issue articles.
    * Uses in-memory cache with 15-minute TTL.
+   *
+   * @param variant - 'draft' for the most recent in-flight issue
+   *   (draft/in_review/approved), 'sent' for the most recent issue
+   *   that has been sent.
    */
   static async generateFeed(
     moduleId: string,
     publicationId: string,
-    forceRefresh = false
+    forceRefresh = false,
+    variant: FeedVariant = 'draft'
   ): Promise<string> {
-    const cacheKey = `${moduleId}:${publicationId}`
+    const cacheKey = `${moduleId}:${publicationId}:${variant}`
 
     // Check cache
     if (!forceRefresh) {
@@ -55,32 +66,43 @@ export class ModuleFeedGenerator {
     const includeImages = rssConfig.include_images !== false
     const includeFullContent = rssConfig.include_full_content !== false
 
-    // Get publication info for feed metadata
-    const { data: pub, error: pubError } = await supabaseAdmin
-      .from('publications')
-      .select('name, slug')
-      .eq('id', publicationId)
-      .single()
+    // Find the most recent issue with articles for this module
+    let issueQuery = supabaseAdmin
+      .from('publication_issues')
+      .select('id, date, status')
+      .eq('publication_id', publicationId)
+
+    if (variant === 'sent') {
+      issueQuery = issueQuery.eq('status', 'sent')
+    } else {
+      issueQuery = issueQuery.in('status', DRAFT_STATUSES)
+    }
+
+    // Publication and issue lookups are independent — run in parallel
+    const [pubResult, issueResult] = await Promise.all([
+      supabaseAdmin
+        .from('publications')
+        .select('name, slug')
+        .eq('id', publicationId)
+        .single(),
+      issueQuery
+        .order('date', { ascending: false })
+        .limit(1)
+        .single(),
+    ])
+
+    const { data: pub, error: pubError } = pubResult
+    const { data: recentIssue, error: issueError } = issueResult
 
     if (pubError) {
       console.error(`[ModuleFeed] Failed to fetch publication ${publicationId}: ${pubError.message}`)
     }
 
-    const pubName = pub?.name || 'Newsletter'
-
-    // Find the most recent issue with articles for this module
-    const { data: recentIssue, error: issueError } = await supabaseAdmin
-      .from('publication_issues')
-      .select('id, date, status')
-      .eq('publication_id', publicationId)
-      .in('status', ['draft', 'in_review', 'approved'])
-      .order('date', { ascending: false })
-      .limit(1)
-      .single()
-
     if (issueError) {
-      console.error(`[ModuleFeed] Failed to fetch recent issue for publication ${publicationId}: ${issueError.message}`)
+      console.error(`[ModuleFeed] Failed to fetch recent ${variant} issue for publication ${publicationId}: ${issueError.message}`)
     }
+
+    const pubName = pub?.name || 'Newsletter'
 
     if (!recentIssue) {
       // Return empty but valid RSS feed
@@ -206,13 +228,14 @@ export class ModuleFeedGenerator {
 
   /**
    * Invalidate the cache for a specific module (across all publications),
-   * a specific module+publication pair, or the entire cache.
+   * a specific module+publication pair (both variants), or the entire cache.
    */
   static invalidateCache(moduleId?: string, publicationId?: string): void {
     if (moduleId && publicationId) {
-      feedCache.delete(`${moduleId}:${publicationId}`)
+      feedCache.delete(`${moduleId}:${publicationId}:draft`)
+      feedCache.delete(`${moduleId}:${publicationId}:sent`)
     } else if (moduleId) {
-      // Clear all entries for this module (any publication)
+      // Clear all entries for this module (any publication, any variant)
       for (const key of Array.from(feedCache.keys())) {
         if (key.startsWith(`${moduleId}:`)) {
           feedCache.delete(key)
@@ -225,10 +248,13 @@ export class ModuleFeedGenerator {
 
   /**
    * Validate a feed token against the module's stored token.
+   * The token is shared across variants; the variant-specific enabled flag
+   * (`enabled` for draft, `enabled_sent` for sent) must also be true.
    */
   static async validateFeedToken(
     moduleId: string,
-    token: string
+    token: string,
+    variant: FeedVariant = 'draft'
   ): Promise<{ valid: boolean; publicationId: string | null }> {
     const { data: mod, error: modError } = await supabaseAdmin
       .from('article_modules')
@@ -247,7 +273,8 @@ export class ModuleFeedGenerator {
     const config = (mod.config as Record<string, any>) || {}
     const rssConfig = config.rss_output || {}
 
-    if (!rssConfig.enabled || !rssConfig.feed_token || rssConfig.feed_token.length < 16) {
+    const variantEnabled = variant === 'sent' ? !!rssConfig.enabled_sent : !!rssConfig.enabled
+    if (!variantEnabled || !rssConfig.feed_token || rssConfig.feed_token.length < 16) {
       return { valid: false, publicationId: null }
     }
 

--- a/src/lib/article-modules/feed-generator.ts
+++ b/src/lib/article-modules/feed-generator.ts
@@ -26,7 +26,7 @@ export class ModuleFeedGenerator {
    * Uses in-memory cache with 15-minute TTL.
    *
    * @param variant - 'draft' for the most recent in-flight issue
-   *   (draft/in_review/approved), 'sent' for the most recent issue
+   *   (statuses in `DRAFT_STATUSES`), 'sent' for the most recent issue
    *   that has been sent.
    */
   static async generateFeed(
@@ -78,7 +78,10 @@ export class ModuleFeedGenerator {
       issueQuery = issueQuery.in('status', DRAFT_STATUSES)
     }
 
-    // Publication and issue lookups are independent — run in parallel
+    // Publication and issue lookups are independent — run in parallel.
+    // maybeSingle() on the issue query returns null (not an error) when no
+    // matching issue exists — a normal state for the 'sent' variant on a
+    // publication that hasn't sent anything yet.
     const [pubResult, issueResult] = await Promise.all([
       supabaseAdmin
         .from('publications')
@@ -88,7 +91,7 @@ export class ModuleFeedGenerator {
       issueQuery
         .order('date', { ascending: false })
         .limit(1)
-        .single(),
+        .maybeSingle(),
     ])
 
     const { data: pub, error: pubError } = pubResult
@@ -105,8 +108,7 @@ export class ModuleFeedGenerator {
     const pubName = pub?.name || 'Newsletter'
 
     if (!recentIssue) {
-      // Return empty but valid RSS feed
-      return ModuleFeedGenerator.buildEmptyFeed(mod.name, pubName)
+      return ModuleFeedGenerator.cacheAndReturn(cacheKey, ModuleFeedGenerator.buildEmptyFeed(mod.name, pubName))
     }
 
     // Get active module articles for this issue, ordered by rank
@@ -128,7 +130,7 @@ export class ModuleFeedGenerator {
     }
 
     if (!articles || articles.length === 0) {
-      return ModuleFeedGenerator.buildEmptyFeed(mod.name, pubName)
+      return ModuleFeedGenerator.cacheAndReturn(cacheKey, ModuleFeedGenerator.buildEmptyFeed(mod.name, pubName))
     }
 
     // Build RSS feed
@@ -196,17 +198,20 @@ export class ModuleFeedGenerator {
       feed.addItem(itemData)
     }
 
-    const xml = feed.rss2()
+    return ModuleFeedGenerator.cacheAndReturn(cacheKey, feed.rss2())
+  }
 
-    // Evict oldest entry if cache is full
-    if (feedCache.size >= MAX_CACHE_ENTRIES) {
+  /**
+   * Cache an XML payload under `cacheKey`, evicting the oldest entry if
+   * the cache is full, then return the XML. Used for every return path
+   * in `generateFeed` so empty and populated feeds are cached uniformly.
+   */
+  private static cacheAndReturn(cacheKey: string, xml: string): string {
+    if (feedCache.size >= MAX_CACHE_ENTRIES && !feedCache.has(cacheKey)) {
       const oldestKey = feedCache.keys().next().value
       if (oldestKey) feedCache.delete(oldestKey)
     }
-
-    // Cache the result
     feedCache.set(cacheKey, { xml, cachedAt: Date.now() })
-
     return xml
   }
 


### PR DESCRIPTION
## Summary
- Adds a second RSS feed variant alongside the existing draft feed, sourced from the most recent issue with `sent` status — lets downstream consumers (Beehiiv, archives) subscribe to what actually shipped.
- New route `/api/feeds/module/[moduleId]/sent` reuses the shared `feed_token` but is gated by a new `enabled_sent` flag on `article_modules.config.rss_output`.
- UI adds a second collapsible "RSS Output (Sent)" section with its own enable toggle; regenerate-token control stays in the draft section only (token is shared across both feeds) with a warning that rotating it invalidates both URLs.

## Implementation notes
- `ModuleFeedGenerator.generateFeed` and `validateFeedToken` gained a `variant: 'draft' | 'sent'` param; cache key is now `moduleId:publicationId:variant`.
- Parallelized the `publications` and `publication_issues` reads in `generateFeed` via `Promise.all` (shaves one roundtrip per cache miss).
- Replaced the `'approved'` status in the draft filter — it was never a valid `IssueStatus` — and typed `DRAFT_STATUSES` as `readonly IssueStatus[]`.
- `invalidateCache(moduleId, publicationId)` now clears both variants via two direct deletes.

## Test plan
- [ ] Enable the Sent feed on a module with at least one sent issue; confirm the feed URL returns the expected articles.
- [ ] Toggle the Sent flag off and confirm the route returns 401.
- [ ] Rotate the token in the draft section and confirm both feed URLs update and old tokens are rejected.
- [ ] Enable only the Sent feed (leaving Draft disabled) and confirm the token auto-generates and the draft route still rejects with 401.
- [ ] Verify draft feed still returns the most recent draft/in_review issue (no behavior change for existing consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added a new "sent" RSS feed output for published content, alongside the existing "draft" feed for in-progress items
  - Enable or disable each feed variant independently
  - Each feed variant has its own unique URL for better content organization
  - Token regeneration now impacts both feed types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->