### PR TITLE
Render AdSense, Meta Pixel, and CMP scripts in SSR HTML

### DIFF
--- a/src/app/website/layout.tsx
+++ b/src/app/website/layout.tsx
@@ -1,7 +1,6 @@
 import type React from "react"
 import type { Metadata } from "next"
 import "./globals.css"
-import Script from "next/script"
 import { resolvePublicationFromRequest } from '@/lib/publication-settings'
 
 export const metadata: Metadata = {
@@ -57,10 +56,11 @@ export default async function WebsiteLayout({
 
   return (
     <>
-      {/* Consent Mode v2 defaults — must run before any Google/ad scripts */}
-      <Script
-        id="consent-mode-defaults"
-        strategy="beforeInteractive"
+      {/* Consent Mode v2 defaults — must run before any Google/ad scripts.
+          Raw <script> tags (not Next.js <Script>) so they land in the SSR HTML
+          — AdSense / Meta Pixel verification crawlers read the initial HTML and
+          miss scripts that are only JS-injected post-hydration. */}
+      <script
         dangerouslySetInnerHTML={{
           __html: `
             window.dataLayer = window.dataLayer || [];
@@ -77,9 +77,7 @@ export default async function WebsiteLayout({
       />
 
       {/* Hide default CCPA bar; we show a footer link that opens the opt-out dialog (Privacy & Messaging API) */}
-      <Script
-        id="google-fc-override-dns-link"
-        strategy="beforeInteractive"
+      <script
         dangerouslySetInnerHTML={{
           __html: `
             window.googlefc = window.googlefc || {};
@@ -90,26 +88,21 @@ export default async function WebsiteLayout({
       />
 
       {/* Google Funding Choices — loads the CMP consent banner configured in AdSense Privacy & Messaging */}
-      <Script
-        id="google-fc"
-        strategy="beforeInteractive"
+      <script
+        async
         src="https://fundingchoicesmessages.google.com/i/pub-1173459595320946?ers=1"
-        nonce=""
       />
-      <Script
-        id="google-fc-init"
-        strategy="beforeInteractive"
+      <script
         dangerouslySetInnerHTML={{
           __html: `(function() {function signalGooglefcPresent(){if(!window.frames['googlefcPresent']){if(document.body){var i=document.createElement('iframe');i.style='width:0;height:0;border:none;z-index:-1000;left:-1000px;top:-1000px;';i.style.display='none';i.name='googlefcPresent';document.body.appendChild(i);}else{setTimeout(signalGooglefcPresent,0);}}}signalGooglefcPresent();})();`,
         }}
       />
 
       {/* Google AdSense */}
-      <Script
+      <script
         async
         src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1173459595320946"
         crossOrigin="anonymous"
-        strategy="afterInteractive"
       />
 
       {/* JSON-LD Structured Data */}
@@ -125,9 +118,7 @@ export default async function WebsiteLayout({
       {/* Facebook Pixel — respects Consent Mode; loads SDK but defers tracking until consent granted */}
       {pixelId && (
         <>
-          <Script
-            id="facebook-pixel"
-            strategy="afterInteractive"
+          <script
             dangerouslySetInnerHTML={{
               __html: `
                 !function(f,b,e,v,n,t,s)


### PR DESCRIPTION
## Summary

- **Bug**: AdSense verification reports the pixel/AdSense script as missing on new domains (traderleak.com). Inspecting the served HTML shows only a `<link rel=\"preload\">` for the AdSense script — no actual `<script>` tag.
- **Root cause**: \`src/app/website/layout.tsx\` wrapped six scripts in Next.js's \`<Script>\` component (\`strategy=\"beforeInteractive\"\` and \`\"afterInteractive\"\`). Both strategies inject the `<script>` tag via client JS after hydration, so it never appears in the SSR HTML. AdSense and Meta Pixel verification crawlers read raw HTML and don't see the tag.
- **Fix**: Swap \`<Script>\` for plain JSX \`<script>\` in the six affected tags so they render as static tags in the document.

## What changed

`src/app/website/layout.tsx` — converted six \`<Script>\` tags to raw \`<script>\` tags:
1. Consent Mode v2 defaults (inline)
2. Google Funding Choices DNS-link override (inline)
3. Google Funding Choices CMP loader (external, \`async\`)
4. googlefc presence-signal iframe (inline)
5. Google AdSense loader (external, \`async\` + \`crossOrigin=\"anonymous\"\`)
6. Meta Pixel init (inline, guarded by \`pixelId\`)

Behavior is unchanged — externals keep \`async\`, inlines execute synchronously in document order — but the tags now appear in the SSR HTML where verification crawlers look.

## Why AI Accounting worked but Trader Leak didn't

AdSense/Meta verification runs once per domain. AI Accounting's domain was presumably verified under an earlier code path (or Google re-crawled it with JS enabled). Trader Leak is a newer domain, and AdSense's initial verification only sees raw HTML.

## Test plan

- [x] Type-check passes
- [ ] After deploy: \`curl -sL https://www.traderleak.com/ | grep -o '<script[^>]*adsbygoogle[^>]*>'\` should return the \`<script async src=\"...adsbygoogle.js...\" crossorigin=\"anonymous\">\` tag
- [ ] After deploy: re-run AdSense site verification for traderleak.com
- [ ] After deploy: verify Meta Pixel Helper sees the pixel on consent grant
- [ ] Sanity-check AI Accounting still works (same layout, same domains registered in AdSense)

🤖 Generated with [Claude Code](https://claude.com/claude-code)