### PR TITLE
Fix SparkLoop API key rotation and subscribe outage handling

### DIFF
--- a/scripts/replay-sparkloop-failed-subscribes.mjs
+++ b/scripts/replay-sparkloop-failed-subscribes.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * Replay SparkLoop subscribes that failed during an API key outage.
+ *
+ * For each email with a `subscriptions_failed` event in the given window,
+ * find its most recent prior `popup_opened` event to recover the ref_codes,
+ * then POST to /api/sparkloop/subscribe so both the SparkLoop subscribe
+ * and the MailerLite/Beehiiv `sparkloop` field update happen.
+ *
+ * Usage:
+ *   node scripts/replay-sparkloop-failed-subscribes.mjs --dry-run
+ *   node scripts/replay-sparkloop-failed-subscribes.mjs --base-url=https://aiprodaily.com
+ *
+ * Flags:
+ *   --dry-run              Preview what would run; do not POST to the API
+ *   --since=<ISO>          Start of window (default: 2026-04-22T19:00:00Z)
+ *   --until=<ISO>          End of window (default: now)
+ *   --publication-id=<id>  Publication ID (default: AI Pros Daily)
+ *   --base-url=<url>       Base URL for the API (default: https://aiprodaily.com)
+ *   --delay-ms=<n>         Delay between requests to avoid rate limits (default: 1500)
+ *
+ * Environment (loaded from .env.local):
+ *   SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL)  (required)
+ *   SUPABASE_SERVICE_ROLE_KEY                    (required)
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import dotenv from 'dotenv'
+
+dotenv.config({ path: '.env.local' })
+dotenv.config() // fallback to .env
+
+const DEFAULT_PUBLICATION_ID = 'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf'
+const DEFAULT_SINCE = '2026-04-22T19:00:00Z'
+const DEFAULT_BASE_URL = 'https://aiprodaily.com'
+const DEFAULT_DELAY_MS = 2500
+
+function parseArgs() {
+  const args = { dryRun: false }
+  for (const arg of process.argv.slice(2)) {
+    if (arg === '--dry-run') args.dryRun = true
+    else if (arg.startsWith('--since=')) args.since = arg.slice('--since='.length)
+    else if (arg.startsWith('--until=')) args.until = arg.slice('--until='.length)
+    else if (arg.startsWith('--publication-id=')) args.publicationId = arg.slice('--publication-id='.length)
+    else if (arg.startsWith('--base-url=')) args.baseUrl = arg.slice('--base-url='.length)
+    else if (arg.startsWith('--delay-ms=')) args.delayMs = parseInt(arg.slice('--delay-ms='.length), 10)
+  }
+  return {
+    dryRun: args.dryRun,
+    since: args.since ?? DEFAULT_SINCE,
+    until: args.until ?? new Date().toISOString(),
+    publicationId: args.publicationId ?? DEFAULT_PUBLICATION_ID,
+    baseUrl: (args.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, ''),
+    delayMs: Number.isFinite(args.delayMs) ? args.delayMs : DEFAULT_DELAY_MS,
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function main() {
+  const opts = parseArgs()
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error('Missing SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL) or SUPABASE_SERVICE_ROLE_KEY in env')
+    process.exit(1)
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } })
+
+  console.log('--- Replay SparkLoop failed subscribes ---')
+  console.log(`Publication: ${opts.publicationId}`)
+  console.log(`Window:      ${opts.since} → ${opts.until}`)
+  console.log(`Base URL:    ${opts.baseUrl}`)
+  console.log(`Delay:       ${opts.delayMs}ms`)
+  console.log(`Mode:        ${opts.dryRun ? 'DRY RUN' : 'LIVE'}`)
+  console.log()
+
+  // 1. Pull distinct failed emails in the window (most recent failure per email)
+  const { data: failedRows, error: failedErr } = await supabase
+    .from('sparkloop_events')
+    .select('subscriber_email, event_timestamp')
+    .eq('publication_id', opts.publicationId)
+    .eq('event_type', 'subscriptions_failed')
+    .gte('event_timestamp', opts.since)
+    .lte('event_timestamp', opts.until)
+    .order('event_timestamp', { ascending: false })
+
+  if (failedErr) {
+    console.error('Failed to query subscriptions_failed events:', failedErr.message)
+    process.exit(1)
+  }
+
+  const latestFailureByEmail = new Map()
+  for (const row of failedRows ?? []) {
+    if (!row.subscriber_email) continue
+    if (!latestFailureByEmail.has(row.subscriber_email)) {
+      latestFailureByEmail.set(row.subscriber_email, row.event_timestamp)
+    }
+  }
+
+  console.log(`Found ${latestFailureByEmail.size} unique failed emails in window`)
+
+  // 2. For each email, get the most recent popup_opened <= failure time
+  const replayQueue = []
+  const skipped = []
+
+  for (const [email, failedAt] of latestFailureByEmail) {
+    const { data: popup, error: popupErr } = await supabase
+      .from('sparkloop_events')
+      .select('raw_payload, event_timestamp')
+      .eq('publication_id', opts.publicationId)
+      .eq('event_type', 'popup_opened')
+      .eq('subscriber_email', email)
+      .lte('event_timestamp', failedAt)
+      .order('event_timestamp', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (popupErr) {
+      skipped.push({ email, reason: `popup query error: ${popupErr.message}` })
+      continue
+    }
+
+    const refCodes = popup?.raw_payload?.ref_codes
+    const source = popup?.raw_payload?.source === 'recs_page' ? 'recs_page' : 'custom_popup'
+
+    if (!Array.isArray(refCodes) || refCodes.length === 0) {
+      skipped.push({ email, reason: 'no ref_codes in popup_opened' })
+      continue
+    }
+
+    // Skip if we already have a successful confirmation for this email in the window
+    const { data: alreadyConfirmed } = await supabase
+      .from('sparkloop_events')
+      .select('id')
+      .eq('publication_id', opts.publicationId)
+      .eq('event_type', 'api_subscribe_confirmed')
+      .eq('subscriber_email', email)
+      .gte('event_timestamp', opts.since)
+      .limit(1)
+      .maybeSingle()
+
+    if (alreadyConfirmed) {
+      skipped.push({ email, reason: 'already confirmed in window' })
+      continue
+    }
+
+    replayQueue.push({ email, refCodes, source })
+  }
+
+  console.log(`Replay queue: ${replayQueue.length}`)
+  console.log(`Skipped:      ${skipped.length}`)
+  if (skipped.length > 0) {
+    for (const s of skipped) console.log(`  - ${s.email}: ${s.reason}`)
+  }
+  console.log()
+
+  if (opts.dryRun) {
+    console.log('DRY RUN — preview of requests that would be sent:')
+    for (const { email, refCodes, source } of replayQueue) {
+      console.log(`  ${email}  [${refCodes.length} recs, source=${source}]`)
+    }
+    return
+  }
+
+  // 3. Fire the replay requests
+  const results = { ok: 0, failed: 0, errors: [] }
+  const url = `${opts.baseUrl}/api/sparkloop/subscribe`
+
+  for (let i = 0; i < replayQueue.length; i++) {
+    const { email, refCodes, source } = replayQueue[i]
+    const label = `[${i + 1}/${replayQueue.length}] ${email}`
+
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          refCodes,
+          source,
+          publicationId: opts.publicationId,
+        }),
+      })
+      const body = await res.json().catch(() => ({}))
+
+      if (res.ok && body.success) {
+        console.log(`${label} ✅ subscribed (${body.subscribedCount ?? refCodes.length} recs)`)
+        results.ok++
+      } else {
+        const errMsg = body.error || `HTTP ${res.status}`
+        console.log(`${label} ❌ ${errMsg}`)
+        results.failed++
+        results.errors.push({ email, error: errMsg })
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err)
+      console.log(`${label} ❌ network error: ${errMsg}`)
+      results.failed++
+      results.errors.push({ email, error: errMsg })
+    }
+
+    if (i < replayQueue.length - 1) await sleep(opts.delayMs)
+  }
+
+  console.log()
+  console.log(`--- Summary ---`)
+  console.log(`Succeeded: ${results.ok}`)
+  console.log(`Failed:    ${results.failed}`)
+  if (results.errors.length > 0) {
+    console.log('Failures:')
+    for (const e of results.errors) console.log(`  - ${e.email}: ${e.error}`)
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal:', err)
+  process.exit(1)
+})

--- a/src/app/api/settings/sparkloop/route.ts
+++ b/src/app/api/settings/sparkloop/route.ts
@@ -18,15 +18,15 @@ export const GET = withApiHandler(
       return NextResponse.json({ error: 'publication_id required' }, { status: 400 })
     }
 
-    const [apiKey, upscribeId, webhookSecret, afteroffersFormId] = await Promise.all([
-      getPublicationSetting(publicationId, 'sparkloop_api_key'),
+    const [upscribeId, webhookSecret, afteroffersFormId] = await Promise.all([
       getPublicationSetting(publicationId, 'sparkloop_upscribe_id'),
       getPublicationSetting(publicationId, 'sparkloop_webhook_secret'),
       getPublicationSetting(publicationId, 'afteroffers_form_id'),
     ])
 
     return NextResponse.json({
-      hasApiKey: !!apiKey,
+      // SparkLoop API key is sourced from the SPARKLOOP_API_KEY env var — shared across publications.
+      hasApiKey: !!process.env.SPARKLOOP_API_KEY,
       upscribeId: upscribeId || '',
       hasWebhookSecret: !!webhookSecret,
       afteroffersFormId: afteroffersFormId || '',
@@ -52,12 +52,6 @@ export const POST = withApiHandler(
 
     const body = await request.json()
     const results: string[] = []
-
-    if (body.apiKey) {
-      const { error } = await updatePublicationSetting(publicationId, 'sparkloop_api_key', body.apiKey)
-      if (error) throw new Error(`Failed to save API key: ${error}`)
-      results.push('API key updated')
-    }
 
     if (body.upscribeId !== undefined) {
       const { error } = await updatePublicationSetting(publicationId, 'sparkloop_upscribe_id', body.upscribeId)

--- a/src/app/api/sparkloop/module-subscribe/route.ts
+++ b/src/app/api/sparkloop/module-subscribe/route.ts
@@ -146,48 +146,67 @@ export const GET = withApiHandler(
       console.error('[SparkLoop Module Subscribe] Create/fetch subscriber failed:', subError)
     }
 
-    // Step 3: Subscribe with UUID for proper referral attribution
-    await service.subscribeToNewsletters({
-      subscriber_email: email,
-      subscriber_uuid: subscriberUuid || undefined,
-      country_code: countryCode,
-      recommendations: refCode,
-      utm_source: 'newsletter_module',
-    })
+    // Step 3: Subscribe with UUID for proper referral attribution (non-blocking)
+    let sparkloopSuccess = false
+    let sparkloopError: string | undefined
+    try {
+      await service.subscribeToNewsletters({
+        subscriber_email: email,
+        subscriber_uuid: subscriberUuid || undefined,
+        country_code: countryCode,
+        recommendations: refCode,
+        utm_source: 'newsletter_module',
+      })
+      sparkloopSuccess = true
+    } catch (subscribeErr) {
+      sparkloopError = subscribeErr instanceof Error ? subscribeErr.message : String(subscribeErr)
+      console.error('[SparkLoop Module Subscribe] SparkLoop subscribe failed:', sparkloopError)
+    }
 
-    // Update click record: SparkLoop was called successfully (fire-and-forget)
+    // Update click record with actual success state (fire-and-forget)
     supabaseAdmin
       .from('sparkloop_module_clicks')
-      .update({ sparkloop_called: true, sparkloop_success: true })
+      .update({ sparkloop_called: true, sparkloop_success: sparkloopSuccess })
       .eq('id', clickRecordId)
       .then(({ error }) => {
         if (error) console.error('[SparkLoop Module Subscribe] Failed to update click record:', error)
       })
 
-    // Record referral in sparkloop_referrals
-    try {
-      await supabaseAdmin
-        .from('sparkloop_referrals')
-        .upsert({
-          publication_id: publicationId,
-          subscriber_email: email,
-          ref_code: refCode,
-          source: 'newsletter_module',
-          status: 'subscribed',
-          subscribed_at: new Date().toISOString(),
-        }, {
-          onConflict: 'publication_id,subscriber_email,ref_code',
-          ignoreDuplicates: true,
+    // Only write referral + aggregates when the subscribe actually succeeded
+    if (sparkloopSuccess) {
+      try {
+        await supabaseAdmin
+          .from('sparkloop_referrals')
+          .upsert({
+            publication_id: publicationId,
+            subscriber_email: email,
+            ref_code: refCode,
+            source: 'newsletter_module',
+            status: 'subscribed',
+            subscribed_at: new Date().toISOString(),
+          }, {
+            onConflict: 'publication_id,subscriber_email,ref_code',
+            ignoreDuplicates: true,
+          })
+      } catch (refErr) {
+        console.error('[SparkLoop Module Subscribe] Failed to record referral:', refErr)
+      }
+
+      try {
+        await supabaseAdmin.rpc('increment_our_subscribes', {
+          p_publication_id: publicationId,
+          p_ref_codes: [refCode],
         })
-    } catch (refErr) {
-      console.error('[SparkLoop Module Subscribe] Failed to record referral:', refErr)
+      } catch (aggErr) {
+        console.error('[SparkLoop Module Subscribe] Failed to increment aggregates:', aggErr)
+      }
     }
 
-    // Record event in sparkloop_events
+    // Record event regardless (attempt is real even if SparkLoop failed)
     try {
       await supabaseAdmin.from('sparkloop_events').insert({
         publication_id: publicationId,
-        event_type: 'newsletter_module_subscribe',
+        event_type: sparkloopSuccess ? 'newsletter_module_subscribe' : 'newsletter_module_subscribe_failed',
         subscriber_email: email,
         raw_payload: {
           source: 'newsletter_module',
@@ -195,6 +214,7 @@ export const GET = withApiHandler(
           issue_id: issueId || null,
           subscriber_uuid: subscriberUuid,
           country_code: countryCode,
+          sparkloop_error: sparkloopError,
           ip_hash: ipAddress ? createHash('sha256').update(ipAddress).digest('hex').slice(0, 16) : null,
         },
         event_timestamp: new Date().toISOString(),
@@ -203,17 +223,9 @@ export const GET = withApiHandler(
       console.error('[SparkLoop Module Subscribe] Failed to record event:', eventErr)
     }
 
-    // Increment our_total_subscribes
-    try {
-      await supabaseAdmin.rpc('increment_our_subscribes', {
-        p_publication_id: publicationId,
-        p_ref_codes: [refCode],
-      })
-    } catch (aggErr) {
-      console.error('[SparkLoop Module Subscribe] Failed to increment aggregates:', aggErr)
+    if (sparkloopSuccess) {
+      console.log(`[SparkLoop Module Subscribe] ${email} subscribed to ${rec.publication_name} via newsletter module`)
     }
-
-    console.log(`[SparkLoop Module Subscribe] ${email} subscribed to ${rec.publication_name} via newsletter module`)
 
     // Redirect to confirmation page
     const confirmUrl = new URL(`${BASE_URL}/website/subscribe/module-confirmed`)

--- a/src/app/api/sparkloop/recommend-subscribe/route.ts
+++ b/src/app/api/sparkloop/recommend-subscribe/route.ts
@@ -131,48 +131,68 @@ export const POST = withApiHandler(
       console.error('[SparkLoop Recommend Subscribe] Create/fetch subscriber failed:', subError)
     }
 
-    // Subscribe with UUID for proper referral attribution
-    await service.subscribeToNewsletters({
-      subscriber_email: email,
-      subscriber_uuid: subscriberUuid || undefined,
-      country_code: countryCode,
-      recommendations: refCode,
-      utm_source: 'newsletter_module',
-    })
+    // Subscribe with UUID for proper referral attribution (non-blocking so we can still
+    // record the attempt cleanly if SparkLoop is down)
+    let sparkloopSuccess = false
+    let sparkloopError: string | undefined
+    try {
+      await service.subscribeToNewsletters({
+        subscriber_email: email,
+        subscriber_uuid: subscriberUuid || undefined,
+        country_code: countryCode,
+        recommendations: refCode,
+        utm_source: 'newsletter_module',
+      })
+      sparkloopSuccess = true
+    } catch (subscribeErr) {
+      sparkloopError = subscribeErr instanceof Error ? subscribeErr.message : String(subscribeErr)
+      console.error('[SparkLoop Recommend Subscribe] SparkLoop subscribe failed:', sparkloopError)
+    }
 
     // Update click record (fire-and-forget)
     supabaseAdmin
       .from('sparkloop_module_clicks')
-      .update({ sparkloop_called: true, sparkloop_success: true })
+      .update({ sparkloop_called: true, sparkloop_success: sparkloopSuccess })
       .eq('id', clickRecordId)
       .then(({ error }) => {
         if (error) console.error('[SparkLoop Recommend Subscribe] Failed to update click record:', error)
       })
 
-    // Record referral
-    try {
-      await supabaseAdmin
-        .from('sparkloop_referrals')
-        .upsert({
-          publication_id: publicationId,
-          subscriber_email: email,
-          ref_code: refCode,
-          source: 'newsletter_module',
-          status: 'subscribed',
-          subscribed_at: new Date().toISOString(),
-        }, {
-          onConflict: 'publication_id,subscriber_email,ref_code',
-          ignoreDuplicates: true,
+    // Only record referral + aggregates on actual success (don't lie about subscription state)
+    if (sparkloopSuccess) {
+      try {
+        await supabaseAdmin
+          .from('sparkloop_referrals')
+          .upsert({
+            publication_id: publicationId,
+            subscriber_email: email,
+            ref_code: refCode,
+            source: 'newsletter_module',
+            status: 'subscribed',
+            subscribed_at: new Date().toISOString(),
+          }, {
+            onConflict: 'publication_id,subscriber_email,ref_code',
+            ignoreDuplicates: true,
+          })
+      } catch (refErr) {
+        console.error('[SparkLoop Recommend Subscribe] Failed to record referral:', refErr)
+      }
+
+      try {
+        await supabaseAdmin.rpc('increment_our_subscribes', {
+          p_publication_id: publicationId,
+          p_ref_codes: [refCode],
         })
-    } catch (refErr) {
-      console.error('[SparkLoop Recommend Subscribe] Failed to record referral:', refErr)
+      } catch (aggErr) {
+        console.error('[SparkLoop Recommend Subscribe] Failed to increment aggregates:', aggErr)
+      }
     }
 
-    // Record event
+    // Record event regardless (attempt is real even if SparkLoop failed)
     try {
       await supabaseAdmin.from('sparkloop_events').insert({
         publication_id: publicationId,
-        event_type: 'newsletter_module_subscribe',
+        event_type: sparkloopSuccess ? 'newsletter_module_subscribe' : 'newsletter_module_subscribe_failed',
         subscriber_email: email,
         raw_payload: {
           source: 'newsletter_module',
@@ -180,6 +200,7 @@ export const POST = withApiHandler(
           issue_id: issueId || null,
           subscriber_uuid: subscriberUuid,
           country_code: countryCode,
+          sparkloop_error: sparkloopError,
           ip_hash: ipAddress ? createHash('sha256').update(ipAddress).digest('hex').slice(0, 16) : null,
         },
         event_timestamp: new Date().toISOString(),
@@ -188,21 +209,14 @@ export const POST = withApiHandler(
       console.error('[SparkLoop Recommend Subscribe] Failed to record event:', eventErr)
     }
 
-    // Increment aggregates
-    try {
-      await supabaseAdmin.rpc('increment_our_subscribes', {
-        p_publication_id: publicationId,
-        p_ref_codes: [refCode],
-      })
-    } catch (aggErr) {
-      console.error('[SparkLoop Recommend Subscribe] Failed to increment aggregates:', aggErr)
+    if (sparkloopSuccess) {
+      console.log(`[SparkLoop Recommend Subscribe] ${email} subscribed to ${rec.publication_name} via landing page`)
     }
 
-    console.log(`[SparkLoop Recommend Subscribe] ${email} subscribed to ${rec.publication_name} via landing page`)
-
     return NextResponse.json({
-      success: true,
+      success: sparkloopSuccess,
       publication_name: rec.publication_name,
+      error: sparkloopError,
     })
   }
 )

--- a/src/app/api/sparkloop/subscribe/route.ts
+++ b/src/app/api/sparkloop/subscribe/route.ts
@@ -99,19 +99,28 @@ export const POST = withApiHandler(
 
     // Step 3: Subscribe to selected newsletters (only active ones)
     // subscriber_uuid is required for proper referral tracking attribution
-    const subscribeResult = await service.subscribeToNewsletters({
-      subscriber_email: email,
-      subscriber_uuid: subscriberUuid || undefined,
-      country_code: countryCode,
-      recommendations: activeRefCodes.join(','),
-      utm_source: submissionSource,
-    })
+    // Non-blocking: if this fails (e.g. SparkLoop API outage), we still want to record the
+    // attempt and flip the MailerLite/Beehiiv `sparkloop` field so our system stays consistent.
+    let subscribeResult: { success: boolean; response?: unknown; error?: string } = { success: false }
+    try {
+      subscribeResult = await service.subscribeToNewsletters({
+        subscriber_email: email,
+        subscriber_uuid: subscriberUuid || undefined,
+        country_code: countryCode,
+        recommendations: activeRefCodes.join(','),
+        utm_source: submissionSource,
+      })
+    } catch (subscribeError) {
+      const errMsg = subscribeError instanceof Error ? subscribeError.message : String(subscribeError)
+      console.error('[SparkLoop Subscribe] Step 3 (subscribe to newsletters) failed:', errMsg)
+      subscribeResult = { success: false, error: errMsg }
+    }
 
-    // Record the SparkLoop API confirmation as a server-side event
+    // Record the SparkLoop API attempt as a server-side event (confirmed or failed)
     try {
       await supabaseAdmin.from('sparkloop_events').insert({
         publication_id: publicationId,
-        event_type: 'api_subscribe_confirmed',
+        event_type: subscribeResult.success ? 'api_subscribe_confirmed' : 'api_subscribe_failed',
         subscriber_email: email,
         raw_payload: {
           source: 'server',
@@ -121,6 +130,7 @@ export const POST = withApiHandler(
           ref_codes: activeRefCodes,
           filtered_out: filteredOut.length > 0 ? filteredOut : undefined,
           sparkloop_response: subscribeResult.response,
+          sparkloop_error: subscribeResult.error,
           ip_hash: ipAddress ? createHash('sha256').update(ipAddress).digest('hex').slice(0, 16) : null,
           selected_count: activeRefCodes.length,
           shown_count: 5,
@@ -128,55 +138,54 @@ export const POST = withApiHandler(
         event_timestamp: new Date().toISOString(),
       })
     } catch (eventError) {
-      console.error('[SparkLoop Subscribe] Failed to record API confirmation event:', eventError)
+      console.error('[SparkLoop Subscribe] Failed to record API event:', eventError)
     }
 
-    // Record submissions in our metrics -- route to popup or page column based on source
-    try {
-      const submissionRpc = submissionSource === 'recs_page'
-        ? 'increment_sparkloop_page_submissions'
-        : 'increment_sparkloop_submissions'
-      await supabaseAdmin.rpc(submissionRpc, {
-        p_publication_id: publicationId,
-        p_ref_codes: activeRefCodes,
-      })
-      console.log(`[SparkLoop Subscribe] Recorded ${activeRefCodes.length} ${submissionSource === 'recs_page' ? 'page' : 'popup'} submissions`)
-    } catch (metricsError) {
-      console.error('[SparkLoop Subscribe] Failed to record metrics:', metricsError)
-      // Don't fail the request for metrics errors
-    }
-
-    // Record referral rows in sparkloop_referrals (one per ref_code)
-    try {
-      const referralRows = activeRefCodes.map((refCode: string) => ({
-        publication_id: publicationId,
-        subscriber_email: email,
-        ref_code: refCode,
-        source: submissionSource,
-        status: 'subscribed',
-        subscribed_at: new Date().toISOString(),
-      }))
-
-      const { error: refError } = await supabaseAdmin
-        .from('sparkloop_referrals')
-        .upsert(referralRows, { onConflict: 'publication_id,subscriber_email,ref_code', ignoreDuplicates: true })
-
-      if (refError) {
-        console.error('[SparkLoop Subscribe] Failed to record referrals:', refError)
-      } else {
-        // Increment our_total_subscribes and our_pending on recommendations
-        const { error: aggError } = await supabaseAdmin.rpc('increment_our_subscribes', {
+    // Only record submissions metrics and referrals when the SparkLoop subscribe actually succeeded.
+    // If Step 3 failed, the user wasn't subscribed to anything — our metrics should not say otherwise.
+    if (subscribeResult.success) {
+      try {
+        const submissionRpc = submissionSource === 'recs_page'
+          ? 'increment_sparkloop_page_submissions'
+          : 'increment_sparkloop_submissions'
+        await supabaseAdmin.rpc(submissionRpc, {
           p_publication_id: publicationId,
           p_ref_codes: activeRefCodes,
         })
-        if (aggError) {
-          console.error('[SparkLoop Subscribe] Failed to increment aggregates:', aggError)
-        }
-        console.log(`[SparkLoop Subscribe] Recorded ${activeRefCodes.length} referral rows`)
+        console.log(`[SparkLoop Subscribe] Recorded ${activeRefCodes.length} ${submissionSource === 'recs_page' ? 'page' : 'popup'} submissions`)
+      } catch (metricsError) {
+        console.error('[SparkLoop Subscribe] Failed to record metrics:', metricsError)
       }
-    } catch (referralError) {
-      console.error('[SparkLoop Subscribe] Failed to record referrals:', referralError)
-      // Don't fail the request for referral tracking errors
+
+      try {
+        const referralRows = activeRefCodes.map((refCode: string) => ({
+          publication_id: publicationId,
+          subscriber_email: email,
+          ref_code: refCode,
+          source: submissionSource,
+          status: 'subscribed',
+          subscribed_at: new Date().toISOString(),
+        }))
+
+        const { error: refError } = await supabaseAdmin
+          .from('sparkloop_referrals')
+          .upsert(referralRows, { onConflict: 'publication_id,subscriber_email,ref_code', ignoreDuplicates: true })
+
+        if (refError) {
+          console.error('[SparkLoop Subscribe] Failed to record referrals:', refError)
+        } else {
+          const { error: aggError } = await supabaseAdmin.rpc('increment_our_subscribes', {
+            p_publication_id: publicationId,
+            p_ref_codes: activeRefCodes,
+          })
+          if (aggError) {
+            console.error('[SparkLoop Subscribe] Failed to increment aggregates:', aggError)
+          }
+          console.log(`[SparkLoop Subscribe] Recorded ${activeRefCodes.length} referral rows`)
+        }
+      } catch (referralError) {
+        console.error('[SparkLoop Subscribe] Failed to record referrals:', referralError)
+      }
     }
 
     // Update email provider subscriber field to mark as SparkLoop participant
@@ -218,11 +227,16 @@ export const POST = withApiHandler(
       // Don't fail the request for email provider errors
     }
 
-    console.log(`[SparkLoop Subscribe] Successfully subscribed ${email} to ${activeRefCodes.length} newsletters${filteredOut.length > 0 ? ` (${filteredOut.length} filtered out as paused/excluded)` : ''}`)
+    if (subscribeResult.success) {
+      console.log(`[SparkLoop Subscribe] Successfully subscribed ${email} to ${activeRefCodes.length} newsletters${filteredOut.length > 0 ? ` (${filteredOut.length} filtered out as paused/excluded)` : ''}`)
+    } else {
+      console.error(`[SparkLoop Subscribe] SparkLoop subscribe failed for ${email}; MailerLite field still updated. Error: ${subscribeResult.error}`)
+    }
 
     return NextResponse.json({
-      success: true,
-      subscribedCount: activeRefCodes.length,
+      success: subscribeResult.success,
+      subscribedCount: subscribeResult.success ? activeRefCodes.length : 0,
+      error: subscribeResult.success ? undefined : subscribeResult.error,
     })
   }
 )

--- a/src/components/settings/SparkLoopSettings.tsx
+++ b/src/components/settings/SparkLoopSettings.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react'
 
 export default function SparkLoopSettings({ publicationId }: { publicationId: string }) {
   const [settings, setSettings] = useState({
-    apiKey: '',
     upscribeId: '',
     webhookSecret: '',
     afteroffersFormId: '',
@@ -26,7 +25,6 @@ export default function SparkLoopSettings({ publicationId }: { publicationId: st
       if (response.ok) {
         const data = await response.json()
         setSettings({
-          apiKey: '', // Never pre-fill secrets
           upscribeId: data.upscribeId || '',
           webhookSecret: '', // Never pre-fill secrets
           afteroffersFormId: data.afteroffersFormId || '',
@@ -85,7 +83,7 @@ export default function SparkLoopSettings({ publicationId }: { publicationId: st
       <div>
         <h2 className="text-lg font-semibold text-gray-900">SparkLoop Integration</h2>
         <p className="text-sm text-gray-500 mt-1">
-          Configure SparkLoop credentials for this publication. Each publication needs its own SparkLoop API key and Upscribe ID.
+          Configure SparkLoop credentials for this publication. The API key is shared across all publications via env var; Upscribe ID and webhook secret are per-publication.
         </p>
       </div>
 
@@ -96,20 +94,16 @@ export default function SparkLoopSettings({ publicationId }: { publicationId: st
       )}
 
       <div className="space-y-4">
-        {/* API Key */}
+        {/* API Key (managed via SPARKLOOP_API_KEY env var — shared across publications) */}
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
             SparkLoop API Key
           </label>
-          <input
-            type="password"
-            value={settings.apiKey}
-            onChange={(e) => setSettings({ ...settings, apiKey: e.target.value })}
-            placeholder={hasApiKey ? '******** (saved, enter new value to update)' : 'Enter API key'}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500"
-          />
+          <div className={`px-3 py-2 border rounded-md text-sm ${hasApiKey ? 'border-gray-200 bg-gray-50 text-gray-600' : 'border-red-200 bg-red-50 text-red-700'}`}>
+            {hasApiKey ? 'Configured (managed via SPARKLOOP_API_KEY environment variable)' : 'Not configured — set SPARKLOOP_API_KEY in Vercel environment variables'}
+          </div>
           <p className="text-xs text-gray-400 mt-1">
-            Found in your SparkLoop dashboard under Account Settings &gt; API
+            The SparkLoop API key is shared across all publications and managed via the <code className="font-mono">SPARKLOOP_API_KEY</code> env var.
           </p>
         </div>
 

--- a/src/lib/publication-settings.ts
+++ b/src/lib/publication-settings.ts
@@ -256,12 +256,13 @@ export async function getSparkLoopCredentials(publicationId: string): Promise<{
     .from('publication_settings')
     .select('key, value')
     .eq('publication_id', publicationId)
-    .in('key', ['sparkloop_api_key', 'sparkloop_upscribe_id', 'sparkloop_webhook_secret'])
+    .in('key', ['sparkloop_upscribe_id', 'sparkloop_webhook_secret'])
 
   const map = Object.fromEntries((data ?? []).map(r => [r.key, r.value]))
 
   return {
-    apiKey: map['sparkloop_api_key'] || process.env.SPARKLOOP_API_KEY || '',
+    // SparkLoop API key is a single shared account-level secret — always sourced from env.
+    apiKey: process.env.SPARKLOOP_API_KEY || '',
     upscribeId: map['sparkloop_upscribe_id'] || process.env.SPARKLOOP_UPSCRIBE_ID || '',
     webhookSecret: map['sparkloop_webhook_secret'] || process.env.SPARKLOOP_WEBHOOK_SECRET || '',
   }


### PR DESCRIPTION
## Summary

- **Root cause of yesterday's SparkLoop outage**: `publication_settings.sparkloop_api_key` rows shadowed the `SPARKLOOP_API_KEY` env var in `getSparkLoopCredentials()`, so the Vercel env var update never took effect. Affected 49 users across ~17 hours (20:03 UTC Apr 22 → 13:17 UTC Apr 23).
- **Separate bug uncovered**: a failure in Step 3 (`subscribeToNewsletters`) short-circuited downstream side effects — `sparkloop_events`, `sparkloop_referrals`, and the MailerLite/Beehiiv `sparkloop` field update all never ran.
- Replay script included and already used to backfill the 49 affected users.

## Changes

- `src/lib/publication-settings.ts` — `getSparkLoopCredentials()` now reads the API key exclusively from `process.env.SPARKLOOP_API_KEY`. Upscribe ID and webhook secret remain per-publication.
- `src/app/api/settings/sparkloop/route.ts` — GET reports `hasApiKey` based on env var; POST no longer accepts `apiKey`.
- `src/components/settings/SparkLoopSettings.tsx` — replaces the API key input with a read-only env-managed status indicator.
- `src/app/api/sparkloop/{subscribe,recommend-subscribe,module-subscribe}/route.ts` — wrap `subscribeToNewsletters()` in try/catch so SparkLoop outages no longer block MailerLite/Beehiiv field updates. Metrics and `sparkloop_referrals` rows only write on real success. New `api_subscribe_failed` / `newsletter_module_subscribe_failed` event types capture errors for audit.
- `scripts/replay-sparkloop-failed-subscribes.mjs` — replays `/api/sparkloop/subscribe` for users with `subscriptions_failed` events in a given window, recovering `ref_codes` from their prior `popup_opened` event.

## DB cleanup (already done)

`DELETE FROM publication_settings WHERE key = 'sparkloop_api_key';` — removed both stale rows (now unread by code).

## Replay results (already done)

Ran `node scripts/replay-sparkloop-failed-subscribes.mjs --base-url=https://www.aiprodaily.com`:
- 49/49 emails subscribed on SparkLoop
- 49 `api_subscribe_confirmed` events recorded
- 191 `sparkloop_referrals` rows inserted
- MailerLite `sparkloop` field flipped to `true` for each user

## Test plan

- [x] Type-check passes
- [x] Lint / bug-pattern checks pass (pre-push hook)
- [x] Live replay script succeeded end-to-end (49/49)
- [x] Downstream events/referrals verified via SQL
- [ ] After merge + deploy: rotate `SPARKLOOP_API_KEY` in Vercel and confirm new signups work without touching the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)