### PR TITLE
Pass publication_id through SparkLoop recs page flow

### DIFF
--- a/src/app/api/sparkloop/track/route.ts
+++ b/src/app/api/sparkloop/track/route.ts
@@ -26,6 +26,7 @@ const trackEventSchema = z.object({
   selected_count: z.number().int().min(0).max(100).optional(),
   timestamp: z.string().optional(),
   error_message: z.string().max(500).optional(),
+  publication_id: z.string().uuid().optional(),
 })
 
 // Simple in-memory rate limiting: max 30 events per IP per minute
@@ -63,8 +64,9 @@ setInterval(() => {
 export const POST = withApiHandler(
   { authTier: 'public', logContext: 'sparkloop-track', inputSchema: trackEventSchema },
   async ({ input, request, logger }) => {
-    // Resolve publication from server-side default (no trust anchor available)
-    const publicationId = PUBLICATION_ID
+    // Prefer the publication_id from the client (set by the page/modal that resolved it from
+    // the request domain). Fall back to the env default for legacy callers.
+    const publicationId = input.publication_id || PUBLICATION_ID
 
     const eventType = input.event_type
 

--- a/src/app/website/subscribe/recommendations/page.tsx
+++ b/src/app/website/subscribe/recommendations/page.tsx
@@ -1,22 +1,15 @@
-import { headers } from 'next/headers'
-import { getPublicationByDomain, getPublicationSettings } from '@/lib/publication-settings'
+import { resolvePublicationFromRequest, getPublicationSettings } from '@/lib/publication-settings'
 import { RecommendationsContent } from './recommendations-content'
 
 // Force dynamic rendering to fetch fresh data
 export const dynamic = 'force-dynamic'
 
 export default async function RecommendationsPage() {
-  // Get domain from headers (Next.js 15 requires await)
-  const headersList = await headers()
-  const host = headersList.get('x-forwarded-host') || headersList.get('host') || 'aiaccountingdaily.com'
+  const { publicationId } = await resolvePublicationFromRequest()
 
-  // Get publication ID from domain
-  const publicationId = await getPublicationByDomain(host) || 'accounting'
-
-  // Fetch settings from publication_settings
   const settings = await getPublicationSettings(publicationId, [
     'logo_url',
-    'newsletter_name'
+    'newsletter_name',
   ])
 
   const logoUrl = settings.logo_url || '/logo.png'
@@ -24,7 +17,11 @@ export default async function RecommendationsPage() {
 
   return (
     <main className="min-h-[100dvh] bg-white px-4">
-      <RecommendationsContent logoUrl={logoUrl} newsletterName={newsletterName} />
+      <RecommendationsContent
+        logoUrl={logoUrl}
+        newsletterName={newsletterName}
+        publicationId={publicationId}
+      />
     </main>
   )
 }

--- a/src/app/website/subscribe/recommendations/recommendations-content.tsx
+++ b/src/app/website/subscribe/recommendations/recommendations-content.tsx
@@ -7,14 +7,15 @@ import { useRecommendations } from './useRecommendations'
 interface RecommendationsContentProps {
   logoUrl: string
   newsletterName: string
+  publicationId: string
 }
 
-export function RecommendationsContent({ logoUrl, newsletterName }: RecommendationsContentProps) {
+export function RecommendationsContent({ logoUrl, newsletterName, publicationId }: RecommendationsContentProps) {
   const {
     email, recommendations, selectedRefCodes,
     isLoading, isSubmitting, error, submitted,
     toggleSelection, goToInfo, handleSkip, handleSubscribe,
-  } = useRecommendations()
+  } = useRecommendations(publicationId)
 
   // Missing email state
   if (!email || !email.includes('@')) {

--- a/src/app/website/subscribe/recommendations/useRecommendations.ts
+++ b/src/app/website/subscribe/recommendations/useRecommendations.ts
@@ -12,6 +12,7 @@ const SOURCE = 'recs_page' as const
 async function trackEvent(
   eventType: SparkLoopPopupEventType,
   email: string,
+  publicationId: string | undefined,
   data?: {
     refCodes?: string[]
     recommendationCount?: number
@@ -32,6 +33,7 @@ async function trackEvent(
         error_message: data?.errorMessage,
         timestamp: new Date().toISOString(),
         source: SOURCE,
+        publication_id: publicationId,
       }),
     })
   } catch (e) {
@@ -39,7 +41,7 @@ async function trackEvent(
   }
 }
 
-export function useRecommendations() {
+export function useRecommendations(publicationId: string) {
   const searchParams = useSearchParams()
   const router = useRouter()
 
@@ -74,14 +76,16 @@ export function useRecommendations() {
       setError(null)
 
       try {
-        const response = await fetch('/api/sparkloop/recommendations?offset=5&limit=3')
+        const params = new URLSearchParams({ offset: '5', limit: '3' })
+        if (publicationId) params.set('publicationId', publicationId)
+        const response = await fetch(`/api/sparkloop/recommendations?${params.toString()}`)
         const data = await response.json()
 
         if (data.recommendations && data.recommendations.length > 0) {
           setRecommendations(data.recommendations)
           setSelectedRefCodes(new Set(data.preSelectedRefCodes || []))
 
-          await trackEvent('popup_opened', email, {
+          await trackEvent('popup_opened', email, publicationId, {
             refCodes: data.recommendations.map((r: SparkLoopRecommendation) => r.ref_code),
             recommendationCount: data.recommendations.length,
             selectedCount: data.preSelectedRefCodes?.length || 0,
@@ -96,7 +100,7 @@ export function useRecommendations() {
     }
 
     fetchRecs()
-  }, [email])
+  }, [email, publicationId])
 
   const toggleSelection = useCallback((refCode: string) => {
     setSelectedRefCodes((prev) => {
@@ -117,13 +121,13 @@ export function useRecommendations() {
 
   const handleSkip = useCallback(async () => {
     if (email && email.includes('@')) {
-      await trackEvent('popup_skipped', email, {
+      await trackEvent('popup_skipped', email, publicationId, {
         recommendationCount: recommendations.length,
         selectedCount: selectedRefCodes.size,
       })
     }
     goToInfo()
-  }, [email, recommendations.length, selectedRefCodes.size, goToInfo])
+  }, [email, recommendations.length, selectedRefCodes.size, goToInfo, publicationId])
 
   const handleSubscribe = useCallback(async () => {
     if (selectedRefCodes.size === 0) {
@@ -144,6 +148,7 @@ export function useRecommendations() {
           email,
           refCodes,
           source: SOURCE,
+          publicationId,
         }),
       })
 
@@ -153,14 +158,14 @@ export function useRecommendations() {
         const allShownRefCodes = recommendations.map(r => r.ref_code)
         const notSelectedRefCodes = allShownRefCodes.filter(code => !selectedRefCodes.has(code))
 
-        await trackEvent('subscriptions_success', email, {
+        await trackEvent('subscriptions_success', email, publicationId, {
           refCodes,
           selectedCount: refCodes.length,
           recommendationCount: recommendations.length,
         })
 
         if (notSelectedRefCodes.length > 0) {
-          await trackEvent('recommendations_not_selected', email, {
+          await trackEvent('recommendations_not_selected', email, publicationId, {
             refCodes: notSelectedRefCodes,
             selectedCount: notSelectedRefCodes.length,
           })
@@ -173,14 +178,14 @@ export function useRecommendations() {
       }
     } catch (err) {
       console.error('[SparkLoop RecsPage] Subscribe failed:', err)
-      await trackEvent('subscriptions_failed', email, {
+      await trackEvent('subscriptions_failed', email, publicationId, {
         errorMessage: err instanceof Error ? err.message : 'Unknown error',
       })
       setError('Failed to subscribe. Please try again.')
     } finally {
       setIsSubmitting(false)
     }
-  }, [selectedRefCodes, email, recommendations, goToInfo, handleSkip])
+  }, [selectedRefCodes, email, recommendations, goToInfo, handleSkip, publicationId])
 
   return {
     email,

--- a/src/components/useSparkLoopModal.ts
+++ b/src/components/useSparkLoopModal.ts
@@ -12,6 +12,7 @@ import type {
 async function trackEvent(
   eventType: SparkLoopPopupEventType,
   email: string,
+  publicationId: string | undefined,
   data?: {
     refCodes?: string[]
     recommendationCount?: number
@@ -31,6 +32,7 @@ async function trackEvent(
         selected_count: data?.selectedCount,
         error_message: data?.errorMessage,
         timestamp: new Date().toISOString(),
+        publication_id: publicationId,
       }),
     })
   } catch (e) {
@@ -79,7 +81,7 @@ export function useSparkLoopModal({
           setRecommendations(data.recommendations)
           setSelectedRefCodes(new Set(data.preSelectedRefCodes || []))
 
-          await trackEvent('popup_opened', subscriberEmail, {
+          await trackEvent('popup_opened', subscriberEmail, publicationId, {
             refCodes: data.recommendations.map((r: SparkLoopRecommendation) => r.ref_code),
             recommendationCount: data.recommendations.length,
             selectedCount: data.preSelectedRefCodes?.length || 0,
@@ -113,13 +115,13 @@ export function useSparkLoopModal({
   }, [])
 
   const handleSkip = useCallback(async () => {
-    await trackEvent('popup_skipped', subscriberEmail, {
+    await trackEvent('popup_skipped', subscriberEmail, publicationId, {
       recommendationCount: recommendations.length,
       selectedCount: selectedRefCodes.size,
     })
     onClose()
     onSubscribeComplete()
-  }, [subscriberEmail, recommendations.length, selectedRefCodes.size, onClose, onSubscribeComplete])
+  }, [subscriberEmail, recommendations.length, selectedRefCodes.size, onClose, onSubscribeComplete, publicationId])
 
   const handleSubscribe = useCallback(async () => {
     if (selectedRefCodes.size === 0) {
@@ -148,14 +150,14 @@ export function useSparkLoopModal({
         const allShownRefCodes = recommendations.map(r => r.ref_code)
         const notSelectedRefCodes = allShownRefCodes.filter(code => !selectedRefCodes.has(code))
 
-        await trackEvent('subscriptions_success', subscriberEmail, {
+        await trackEvent('subscriptions_success', subscriberEmail, publicationId, {
           refCodes,
           selectedCount: refCodes.length,
           recommendationCount: recommendations.length,
         })
 
         if (notSelectedRefCodes.length > 0) {
-          await trackEvent('recommendations_not_selected', subscriberEmail, {
+          await trackEvent('recommendations_not_selected', subscriberEmail, publicationId, {
             refCodes: notSelectedRefCodes,
             selectedCount: notSelectedRefCodes.length,
           })
@@ -168,14 +170,14 @@ export function useSparkLoopModal({
       }
     } catch (err) {
       console.error('[SparkLoop] Subscribe failed:', err)
-      await trackEvent('subscriptions_failed', subscriberEmail, {
+      await trackEvent('subscriptions_failed', subscriberEmail, publicationId, {
         errorMessage: err instanceof Error ? err.message : 'Unknown error',
       })
       setError('Failed to subscribe. Please try again or skip.')
     } finally {
       setIsSubmitting(false)
     }
-  }, [selectedRefCodes, subscriberEmail, onClose, onSubscribeComplete, handleSkip])
+  }, [selectedRefCodes, subscriberEmail, onClose, onSubscribeComplete, handleSkip, publicationId])
 
   return {
     isLoading,


### PR DESCRIPTION
## Summary

- **Bug**: On **traderleak.com**, the `/subscribe/recommendations` page was displaying AI Accounting Daily's recommendations instead of Trader Leak's, and subscribe/track events were attributed to AI Accounting's `publication_id`.
- **Root cause**: `useRecommendations.ts` called `/api/sparkloop/recommendations`, `/api/sparkloop/subscribe`, and `/api/sparkloop/track` without a `publicationId`. Each of those endpoints falls back to `process.env.PUBLICATION_ID` (AI Accounting) when the caller doesn't provide one.
- **Fix**: Resolve the publication from the request domain in the server component, pass it down to the client hook, and include it in every SparkLoop API call.

## Changes

- `src/app/website/subscribe/recommendations/page.tsx` — use `resolvePublicationFromRequest()` (the canonical helper), pass `publicationId` to `RecommendationsContent`. Removes the bogus `|| 'accounting'` string fallback.
- `src/app/website/subscribe/recommendations/recommendations-content.tsx` — accept `publicationId` prop and forward it to the hook.
- `src/app/website/subscribe/recommendations/useRecommendations.ts` — `useRecommendations(publicationId)` now threads the id into:
  - `GET /api/sparkloop/recommendations?publicationId=…`
  - `POST /api/sparkloop/subscribe` body
  - `POST /api/sparkloop/track` body (via the `trackEvent` helper, which now takes `publicationId` as its 3rd arg)
- `src/components/useSparkLoopModal.ts` — `trackEvent` helper also accepts `publicationId` and sends it. (The modal's own fetch/subscribe already passed `publicationId`; only its track events were missing it.)
- `src/app/api/sparkloop/track/route.ts` — schema accepts optional `publication_id`; handler prefers the client-supplied id over the env default.

## Behavior after merge

- `traderleak.com/subscribe/recommendations` will now fetch Trader Leak's recommendations (Trader Leak currently has 3 recs, all `awaiting_approval`, so the page will show the existing "No additional recommendations available right now" empty state until partners approve).
- All `sparkloop_events` track rows from the recs page will be attributed to the correct publication going forward.
- Subscribe submissions from the recs page will land in the correct publication's `sparkloop_referrals`.

## Test plan

- [x] Type-check passes
- [ ] After deploy: load `traderleak.com/subscribe/recommendations` — verify it shows the empty state (not AI Accounting's recs) until partners approve
- [ ] After deploy: check recent `sparkloop_events` for Trader Leak's publication_id — track events should appear there

## Follow-up (not in this PR)

- Trader Leak needs SparkLoop partner programs approved (all 3 current recs are `awaiting_approval` on SparkLoop's side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API endpoint now accepts optional client-supplied publication ID in event payloads.
  * Publication ID is consistently maintained throughout recommendation workflows and API communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->