### PR TITLE
Staging release: archive cover image, SparkLoop fixes, RSS (Sent) feed, scoring improvements

### DIFF
--- a/docs/superpowers/plans/2026-04-23-analytics-pr1-foundation.md
+++ b/docs/superpowers/plans/2026-04-23-analytics-pr1-foundation.md
@@ -1,0 +1,1645 @@
+# Analytics Metrics Standardization — PR 1 (Foundation Library + Glossary) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the typed metrics foundation — pure formulas, a bot/IP filter policy, a DAL for analytics reads, and the metrics glossary doc. No consumers yet; this is pure addition.
+
+**Architecture:** Split by concern — pure formulas in `src/lib/analytics/metrics.ts` (no DB imports), DAL reads in `src/lib/dal/analytics.ts`, bot policy in `src/lib/analytics/bot-policy.ts`. Formulas are trivially unit-testable; DAL follows existing `issues.ts` patterns (explicit column lists, `publicationId` filtered, errors logged never thrown).
+
+**Tech Stack:** TypeScript, Vitest, Supabase JS client (via `supabaseAdmin`), pino logger (via `createLogger`).
+
+**Parent spec:** `docs/superpowers/specs/2026-04-23-analytics-metrics-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `src/lib/analytics/types.ts` — Type definitions (`DeliveryCounts`, `IssueEngagement`, `ModuleEngagement`, `LinkClickRow`, `ExcludedIpRow`).
+- `src/lib/analytics/metrics.ts` — Pure formula functions.
+- `src/lib/analytics/bot-policy.ts` — `ExcludedIpSet` class + `isClickCountable` + `loadExcludedIps`.
+- `src/lib/analytics/index.ts` — Barrel export.
+- `src/lib/analytics/__tests__/metrics.test.ts` — Formula unit tests.
+- `src/lib/analytics/__tests__/bot-policy.test.ts` — Policy tests (mocked Supabase).
+- `src/lib/dal/analytics.ts` — DAL functions.
+- `src/lib/dal/__tests__/analytics.test.ts` — DAL tests (mocked Supabase following `issues.test.ts` pattern).
+- `docs/operations/metrics.md` — Metrics glossary governance doc.
+
+**Modify:**
+- `src/lib/dal/index.ts` — Add analytics barrel export.
+
+---
+
+## Schema Reference (observed from migrations)
+
+**`link_clicks`** columns used by this PR:
+`id, publication_id, issue_id, issue_date, subscriber_email, subscriber_id, link_url, link_section, clicked_at, user_agent, ip_address, is_bot_ua, bot_ua_reason`
+
+**`excluded_ips`** columns used:
+`id, publication_id, ip_address, is_range, cidr_prefix, exclusion_source`
+
+**`email_metrics`** columns used:
+`id, issue_id, sent_count, delivered_count, opened_count, clicked_count, bounced_count, unsubscribed_count, open_rate, click_rate, bounce_rate, unsubscribe_rate, imported_at` — no `publication_id`; ownership verified via join on `publication_issues`.
+
+**`publication_issues`** is the issues table (per `src/lib/dal/issues.ts`).
+
+---
+
+## Task 1: Scaffolding — types file
+
+**Files:**
+- Create: `src/lib/analytics/types.ts`
+
+- [ ] **Step 1: Create `src/lib/analytics/types.ts`**
+
+```typescript
+/**
+ * Type definitions for the analytics metrics library.
+ * Shared between pure formulas (metrics.ts), bot policy (bot-policy.ts),
+ * and the DAL (src/lib/dal/analytics.ts).
+ */
+
+/**
+ * Email delivery counts sourced from email_metrics.
+ * Denominator for issue-level rates.
+ */
+export interface DeliveryCounts {
+  issueId: string
+  sentCount: number
+  deliveredCount: number
+  openedCount: number
+  clickedCount: number
+  bouncedCount: number
+  unsubscribedCount: number
+  /** ESP-reported open rate; displayed separately from computed open rate. */
+  espOpenRate: number | null
+  /** ESP-reported click rate; displayed separately from computed click rate. */
+  espClickRate: number | null
+  /** Timestamp of last sync from ESP. null for legacy rows. */
+  lastSyncedAt: string | null
+}
+
+/**
+ * Aggregated click/engagement metrics for a single issue.
+ * Always derived from link_clicks; bot/IP filter applied per excludeBots flag.
+ */
+export interface IssueEngagement {
+  issueId: string
+  publicationId: string
+  totalClicks: number
+  uniqueClickers: number
+  delivery: DeliveryCounts
+}
+
+/**
+ * Aggregated click metrics for a single module within an issue.
+ * moduleRecipients defaults to delivery.deliveredCount for non-segmented modules.
+ */
+export interface ModuleEngagement {
+  moduleId: string
+  issueId: string
+  publicationId: string
+  totalClicks: number
+  uniqueClickers: number
+  moduleRecipients: number
+}
+
+/** Columns on link_clicks used by bot policy and DAL reads. */
+export interface LinkClickRow {
+  id: string
+  publication_id: string
+  issue_id: string | null
+  subscriber_email: string
+  link_url: string
+  link_section: string
+  ip_address: string | null
+  is_bot_ua: boolean | null
+}
+
+/** Columns on excluded_ips used by bot policy. */
+export interface ExcludedIpRow {
+  ip_address: string
+  is_range: boolean
+  cidr_prefix: number | null
+}
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `npm run type-check`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/analytics/types.ts
+git commit -m "feat(analytics): add shared type definitions"
+```
+
+---
+
+## Task 2: Pure formulas — `metrics.ts`
+
+**Files:**
+- Create: `src/lib/analytics/metrics.ts`
+- Create: `src/lib/analytics/__tests__/metrics.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `src/lib/analytics/__tests__/metrics.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import {
+  computeIssueCTR,
+  computeModuleCTR,
+  computeIssueOpenRate,
+  computePollResponseRate,
+  computeFeedbackResponseRate,
+  computeBounceRate,
+  computeUnsubscribeRate,
+} from '../metrics'
+
+describe('computeIssueCTR', () => {
+  it('returns unique clickers divided by delivered count', () => {
+    expect(computeIssueCTR({ uniqueClickers: 50, deliveredCount: 1000 })).toBe(0.05)
+  })
+
+  it('returns 0 when deliveredCount is 0', () => {
+    expect(computeIssueCTR({ uniqueClickers: 50, deliveredCount: 0 })).toBe(0)
+  })
+
+  it('returns 0 when uniqueClickers is 0', () => {
+    expect(computeIssueCTR({ uniqueClickers: 0, deliveredCount: 1000 })).toBe(0)
+  })
+
+  it('throws if inputs are negative', () => {
+    expect(() => computeIssueCTR({ uniqueClickers: -1, deliveredCount: 100 })).toThrow()
+    expect(() => computeIssueCTR({ uniqueClickers: 1, deliveredCount: -1 })).toThrow()
+  })
+
+  it('clamps to 1.0 if unique clickers exceed delivered (data anomaly)', () => {
+    expect(computeIssueCTR({ uniqueClickers: 1500, deliveredCount: 1000 })).toBe(1)
+  })
+})
+
+describe('computeModuleCTR', () => {
+  it('returns unique clickers divided by module recipients', () => {
+    expect(computeModuleCTR({ uniqueClickers: 30, moduleRecipients: 600 })).toBe(0.05)
+  })
+
+  it('returns 0 when moduleRecipients is 0', () => {
+    expect(computeModuleCTR({ uniqueClickers: 30, moduleRecipients: 0 })).toBe(0)
+  })
+
+  it('throws on negative inputs', () => {
+    expect(() => computeModuleCTR({ uniqueClickers: -1, moduleRecipients: 100 })).toThrow()
+  })
+})
+
+describe('computeIssueOpenRate', () => {
+  it('returns unique openers divided by delivered count', () => {
+    expect(computeIssueOpenRate({ uniqueOpeners: 500, deliveredCount: 1000 })).toBe(0.5)
+  })
+
+  it('returns 0 when deliveredCount is 0', () => {
+    expect(computeIssueOpenRate({ uniqueOpeners: 500, deliveredCount: 0 })).toBe(0)
+  })
+
+  it('clamps to 1.0 on data anomaly', () => {
+    expect(computeIssueOpenRate({ uniqueOpeners: 1500, deliveredCount: 1000 })).toBe(1)
+  })
+})
+
+describe('computePollResponseRate', () => {
+  it('returns unique respondents divided by delivered count', () => {
+    expect(computePollResponseRate({ uniqueRespondents: 100, deliveredCount: 1000 })).toBe(0.1)
+  })
+
+  it('returns 0 when deliveredCount is 0', () => {
+    expect(computePollResponseRate({ uniqueRespondents: 100, deliveredCount: 0 })).toBe(0)
+  })
+})
+
+describe('computeFeedbackResponseRate', () => {
+  it('returns unique respondents divided by delivered count', () => {
+    expect(computeFeedbackResponseRate({ uniqueRespondents: 200, deliveredCount: 1000 })).toBe(0.2)
+  })
+
+  it('returns 0 when deliveredCount is 0', () => {
+    expect(computeFeedbackResponseRate({ uniqueRespondents: 200, deliveredCount: 0 })).toBe(0)
+  })
+})
+
+describe('computeBounceRate', () => {
+  it('returns bounced count divided by sent count', () => {
+    expect(computeBounceRate({ bouncedCount: 20, sentCount: 1000 })).toBe(0.02)
+  })
+
+  it('returns 0 when sentCount is 0', () => {
+    expect(computeBounceRate({ bouncedCount: 20, sentCount: 0 })).toBe(0)
+  })
+})
+
+describe('computeUnsubscribeRate', () => {
+  it('returns unsubscribed count divided by delivered count', () => {
+    expect(computeUnsubscribeRate({ unsubscribedCount: 5, deliveredCount: 1000 })).toBe(0.005)
+  })
+
+  it('returns 0 when deliveredCount is 0', () => {
+    expect(computeUnsubscribeRate({ unsubscribedCount: 5, deliveredCount: 0 })).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run: `npx vitest run src/lib/analytics/__tests__/metrics.test.ts`
+Expected: all tests fail with "Cannot find module '../metrics'".
+
+- [ ] **Step 3: Implement `metrics.ts`**
+
+Create `src/lib/analytics/metrics.ts`:
+
+```typescript
+/**
+ * Pure metric formulas for the analytics layer.
+ *
+ * All functions are synchronous and dependency-free. Any DB access
+ * belongs in src/lib/dal/analytics.ts, which feeds typed rows into
+ * these formulas.
+ *
+ * Rules:
+ * - Division-by-zero returns 0 (so empty-issue dashboards render cleanly).
+ * - Negative inputs throw (signals a DAL bug; fail loud in dev/test).
+ * - Rates clamp to [0, 1] on data anomalies (e.g., vendor double-counting).
+ */
+
+function clampRate(numerator: number, denominator: number): number {
+  if (numerator < 0 || denominator < 0) {
+    throw new RangeError(`Metric inputs must be non-negative: ${numerator}/${denominator}`)
+  }
+  if (denominator === 0) return 0
+  const rate = numerator / denominator
+  return rate > 1 ? 1 : rate
+}
+
+export function computeIssueCTR(args: {
+  uniqueClickers: number
+  deliveredCount: number
+}): number {
+  return clampRate(args.uniqueClickers, args.deliveredCount)
+}
+
+export function computeModuleCTR(args: {
+  uniqueClickers: number
+  moduleRecipients: number
+}): number {
+  return clampRate(args.uniqueClickers, args.moduleRecipients)
+}
+
+export function computeIssueOpenRate(args: {
+  uniqueOpeners: number
+  deliveredCount: number
+}): number {
+  return clampRate(args.uniqueOpeners, args.deliveredCount)
+}
+
+export function computePollResponseRate(args: {
+  uniqueRespondents: number
+  deliveredCount: number
+}): number {
+  return clampRate(args.uniqueRespondents, args.deliveredCount)
+}
+
+export function computeFeedbackResponseRate(args: {
+  uniqueRespondents: number
+  deliveredCount: number
+}): number {
+  return clampRate(args.uniqueRespondents, args.deliveredCount)
+}
+
+export function computeBounceRate(args: {
+  bouncedCount: number
+  sentCount: number
+}): number {
+  return clampRate(args.bouncedCount, args.sentCount)
+}
+
+export function computeUnsubscribeRate(args: {
+  unsubscribedCount: number
+  deliveredCount: number
+}): number {
+  return clampRate(args.unsubscribedCount, args.deliveredCount)
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `npx vitest run src/lib/analytics/__tests__/metrics.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/analytics/metrics.ts src/lib/analytics/__tests__/metrics.test.ts
+git commit -m "feat(analytics): add pure metric formulas with unit tests"
+```
+
+---
+
+## Task 3: Bot policy — `ExcludedIpSet` + `isClickCountable`
+
+**Files:**
+- Create: `src/lib/analytics/bot-policy.ts`
+- Create: `src/lib/analytics/__tests__/bot-policy.test.ts`
+
+- [ ] **Step 1: Write the failing test for `ExcludedIpSet` and `isClickCountable`**
+
+Create `src/lib/analytics/__tests__/bot-policy.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports that use them
+// ---------------------------------------------------------------------------
+const mockChain: Record<string, any> = {
+  select: vi.fn(function (this: any) { return mockChain }),
+  eq: vi.fn(function () { return mockChain }),
+}
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => mockChain),
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    correlationId: 'test-id',
+  })),
+}))
+
+import { ExcludedIpSet, isClickCountable, loadExcludedIps } from '../bot-policy'
+import type { LinkClickRow } from '../types'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockChain.select.mockReturnValue(mockChain)
+  mockChain.eq.mockReturnValue(mockChain)
+})
+
+describe('ExcludedIpSet', () => {
+  it('matches exact IPs', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '1.2.3.4', is_range: false, cidr_prefix: null },
+    ])
+    expect(set.has('1.2.3.4')).toBe(true)
+    expect(set.has('1.2.3.5')).toBe(false)
+  })
+
+  it('matches IPv4 CIDR ranges', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '10.0.0.0', is_range: true, cidr_prefix: 8 },
+    ])
+    expect(set.matchesCidr('10.1.2.3')).toBe(true)
+    expect(set.matchesCidr('11.1.2.3')).toBe(false)
+  })
+
+  it('handles null IP lookup gracefully', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '1.2.3.4', is_range: false, cidr_prefix: null },
+    ])
+    expect(set.has(null)).toBe(false)
+    expect(set.matchesCidr(null)).toBe(false)
+  })
+
+  it('is case-insensitive to IP casing (IPv6 safety)', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '2001:DB8::1', is_range: false, cidr_prefix: null },
+    ])
+    expect(set.has('2001:db8::1')).toBe(true)
+  })
+})
+
+describe('isClickCountable', () => {
+  const emptySet = new ExcludedIpSet([])
+
+  function row(overrides: Partial<LinkClickRow>): LinkClickRow {
+    return {
+      id: 'id-1',
+      publication_id: 'pub-1',
+      issue_id: 'issue-1',
+      subscriber_email: 'a@b.com',
+      link_url: 'https://example.com',
+      link_section: 'Articles',
+      ip_address: '1.1.1.1',
+      is_bot_ua: false,
+      ...overrides,
+    }
+  }
+
+  it('returns true for a normal human click', () => {
+    expect(isClickCountable(row({}), emptySet)).toBe(true)
+  })
+
+  it('returns false when is_bot_ua is true', () => {
+    expect(isClickCountable(row({ is_bot_ua: true }), emptySet)).toBe(false)
+  })
+
+  it('returns false when IP is in excluded set (exact match)', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '1.1.1.1', is_range: false, cidr_prefix: null },
+    ])
+    expect(isClickCountable(row({}), set)).toBe(false)
+  })
+
+  it('returns false when IP matches an excluded CIDR range', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '1.1.0.0', is_range: true, cidr_prefix: 16 },
+    ])
+    expect(isClickCountable(row({ ip_address: '1.1.5.200' }), set)).toBe(false)
+  })
+
+  it('treats null is_bot_ua as not-a-bot (historical rows)', () => {
+    expect(isClickCountable(row({ is_bot_ua: null }), emptySet)).toBe(true)
+  })
+})
+
+describe('loadExcludedIps', () => {
+  it('queries excluded_ips for the given publication and returns a populated set', async () => {
+    mockChain.eq.mockImplementationOnce(() => mockChain)
+    mockChain.eq.mockResolvedValueOnce({
+      data: [
+        { ip_address: '1.2.3.4', is_range: false, cidr_prefix: null },
+        { ip_address: '10.0.0.0', is_range: true, cidr_prefix: 8 },
+      ],
+      error: null,
+    })
+
+    const set = await loadExcludedIps('pub-1')
+
+    expect(set.has('1.2.3.4')).toBe(true)
+    expect(set.matchesCidr('10.5.5.5')).toBe(true)
+  })
+
+  it('returns empty set on DB error', async () => {
+    mockChain.eq.mockResolvedValueOnce({ data: null, error: { message: 'oops' } })
+
+    const set = await loadExcludedIps('pub-1')
+
+    expect(set.has('1.2.3.4')).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run: `npx vitest run src/lib/analytics/__tests__/bot-policy.test.ts`
+Expected: fail with "Cannot find module '../bot-policy'".
+
+- [ ] **Step 3: Implement `bot-policy.ts`**
+
+Create `src/lib/analytics/bot-policy.ts`:
+
+```typescript
+/**
+ * Bot and IP filter policy for click analytics.
+ *
+ * Single source of truth for "should this click count?".
+ * Called by every DAL read that returns link_clicks aggregates.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { createLogger } from '@/lib/logger'
+import type { LinkClickRow, ExcludedIpRow } from './types'
+
+const log = createLogger({ module: 'analytics:bot-policy' })
+
+/**
+ * In-memory index of a publication's excluded IPs.
+ * Supports exact-match lookup (has) and CIDR-range match (matchesCidr).
+ * Case-insensitive; handles null lookups.
+ */
+export class ExcludedIpSet {
+  private readonly exactIps: Set<string>
+  private readonly ranges: Array<{ cidr: string; prefix: number }>
+
+  constructor(rows: ExcludedIpRow[]) {
+    this.exactIps = new Set()
+    this.ranges = []
+    for (const row of rows) {
+      if (row.is_range && row.cidr_prefix !== null) {
+        this.ranges.push({ cidr: row.ip_address, prefix: row.cidr_prefix })
+      } else {
+        this.exactIps.add(row.ip_address.toLowerCase())
+      }
+    }
+  }
+
+  has(ip: string | null): boolean {
+    if (!ip) return false
+    return this.exactIps.has(ip.toLowerCase())
+  }
+
+  matchesCidr(ip: string | null): boolean {
+    if (!ip) return false
+    for (const range of this.ranges) {
+      if (ipInCidr(ip, range.cidr, range.prefix)) return true
+    }
+    return false
+  }
+}
+
+/** Pure function — does a click count toward metrics? */
+export function isClickCountable(
+  row: Pick<LinkClickRow, 'is_bot_ua' | 'ip_address'>,
+  excludedIps: ExcludedIpSet
+): boolean {
+  if (row.is_bot_ua === true) return false
+  if (excludedIps.has(row.ip_address)) return false
+  if (excludedIps.matchesCidr(row.ip_address)) return false
+  return true
+}
+
+/** Load excluded IPs for a publication. Returns empty set on error. */
+export async function loadExcludedIps(publicationId: string): Promise<ExcludedIpSet> {
+  const { data, error } = await supabaseAdmin
+    .from('excluded_ips')
+    .select('ip_address, is_range, cidr_prefix')
+    .eq('publication_id', publicationId)
+
+  if (error || !data) {
+    log.error('Failed to load excluded_ips', { error, publicationId })
+    return new ExcludedIpSet([])
+  }
+  return new ExcludedIpSet(data as ExcludedIpRow[])
+}
+
+// ---------------------------------------------------------------------------
+// CIDR helpers (IPv4 only; IPv6 CIDR not currently used by excluded_ips)
+// ---------------------------------------------------------------------------
+
+function ipInCidr(ip: string, cidr: string, prefix: number): boolean {
+  if (ip.includes(':') || cidr.includes(':')) {
+    return false // IPv6 not supported for CIDR match
+  }
+  const ipInt = ipv4ToInt(ip)
+  const cidrInt = ipv4ToInt(cidr)
+  if (ipInt === null || cidrInt === null) return false
+  if (prefix < 0 || prefix > 32) return false
+  const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0
+  return (ipInt & mask) === (cidrInt & mask)
+}
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  let out = 0
+  for (const part of parts) {
+    const n = Number(part)
+    if (!Number.isInteger(n) || n < 0 || n > 255) return null
+    out = (out << 8) | n
+  }
+  return out >>> 0
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `npx vitest run src/lib/analytics/__tests__/bot-policy.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/analytics/bot-policy.ts src/lib/analytics/__tests__/bot-policy.test.ts
+git commit -m "feat(analytics): add bot and IP filter policy"
+```
+
+---
+
+## Task 4: DAL — `getDeliveryCounts`
+
+**Files:**
+- Create: `src/lib/dal/analytics.ts`
+- Create: `src/lib/dal/__tests__/analytics.test.ts`
+
+- [ ] **Step 1: Write the failing DAL test file header + getDeliveryCounts tests**
+
+Create `src/lib/dal/__tests__/analytics.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that use them
+// ---------------------------------------------------------------------------
+const mockSingle = vi.fn()
+const mockChain: Record<string, any> = {
+  select: vi.fn(function () { return mockChain }),
+  eq: vi.fn(function () { return mockChain }),
+  is: vi.fn(function () { return mockChain }),
+  in: vi.fn(function () { return mockChain }),
+  not: vi.fn(function () { return mockChain }),
+  single: mockSingle,
+  maybeSingle: vi.fn(),
+  order: vi.fn(function () { return mockChain }),
+  limit: vi.fn(function () { return mockChain }),
+}
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => mockChain),
+    rpc: vi.fn(() => mockChain),
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    correlationId: 'test-id',
+  })),
+}))
+
+vi.mock('@/lib/analytics/bot-policy', () => ({
+  loadExcludedIps: vi.fn(async () => ({
+    has: () => false,
+    matchesCidr: () => false,
+  })),
+  isClickCountable: vi.fn(() => true),
+  ExcludedIpSet: class {
+    has() { return false }
+    matchesCidr() { return false }
+  },
+}))
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { getDeliveryCounts } from '../analytics'
+
+const PUB_ID = 'pub-test-123'
+const ISSUE_ID = 'issue-test-456'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getDeliveryCounts', () => {
+  it('returns delivery counts when the row exists and ownership matches', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        issue_id: ISSUE_ID,
+        sent_count: 1000,
+        delivered_count: 980,
+        opened_count: 500,
+        clicked_count: 50,
+        bounced_count: 20,
+        unsubscribed_count: 5,
+        open_rate: 0.51,
+        click_rate: 0.051,
+        imported_at: '2026-04-23T10:00:00Z',
+        publication_issues: { publication_id: PUB_ID },
+      },
+      error: null,
+    })
+
+    const result = await getDeliveryCounts({ issueId: ISSUE_ID, publicationId: PUB_ID })
+
+    expect(result).not.toBeNull()
+    expect(result!.deliveredCount).toBe(980)
+    expect(result!.sentCount).toBe(1000)
+    expect(result!.espClickRate).toBe(0.051)
+    expect(result!.lastSyncedAt).toBe('2026-04-23T10:00:00Z')
+  })
+
+  it('returns null when ownership does not match (no row)', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: null })
+
+    const result = await getDeliveryCounts({ issueId: ISSUE_ID, publicationId: 'other-pub' })
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null on DB error', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+
+    const result = await getDeliveryCounts({ issueId: ISSUE_ID, publicationId: PUB_ID })
+
+    expect(result).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run: `npx vitest run src/lib/dal/__tests__/analytics.test.ts`
+Expected: fail with "Cannot find module '../analytics'".
+
+- [ ] **Step 3: Implement `src/lib/dal/analytics.ts` skeleton + getDeliveryCounts**
+
+Create `src/lib/dal/analytics.ts`:
+
+```typescript
+/**
+ * Data Access Layer — Analytics Domain
+ *
+ * All reads that feed the analytics library go through here.
+ * Every method requires publicationId for multi-tenant isolation.
+ * Explicit column lists — no select('*').
+ * Errors are logged, never thrown — callers receive null/empty on failure.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { createLogger } from '@/lib/logger'
+import { loadExcludedIps, isClickCountable } from '@/lib/analytics/bot-policy'
+import type {
+  DeliveryCounts,
+  IssueEngagement,
+  ModuleEngagement,
+  LinkClickRow,
+} from '@/lib/analytics/types'
+
+const log = createLogger({ module: 'dal:analytics' })
+
+// Explicit column lists
+const EMAIL_METRICS_COLUMNS = `
+  issue_id,
+  sent_count, delivered_count, opened_count, clicked_count,
+  bounced_count, unsubscribed_count,
+  open_rate, click_rate,
+  imported_at
+` as const
+
+const LINK_CLICK_COLUMNS = `
+  id, publication_id, issue_id, subscriber_email,
+  link_url, link_section, ip_address, is_bot_ua
+` as const
+
+// ==================== READ OPERATIONS ====================
+
+/**
+ * Fetch delivery counts for an issue, verifying publication ownership
+ * via a join on publication_issues.
+ */
+export async function getDeliveryCounts(args: {
+  issueId: string
+  publicationId: string
+}): Promise<DeliveryCounts | null> {
+  const { issueId, publicationId } = args
+
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('email_metrics')
+      .select(`${EMAIL_METRICS_COLUMNS}, publication_issues!inner(publication_id)`)
+      .eq('issue_id', issueId)
+      .eq('publication_issues.publication_id', publicationId)
+      .single()
+
+    if (error || !data) {
+      if (error) log.error('getDeliveryCounts failed', { error, issueId, publicationId })
+      return null
+    }
+
+    return {
+      issueId: data.issue_id,
+      sentCount: data.sent_count ?? 0,
+      deliveredCount: data.delivered_count ?? 0,
+      openedCount: data.opened_count ?? 0,
+      clickedCount: data.clicked_count ?? 0,
+      bouncedCount: data.bounced_count ?? 0,
+      unsubscribedCount: data.unsubscribed_count ?? 0,
+      espOpenRate: data.open_rate,
+      espClickRate: data.click_rate,
+      lastSyncedAt: data.imported_at ?? null,
+    }
+  } catch (err) {
+    log.error('getDeliveryCounts threw', { err, issueId, publicationId })
+    return null
+  }
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `npx vitest run src/lib/dal/__tests__/analytics.test.ts -t getDeliveryCounts`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/dal/analytics.ts src/lib/dal/__tests__/analytics.test.ts
+git commit -m "feat(dal): add analytics DAL skeleton with getDeliveryCounts"
+```
+
+---
+
+## Task 5: DAL — `getUniqueClickers`
+
+**Files:**
+- Modify: `src/lib/dal/analytics.ts`
+- Modify: `src/lib/dal/__tests__/analytics.test.ts`
+
+- [ ] **Step 1: Add failing tests for getUniqueClickers**
+
+Append to `src/lib/dal/__tests__/analytics.test.ts` (inside the top-level imports, add `getUniqueClickers` to the import):
+
+```typescript
+// Update the existing import near top of file:
+import { getDeliveryCounts, getUniqueClickers } from '../analytics'
+```
+
+Then append these describe blocks at the end of the file:
+
+```typescript
+describe('getUniqueClickers', () => {
+  it('counts unique subscriber_email across countable clicks', async () => {
+    // Mock chain returns rows after the final filter call
+    const rows = [
+      { id: '1', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.1', is_bot_ua: false },
+      { id: '2', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'b@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.2', is_bot_ua: false },
+      { id: '3', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.1', is_bot_ua: false },
+    ]
+    // Mock the terminal call: the fluent chain ends with a thenable.
+    ;(mockChain.eq as any).mockImplementation(function () { return mockChain })
+    ;(mockChain.is as any).mockImplementation(function () { return mockChain })
+    // Make the final .is() resolve to data when awaited
+    const finalResolved = Promise.resolve({ data: rows, error: null })
+    ;(mockChain.is as any).mockReturnValueOnce(finalResolved)
+
+    const count = await getUniqueClickers({
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      excludeBots: true,
+    })
+
+    expect(count).toBe(2)
+  })
+
+  it('returns 0 on DB error', async () => {
+    ;(mockChain.is as any).mockReturnValueOnce(
+      Promise.resolve({ data: null, error: { message: 'oops' } })
+    )
+
+    const count = await getUniqueClickers({
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      excludeBots: true,
+    })
+
+    expect(count).toBe(0)
+  })
+
+  it('returns 0 when no rows', async () => {
+    ;(mockChain.is as any).mockReturnValueOnce(
+      Promise.resolve({ data: [], error: null })
+    )
+
+    const count = await getUniqueClickers({
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      excludeBots: true,
+    })
+
+    expect(count).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run: `npx vitest run src/lib/dal/__tests__/analytics.test.ts -t getUniqueClickers`
+Expected: fail because `getUniqueClickers` is not exported.
+
+- [ ] **Step 3: Implement getUniqueClickers**
+
+Append to `src/lib/dal/analytics.ts`:
+
+```typescript
+/**
+ * Count unique clickers for an issue (optionally filtered to a single link).
+ * Applies bot and IP filtering in SQL where possible; CIDR matches applied in-app.
+ *
+ * "Unique clicker" = distinct subscriber_email for rows passing isClickCountable.
+ */
+export async function getUniqueClickers(args: {
+  issueId: string
+  publicationId: string
+  linkUrl?: string
+  excludeBots?: boolean
+}): Promise<number> {
+  const { issueId, publicationId, linkUrl, excludeBots = true } = args
+
+  try {
+    let query = supabaseAdmin
+      .from('link_clicks')
+      .select(LINK_CLICK_COLUMNS)
+      .eq('publication_id', publicationId)
+      .eq('issue_id', issueId)
+
+    if (linkUrl) query = query.eq('link_url', linkUrl)
+
+    // SQL-level: exclude is_bot_ua = true rows when excludeBots is on.
+    if (excludeBots) query = query.is('is_bot_ua', false)
+
+    const { data, error } = await query
+
+    if (error || !data) {
+      if (error) log.error('getUniqueClickers failed', { error, issueId, publicationId })
+      return 0
+    }
+
+    if (!excludeBots) {
+      return countUniqueEmails(data as LinkClickRow[])
+    }
+
+    // Apply in-app IP + CIDR filter, then count uniques.
+    const excludedIps = await loadExcludedIps(publicationId)
+    const countable = (data as LinkClickRow[]).filter((row) =>
+      isClickCountable(row, excludedIps)
+    )
+    return countUniqueEmails(countable)
+  } catch (err) {
+    log.error('getUniqueClickers threw', { err, issueId, publicationId })
+    return 0
+  }
+}
+
+function countUniqueEmails(rows: LinkClickRow[]): number {
+  const set = new Set<string>()
+  for (const row of rows) set.add(row.subscriber_email.toLowerCase())
+  return set.size
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `npx vitest run src/lib/dal/__tests__/analytics.test.ts`
+Expected: all existing + new tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/dal/analytics.ts src/lib/dal/__tests__/analytics.test.ts
+git commit -m "feat(dal): add getUniqueClickers with bot/IP filtering"
+```
+
+---
+
+## Task 6: DAL — `getIssueEngagement` (composes getDeliveryCounts + getUniqueClickers + total count)
+
+**Files:**
+- Modify: `src/lib/dal/analytics.ts`
+- Modify: `src/lib/dal/__tests__/analytics.test.ts`
+
+- [ ] **Step 1: Add failing test for getIssueEngagement**
+
+Update the import in `src/lib/dal/__tests__/analytics.test.ts`:
+
+```typescript
+import { getDeliveryCounts, getUniqueClickers, getIssueEngagement } from '../analytics'
+```
+
+Append this describe block at the end of the file:
+
+```typescript
+describe('getIssueEngagement', () => {
+  it('returns null when delivery counts cannot be loaded', async () => {
+    // First call (delivery): returns no row
+    mockSingle.mockResolvedValueOnce({ data: null, error: null })
+
+    const result = await getIssueEngagement({
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      excludeBots: true,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('returns composed engagement with delivery + totals + uniques', async () => {
+    // Delivery counts call
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        issue_id: ISSUE_ID,
+        sent_count: 1000,
+        delivered_count: 980,
+        opened_count: 500,
+        clicked_count: 50,
+        bounced_count: 20,
+        unsubscribed_count: 5,
+        open_rate: 0.51,
+        click_rate: 0.051,
+        imported_at: '2026-04-23T10:00:00Z',
+        publication_issues: { publication_id: PUB_ID },
+      },
+      error: null,
+    })
+
+    // Two subsequent fluent-chain resolutions for total + unique queries.
+    const rows = [
+      { id: '1', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.1', is_bot_ua: false },
+      { id: '2', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.1', is_bot_ua: false },
+      { id: '3', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'b@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.2', is_bot_ua: false },
+    ]
+    ;(mockChain.is as any)
+      .mockReturnValueOnce(Promise.resolve({ data: rows, error: null }))
+      .mockReturnValueOnce(Promise.resolve({ data: rows, error: null }))
+
+    const result = await getIssueEngagement({
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      excludeBots: true,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.totalClicks).toBe(3)
+    expect(result!.uniqueClickers).toBe(2)
+    expect(result!.delivery.deliveredCount).toBe(980)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run: `npx vitest run src/lib/dal/__tests__/analytics.test.ts -t getIssueEngagement`
+Expected: fail — not exported.
+
+- [ ] **Step 3: Implement getIssueEngagement + getTotalClicks helper**
+
+Append to `src/lib/dal/analytics.ts`:
+
+```typescript
+/**
+ * Total raw click count for an issue (pre-dedup). Bot/IP filter applied
+ * when excludeBots is true; no uniqueness reduction.
+ */
+async function getTotalClicks(args: {
+  issueId: string
+  publicationId: string
+  excludeBots: boolean
+}): Promise<number> {
+  const { issueId, publicationId, excludeBots } = args
+
+  try {
+    let query = supabaseAdmin
+      .from('link_clicks')
+      .select(LINK_CLICK_COLUMNS)
+      .eq('publication_id', publicationId)
+      .eq('issue_id', issueId)
+
+    if (excludeBots) query = query.is('is_bot_ua', false)
+
+    const { data, error } = await query
+    if (error || !data) {
+      if (error) log.error('getTotalClicks failed', { error, issueId, publicationId })
+      return 0
+    }
+
+    if (!excludeBots) return data.length
+
+    const excludedIps = await loadExcludedIps(publicationId)
+    return (data as LinkClickRow[]).filter((row) =>
+      isClickCountable(row, excludedIps)
+    ).length
+  } catch (err) {
+    log.error('getTotalClicks threw', { err, issueId, publicationId })
+    return 0
+  }
+}
+
+/**
+ * Aggregate engagement for an issue: delivery counts + total clicks + unique clickers.
+ * Returns null if delivery counts cannot be loaded (issue/publication mismatch or DB error).
+ */
+export async function getIssueEngagement(args: {
+  issueId: string
+  publicationId: string
+  excludeBots?: boolean
+}): Promise<IssueEngagement | null> {
+  const { issueId, publicationId, excludeBots = true } = args
+
+  const delivery = await getDeliveryCounts({ issueId, publicationId })
+  if (!delivery) return null
+
+  const [totalClicks, uniqueClickers] = await Promise.all([
+    getTotalClicks({ issueId, publicationId, excludeBots }),
+    getUniqueClickers({ issueId, publicationId, excludeBots }),
+  ])
+
+  return {
+    issueId,
+    publicationId,
+    totalClicks,
+    uniqueClickers,
+    delivery,
+  }
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `npx vitest run src/lib/dal/__tests__/analytics.test.ts`
+Expected: all existing + new tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/dal/analytics.ts src/lib/dal/__tests__/analytics.test.ts
+git commit -m "feat(dal): add getIssueEngagement composing delivery + clicks"
+```
+
+---
+
+## Task 7: DAL — `getModuleEngagement`
+
+**Files:**
+- Modify: `src/lib/dal/analytics.ts`
+- Modify: `src/lib/dal/__tests__/analytics.test.ts`
+
+- [ ] **Step 1: Add failing tests for getModuleEngagement**
+
+Update import in `src/lib/dal/__tests__/analytics.test.ts`:
+
+```typescript
+import {
+  getDeliveryCounts,
+  getUniqueClickers,
+  getIssueEngagement,
+  getModuleEngagement,
+} from '../analytics'
+```
+
+Append:
+
+```typescript
+describe('getModuleEngagement', () => {
+  it('returns module engagement with defaults to deliveredCount when moduleRecipients not provided', async () => {
+    // Delivery counts call (inside getIssueEngagement path)
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        issue_id: ISSUE_ID,
+        sent_count: 1000,
+        delivered_count: 980,
+        opened_count: 500,
+        clicked_count: 50,
+        bounced_count: 20,
+        unsubscribed_count: 5,
+        open_rate: 0.51,
+        click_rate: 0.051,
+        imported_at: '2026-04-23T10:00:00Z',
+        publication_issues: { publication_id: PUB_ID },
+      },
+      error: null,
+    })
+
+    const rows = [
+      { id: '1', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 'Ads', ip_address: '1.1.1.1', is_bot_ua: false },
+      { id: '2', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'b@x.com', link_url: 'u', link_section: 'Ads', ip_address: '1.1.1.2', is_bot_ua: false },
+    ]
+    ;(mockChain.is as any)
+      .mockReturnValueOnce(Promise.resolve({ data: rows, error: null }))
+      .mockReturnValueOnce(Promise.resolve({ data: rows, error: null }))
+
+    const result = await getModuleEngagement({
+      moduleId: 'module-1',
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      linkSection: 'Ads',
+      excludeBots: true,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.uniqueClickers).toBe(2)
+    expect(result!.totalClicks).toBe(2)
+    expect(result!.moduleRecipients).toBe(980) // default = deliveredCount
+  })
+
+  it('uses explicit moduleRecipients when provided (segmented module)', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        issue_id: ISSUE_ID,
+        sent_count: 1000,
+        delivered_count: 980,
+        opened_count: 500,
+        clicked_count: 10,
+        bounced_count: 20,
+        unsubscribed_count: 5,
+        open_rate: 0.51,
+        click_rate: 0.01,
+        imported_at: '2026-04-23T10:00:00Z',
+        publication_issues: { publication_id: PUB_ID },
+      },
+      error: null,
+    })
+
+    ;(mockChain.is as any)
+      .mockReturnValueOnce(Promise.resolve({ data: [], error: null }))
+      .mockReturnValueOnce(Promise.resolve({ data: [], error: null }))
+
+    const result = await getModuleEngagement({
+      moduleId: 'module-1',
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      linkSection: 'Ads',
+      moduleRecipients: 500, // segmented: only 500 of 980 saw this module
+      excludeBots: true,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.moduleRecipients).toBe(500)
+  })
+
+  it('returns null when delivery cannot be loaded', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: null })
+
+    const result = await getModuleEngagement({
+      moduleId: 'module-1',
+      issueId: ISSUE_ID,
+      publicationId: 'wrong-pub',
+      linkSection: 'Ads',
+    })
+
+    expect(result).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run: `npx vitest run src/lib/dal/__tests__/analytics.test.ts -t getModuleEngagement`
+Expected: fail — not exported.
+
+- [ ] **Step 3: Implement getModuleEngagement**
+
+Append to `src/lib/dal/analytics.ts`:
+
+```typescript
+/**
+ * Aggregate engagement for a module within an issue.
+ *
+ * Module scope is defined by linkSection (e.g., 'Ads', 'AI Apps', 'Articles').
+ * Numbers are narrowed to clicks with that link_section.
+ *
+ * moduleRecipients defaults to delivery.deliveredCount for non-segmented modules.
+ * For segmented modules (an ad shown to a subset), callers pass the explicit
+ * recipient count from the per-issue module-assignment table.
+ */
+export async function getModuleEngagement(args: {
+  moduleId: string
+  issueId: string
+  publicationId: string
+  linkSection: string
+  moduleRecipients?: number
+  excludeBots?: boolean
+}): Promise<ModuleEngagement | null> {
+  const {
+    moduleId,
+    issueId,
+    publicationId,
+    linkSection,
+    moduleRecipients,
+    excludeBots = true,
+  } = args
+
+  const delivery = await getDeliveryCounts({ issueId, publicationId })
+  if (!delivery) return null
+
+  const [totalClicks, uniqueClickers] = await Promise.all([
+    getModuleTotalClicks({ issueId, publicationId, linkSection, excludeBots }),
+    getModuleUniqueClickers({ issueId, publicationId, linkSection, excludeBots }),
+  ])
+
+  return {
+    moduleId,
+    issueId,
+    publicationId,
+    totalClicks,
+    uniqueClickers,
+    moduleRecipients: moduleRecipients ?? delivery.deliveredCount,
+  }
+}
+
+async function getModuleTotalClicks(args: {
+  issueId: string
+  publicationId: string
+  linkSection: string
+  excludeBots: boolean
+}): Promise<number> {
+  return runLinkClicksAggregate({ ...args, countUnique: false })
+}
+
+async function getModuleUniqueClickers(args: {
+  issueId: string
+  publicationId: string
+  linkSection: string
+  excludeBots: boolean
+}): Promise<number> {
+  return runLinkClicksAggregate({ ...args, countUnique: true })
+}
+
+async function runLinkClicksAggregate(args: {
+  issueId: string
+  publicationId: string
+  linkSection: string
+  excludeBots: boolean
+  countUnique: boolean
+}): Promise<number> {
+  const { issueId, publicationId, linkSection, excludeBots, countUnique } = args
+
+  try {
+    let query = supabaseAdmin
+      .from('link_clicks')
+      .select(LINK_CLICK_COLUMNS)
+      .eq('publication_id', publicationId)
+      .eq('issue_id', issueId)
+      .eq('link_section', linkSection)
+
+    if (excludeBots) query = query.is('is_bot_ua', false)
+
+    const { data, error } = await query
+    if (error || !data) {
+      if (error) log.error('module aggregate failed', { error, issueId, linkSection })
+      return 0
+    }
+
+    const rows = data as LinkClickRow[]
+
+    if (excludeBots) {
+      const excludedIps = await loadExcludedIps(publicationId)
+      const countable = rows.filter((row) => isClickCountable(row, excludedIps))
+      return countUnique ? countUniqueEmails(countable) : countable.length
+    }
+
+    return countUnique ? countUniqueEmails(rows) : rows.length
+  } catch (err) {
+    log.error('module aggregate threw', { err, issueId, linkSection })
+    return 0
+  }
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `npx vitest run src/lib/dal/__tests__/analytics.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/dal/analytics.ts src/lib/dal/__tests__/analytics.test.ts
+git commit -m "feat(dal): add getModuleEngagement with section-scoped aggregation"
+```
+
+---
+
+## Task 8: Barrel exports
+
+**Files:**
+- Create: `src/lib/analytics/index.ts`
+- Modify: `src/lib/dal/index.ts`
+
+- [ ] **Step 1: Create `src/lib/analytics/index.ts`**
+
+```typescript
+/**
+ * Analytics library — barrel export.
+ * Consumers import from '@/lib/analytics'.
+ */
+
+export {
+  computeIssueCTR,
+  computeModuleCTR,
+  computeIssueOpenRate,
+  computePollResponseRate,
+  computeFeedbackResponseRate,
+  computeBounceRate,
+  computeUnsubscribeRate,
+} from './metrics'
+
+export {
+  ExcludedIpSet,
+  isClickCountable,
+  loadExcludedIps,
+} from './bot-policy'
+
+export type {
+  DeliveryCounts,
+  IssueEngagement,
+  ModuleEngagement,
+  LinkClickRow,
+  ExcludedIpRow,
+} from './types'
+```
+
+- [ ] **Step 2: Read current `src/lib/dal/index.ts`**
+
+Run: `cat src/lib/dal/index.ts`
+Note the existing exports so we don't break them.
+
+- [ ] **Step 3: Append analytics export to `src/lib/dal/index.ts`**
+
+Add to the bottom of the existing file:
+
+```typescript
+// Analytics DAL
+export {
+  getDeliveryCounts,
+  getUniqueClickers,
+  getIssueEngagement,
+  getModuleEngagement,
+} from './analytics'
+```
+
+- [ ] **Step 4: Verify build + type-check**
+
+Run: `npm run type-check`
+Expected: zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/analytics/index.ts src/lib/dal/index.ts
+git commit -m "feat(analytics): add barrel exports for analytics and DAL"
+```
+
+---
+
+## Task 9: Glossary doc
+
+**Files:**
+- Create: `docs/operations/metrics.md`
+
+- [ ] **Step 1: Create the glossary doc**
+
+Create `docs/operations/metrics.md`:
+
+```markdown
+# Metrics Glossary
+
+_Last updated: 2026-04-23_
+
+Canonical definitions for every KPI surfaced on analytics pages. Any PR that adds a dashboard metric must update this glossary. Compute functions live in `src/lib/analytics/metrics.ts`; data reads in `src/lib/dal/analytics.ts`.
+
+---
+
+## Issue CTR
+
+- **Formula:** `unique_clickers / delivered_count`
+- **Numerator source:** `link_clicks` (own event table), filtered by `isClickCountable` (`src/lib/analytics/bot-policy.ts`)
+- **Denominator source:** `email_metrics.delivered_count` (ESP-reported)
+- **Uniqueness rule:** one row per `(subscriber_email, link_url, issue_id)` — no time window; issue is the natural boundary
+- **Compute with:** `computeIssueCTR()` + `dal.getIssueEngagement()`
+- **Known quirks:** `email_metrics.click_rate` is an ESP-reported value and may differ — vendor bot filtering is opaque. Displayed separately as "ESP-reported Click Rate" for deliverability debugging.
+- **Owner:** @jake
+
+## Module CTR
+
+- **Formula:** `unique_clickers_in_module / module_recipients`
+- **Numerator source:** `link_clicks` rows with `link_section` matching the module, bot/IP filtered
+- **Denominator source:** defaults to `email_metrics.delivered_count`; segmented modules pass an explicit recipient count from the per-issue module-assignment table
+- **Uniqueness rule:** one row per `(subscriber_email, link_url, issue_id, link_section)`
+- **Compute with:** `computeModuleCTR()` + `dal.getModuleEngagement()`
+- **Known quirks:** distinct from Issue CTR — never compare directly. UI labels must say "Module CTR" when showing this.
+- **Owner:** @jake
+
+## Issue Open Rate
+
+- **Formula:** `unique_openers / delivered_count`
+- **Numerator source:** `email_metrics.opened_count` (ESP-reported — we do not run our own open pixel)
+- **Denominator source:** `email_metrics.delivered_count`
+- **Uniqueness rule:** vendor-defined
+- **Compute with:** `computeIssueOpenRate()`
+- **Known quirks:** ESP bot filtering is opaque. Apple Mail Privacy Protection inflates opens (~30–60% of Apple users).
+- **Owner:** @jake
+
+## Poll Response Rate
+
+- **Formula:** `unique_respondents / delivered_count`
+- **Numerator source:** `poll_responses` (the typed DAL read that feeds this formula lands in PR 3 when `/api/polls/analytics` is rewritten)
+- **Denominator source:** `email_metrics.delivered_count`
+- **Uniqueness rule:** one row per `(subscriber_email, poll_id)`
+- **Compute with:** `computePollResponseRate()`
+- **Owner:** @jake
+
+## Feedback Response Rate
+
+- **Formula:** `unique_respondents / delivered_count`
+- **Numerator source:** `feedback_responses`
+- **Denominator source:** `email_metrics.delivered_count`
+- **Uniqueness rule:** one row per `(subscriber_email, issue_id)`
+- **Compute with:** `computeFeedbackResponseRate()`
+- **Owner:** @jake
+
+## Ad CTR / AI App CTR / Tools Directory CTR
+
+All three are Module CTR specializations — `link_section` varies (`Ads`, `AI Apps`, `Tools`). Same formula, same dedup rule. Documented here as aliases; dashboards label them appropriately.
+
+## Delivered Count
+
+- **Source:** `email_metrics.delivered_count`
+- **Definition:** sent minus vendor-reported bounces
+- **Used as denominator for:** Issue CTR, Module CTR (default), Open Rate, Response Rates, Unsubscribe Rate
+
+## Bounce Rate
+
+- **Formula:** `bounced_count / sent_count`
+- **Source:** `email_metrics.bounced_count` / `email_metrics.sent_count`
+- **Compute with:** `computeBounceRate()`
+- **Owner:** @jake
+
+## Unsubscribe Rate
+
+- **Formula:** `unsubscribed_count / delivered_count`
+- **Source:** `email_metrics`
+- **Compute with:** `computeUnsubscribeRate()`
+- **Owner:** @jake
+
+---
+
+## Bot & IP Filter Policy
+
+A click counts toward metrics (`isClickCountable` returns `true`) unless any of:
+- `link_clicks.is_bot_ua = true` (UA matched a bot pattern at ingest)
+- `link_clicks.ip_address` is in `excluded_ips` (exact match)
+- `link_clicks.ip_address` matches any CIDR range in `excluded_ips`
+
+Historical rows with `is_bot_ua = NULL` are treated as not-a-bot (no backfill applied — see prior incident notes).
+
+ESP-reported counts (`opened_count`, `clicked_count`) inherit vendor filtering and **cannot** be re-filtered. `email_metrics.click_rate` therefore diverges from computed Issue CTR; this is expected.
+
+## Data Lineage
+
+| Metric | Upstream table(s) | Sync job |
+|--------|-------------------|----------|
+| Issue CTR | `link_clicks` | real-time insert by tracking endpoint |
+| Module CTR | `link_clicks` | real-time insert by tracking endpoint |
+| Open Rate / ESP Click Rate / Bounce / Unsubscribe | `email_metrics` | `/api/cron/import-email-metrics` (MailerLite) |
+| Poll Response Rate | `poll_responses` | real-time insert |
+| Feedback Response Rate | `feedback_responses` | real-time insert |
+
+## Freshness
+
+`email_metrics.imported_at` carries the last sync timestamp (renamed to `last_synced_at` in PR 2). Stale threshold: 12 hours (configurable via `app_settings.email_metrics_stale_threshold_hours`). Dashboards display "as of X" via `<FreshnessBadge>`.
+
+## Adding a New Metric
+
+1. Add the compute function to `src/lib/analytics/metrics.ts` with unit tests.
+2. Add a DAL read to `src/lib/dal/analytics.ts` with tests.
+3. Add a section to this glossary with formula, source, uniqueness rule, and owner.
+4. Link the glossary entry from the dashboard PR description.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/operations/metrics.md
+git commit -m "docs(analytics): add metrics glossary"
+```
+
+---
+
+## Task 10: Full verification
+
+- [ ] **Step 1: Run full type-check**
+
+Run: `npm run type-check`
+Expected: zero errors.
+
+- [ ] **Step 2: Run full lint**
+
+Run: `npm run lint`
+Expected: within the 360-warning ceiling per CLAUDE.md §13.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `npm run test:run`
+Expected: all tests pass, including new analytics/dal tests.
+
+- [ ] **Step 4: Run build**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Run bug-pattern check**
+
+Run: `npm run check:bug-patterns`
+Expected: no new issues.
+
+- [ ] **Step 6: Pre-push review gate**
+
+Run: `/simplify` on changed files. Review output, apply any trivial simplifications, re-run tests.
+Run: `/review:pre-push`. Address any findings.
+
+- [ ] **Step 7: Open PR**
+
+Branch: `feature/analytics-foundation`
+PR title: `feat(analytics): foundation library + metrics glossary`
+PR body: link to `docs/superpowers/specs/2026-04-23-analytics-metrics-design.md` PR 1 section. Call out that this adds no consumers — it's pure addition setting up subsequent PRs.

--- a/docs/superpowers/specs/2026-04-23-analytics-metrics-design.md
+++ b/docs/superpowers/specs/2026-04-23-analytics-metrics-design.md
@@ -1,0 +1,217 @@
+---
+name: Analytics & Metrics Standardization
+created: 2026-04-23
+status: draft
+owner: @jake
+---
+
+# Analytics & Metrics Standardization — Design
+
+## 1. Problem
+
+The `/analytics` pages currently violate several industry best practices for product metrics:
+
+- **No single source of truth for metric definitions.** CTR is computed with two different denominators in different routes (`email_metrics.sent_count` vs "recipients who saw module"). Issue click rate switches data sources based on an `excludeIps` UI toggle, hiding two definitions behind one label.
+- **No metrics glossary.** Nothing documents what each KPI means, its formula, its data lineage, or its freshness guarantees.
+- **Inconsistent bot/IP filtering.** The policy exists in `src/lib/bot-detection/` but is only applied at display time in one route; other routes inherit vendor-rolled numbers with opaque filtering.
+- **Multiple `CLAUDE.md`-rule violations in analytics routes** — `SELECT *`, hardcoded `PUBLICATION_ID`, ISO-timestamp date logic in at least three routes.
+- **No anomaly detection on product metrics.** System latency has drift alerts via `src/lib/monitoring/metrics-recorder.ts`; product metrics do not.
+- **No freshness indication.** ESP-imported metrics can be hours stale with no UI signal.
+
+## 2. Goals
+
+1. Establish a governance artifact — a metrics glossary — so every KPI has exactly one definition.
+2. Introduce a typed metrics library with pure formulas and a DAL that prevents drift from re-appearing.
+3. Fix the audit-identified bugs as part of the cutover.
+4. Apply bot/IP filter policy consistently across all analytics queries via one filter function.
+5. Surface data freshness in the UI.
+6. Add anomaly detection for product metrics, delivered via Slack + an in-app alerts tab.
+
+Out of scope for this spec (deferred to a future "evaluate PostHog vs Metabase" spec): hand-rolled funnels, cohorts, multi-touch attribution, A/B test analysis framework.
+
+## 3. Architectural Decisions
+
+### 3.1 Module layout (split by concern)
+
+```
+src/lib/
+├── analytics/
+│   ├── metrics.ts          # Pure formulas. No DB imports.
+│   ├── types.ts            # MetricRow, IssueMetrics, ModuleMetrics, DeliveryCounts
+│   ├── bot-policy.ts       # isClickCountable() — single source of truth for "does this click count?"
+│   └── index.ts            # Barrel export
+├── dal/
+│   └── analytics.ts        # DB reads. Explicit columns. publication_id filtered.
+└── monitoring/
+    ├── metrics-recorder.ts # (existing) system-level metrics
+    └── anomaly-alerts.ts   # NEW. Product-metric drift detection.
+```
+
+**Rules enforced by this layout:**
+- API routes never touch `link_clicks` / `email_metrics` directly — they call DAL.
+- DAL never does math — returns typed rows for formulas.
+- Formulas are pure functions — no Supabase imports, trivially unit-testable.
+- `excludeBots` defaults to `true` at the DAL layer; explicit `false` required for raw-data views.
+
+### 3.2 Canonical metric definitions
+
+Two distinct CTR metrics, both named:
+
+- **Issue CTR** = `unique_clickers_in_issue / delivered_count`. Denominator = `email_metrics.delivered_count` (excludes bounces, aligns with ESP conventions).
+- **Module CTR** = `unique_clickers_in_module / module_recipients`. Denominator varies when a module is segmented. Distinct from Issue CTR and always labeled as "Module CTR" in the UI.
+
+**Unique clicker rule:** one row per `(subscriber_id, link, issue_id)`. No time window — issue is the natural boundary.
+
+**Open rate** — sourced from `email_metrics` (we don't run our own open pixel). `issue_open_rate` only; no module-level opens.
+
+**Response rates (polls, feedback)** — unique respondents / `delivered_count`.
+
+**Bounce rate** — `email_metrics.bounced_count / email_metrics.sent_count`.
+
+**Unsubscribe rate** — `email_metrics.unsubscribed_count / email_metrics.delivered_count`.
+
+**`moduleRecipients` resolution:** for Module CTR, defaults to the issue's `delivered_count` for non-segmented modules. For segmented modules (ads/AI apps targeted at a subset), comes from the per-issue module-assignment table. Exact column/table confirmed at implementation time against current schema.
+
+### 3.3 Data source rules
+
+- **Clicks** — read from `link_clicks` (own event table). Enables consistent dedup + bot filter.
+- **Opens, delivered, bounces, unsubscribes** — read from `email_metrics` (ESP numbers). Vendor bot-filter applied; documented quirk.
+- `email_metrics.click_rate` becomes a secondary "ESP-reported" read-only display, useful for deliverability debugging. It is **not** the headline Issue CTR.
+
+### 3.4 Bot / IP filter policy
+
+Single function `isClickCountable(row, excludedIps)` in `src/lib/analytics/bot-policy.ts`. A click is countable unless:
+- `row.is_bot_ua === true`, or
+- `row.ip_address` is in `excluded_ips` (exact match), or
+- `row.ip_address` matches any CIDR in `excluded_ips`.
+
+SQL-level filtering where possible (`is_bot_ua = false AND ip_address NOT IN (...)`); CIDR check applied in app code.
+
+**No historical backfill.** New clicks get flagged at ingest going forward; historical rows retain their original flags. Prior lesson: overly aggressive backfill caught legitimate power users.
+
+### 3.5 Freshness
+
+Single additive migration:
+
+```sql
+ALTER TABLE email_metrics ADD COLUMN last_synced_at TIMESTAMPTZ;
+CREATE INDEX idx_email_metrics_last_synced ON email_metrics(last_synced_at);
+```
+
+Populated by `emailMetricsService` on every sync write. (No `sync_source` column — SendGrid is never used in practice; if it ever is, that PR can add the column.)
+
+UI component `<FreshnessBadge lastSyncedAt={...} />` renders "as of 12m ago" with tooltip. Mounted on every analytics panel that reads email-derived numbers. Stale threshold read from `app_settings.email_metrics_stale_threshold_hours` (default `12`).
+
+### 3.6 Anomaly alerts (Track 5e)
+
+**Schema:**
+
+```sql
+CREATE TABLE metric_alerts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  publication_id UUID NOT NULL REFERENCES publications(id),
+  metric_name TEXT NOT NULL,
+  issue_id UUID REFERENCES issues(id),
+  observed_value NUMERIC NOT NULL,
+  baseline_mean NUMERIC NOT NULL,
+  baseline_stddev NUMERIC NOT NULL,
+  deviation_sigmas NUMERIC NOT NULL,
+  direction TEXT CHECK (direction IN ('drop', 'spike')),
+  severity TEXT CHECK (severity IN ('warning', 'critical')),
+  slack_sent_at TIMESTAMPTZ,
+  acknowledged_at TIMESTAMPTZ,
+  acknowledged_by TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_metric_alerts_pub_created ON metric_alerts(publication_id, created_at DESC);
+CREATE INDEX idx_metric_alerts_unack ON metric_alerts(publication_id) WHERE acknowledged_at IS NULL;
+```
+
+**Detection flow** (`/api/cron/detect-metric-anomalies`, hourly):
+1. For each active publication, for each tracked metric, load last 7 days of values from DAL.
+2. Compute mean + stddev of days 1–6. Compare today.
+3. `|today − mean| > 2σ` → insert `metric_alerts` row. `> 3σ` → severity `critical`.
+4. If severity ≥ `warning` AND no identical unacknowledged alert exists → post Slack, stamp `slack_sent_at`.
+
+**Tracked metrics (Phase 1):** `issue_ctr`, `issue_open_rate`, `poll_response_rate`, `feedback_response_rate`, `bounce_rate`, `unsubscribe_rate`.
+
+**Slack gate:** `app_settings.anomaly_alerts_slack_enabled` (default `false`). Flip via settings after one observation cycle; no PR needed.
+
+**Dashboard:** new "Alerts" tab in `/dashboard/[slug]/analytics` lists unacknowledged alerts with ACK button. Retention 90 days, matching `system_metrics`.
+
+### 3.7 Historical numbers policy
+
+When a formula changes (notably Issue CTR denominator shift to `delivered_count`), historical dashboard values move. This is accepted — documented in CHANGELOG and glossary. The alternative (freezing historical numbers behind a "metric as of vX" dimension) is heavyweight and re-introduces the multiple-definition problem we are fixing.
+
+## 4. Bug-fix inventory
+
+| # | File | Issue | Fix |
+|---|------|-------|-----|
+| 1 | `src/app/api/analytics/[campaign]/route.ts:14` | `select('*')` on `email_metrics` | Explicit columns matching `DeliveryCounts` |
+| 2 | `src/app/api/link-tracking/analytics/route.ts:78` | `select('*')` on `link_clicks` | Explicit columns; read moves into `dal.getUniqueClickers` |
+| 3 | `src/app/api/tools/analytics/route.ts:36-38` | `select('*')` + hardcoded `PUBLICATION_ID` + ISO-timestamp date logic | Explicit columns, resolve publication from slug, local-date strings |
+| 4 | `src/app/api/ads/analytics/route.ts` + `ai-apps/analytics/route.ts` | Module CTR denominator hidden inside one-off math | Adopt `computeModuleCTR`; label metric as **Module CTR** in UI |
+| 5 | `src/app/dashboard/[slug]/analytics/components/issues-tab/useIssuesAnalytics.ts:46-59` | Click rate reads from `email_metrics.click_rate` or `link_clicks` depending on `excludeIps` toggle | Always compute from `link_clicks` via DAL. `excludeIps` toggle now controls bot-policy flag, not data source. `email_metrics.click_rate` displayed separately as "ESP-reported". |
+
+Bugs 4 and 5 land via shadow-read (Section 5, PR 4–5) because numbers visibly change.
+
+## 5. Rollout — six PRs
+
+| PR | Contents | Risk |
+|----|----------|------|
+| **1. Glossary + foundation library** | `docs/operations/metrics.md` + `src/lib/analytics/*` + `src/lib/dal/analytics.ts` + unit/integration tests. No consumers. | Low |
+| **2. Freshness** | Migration adding `email_metrics.last_synced_at` + sync-writer update + `<FreshnessBadge>` component mounted on all analytics panels. | Low |
+| **3. Direct-cutover fixes + bot-policy consolidation** | Bug #1, #2, #3. Three routes rewritten to use DAL. Duplicate display-layer filter code in `link-tracking/analytics` deleted. Numbers should not visibly change. | Medium |
+| **4. Shadow-read introduction** | Bug #4, #5 routes compute both old and new, return old, log delta. No user-visible change. | Low |
+| **5. Cutover flip** (small PR after 7-day observation) | Remove shadow-read, return new numbers. Update glossary with change notice. | Medium |
+| **6. Anomaly alerts (Track 5e)** | Migration for `metric_alerts` + detection cron + Slack integration + Alerts tab. Slack gated by `app_settings.anomaly_alerts_slack_enabled` flag. | Medium |
+
+All DB migrations are additive; rollback is PR revert.
+
+## 6. Testing strategy
+
+- **Unit tests** for every `compute*` formula: zero denominator, zero numerator, rounding, type guards.
+- **Integration tests** (seeded Supabase fixture, no mocks — per prior feedback): every DAL function, including bot/IP filter behavior.
+- **Shadow-read audit script** `scripts/audit-shadow-read-deltas.mjs`: aggregates PR-4 logs into max-delta, distribution, outlier list. Run before PR 5 cutover.
+- **Anomaly alerts**: unit tests for baseline σ math + severity classification; integration test that seeds 7 issues of metrics and verifies alert inserts.
+- **Existing verification gates**: `npm run build`, `npm run type-check`, `npm run test:run`, `npm run check:bug-patterns`, plus `/simplify` + `/review:pre-push` per `CLAUDE.md` Section 5.
+
+Not doing: E2E browser tests (no existing harness), DAL performance benchmarks (measure in prod, optimize if needed).
+
+## 7. Glossary document
+
+Location: `docs/operations/metrics.md`. Structure per metric:
+
+```
+## <Metric name>
+- Formula: <numerator> / <denominator>
+- Numerator source: <table, column, filter rules>
+- Denominator source: <table, column>
+- Uniqueness rule: <what counts as unique>
+- Time boundary: <issue / day / 7d-window>
+- Compute with: <TS function name>
+- Known quirks: <vendor differences, filtering gaps>
+- Owner: <person>
+```
+
+Covered metrics: Issue CTR, Module CTR, Issue Open Rate, Poll Response Rate, Poll Option Share, Feedback Response Rate, Ad CTR, AI App CTR, Tools Directory CTR, Delivered Count, Bounce Rate, Unsubscribe Rate.
+
+Plus three cross-cutting sections:
+- **Bot & IP filter policy** — what `isClickCountable` rejects and why.
+- **Data lineage** — table mapping each metric to upstream table(s) and sync job.
+- **Freshness** — how to read `email_metrics.last_synced_at`, stale threshold per dashboard.
+
+Governance rule: any PR adding a dashboard metric must also add its glossary entry; enforced in review.
+
+## 8. Explicit non-goals
+
+- Funnels (send → open → click → conversion aggregation).
+- Cohort analysis (retention by signup cohort).
+- Multi-touch attribution modeling.
+- A/B test analysis framework.
+- Bot filtering on ESP-reported opens (would require own open-pixel beacon).
+- ML-based anomaly detection (rolling σ is sufficient).
+- Per-publication configurable anomaly thresholds (hardcoded defaults for Phase 1).
+
+A future spec evaluates PostHog (self-hosted) vs Metabase (on Postgres) for the deferred items rather than hand-rolling.

--- a/src/app/api/settings/business/route.ts
+++ b/src/app/api/settings/business/route.ts
@@ -13,6 +13,7 @@ const BUSINESS_SETTINGS_KEYS = [
   'header_image_url',
   'website_header_url',
   'logo_url',
+  'archive_cover_image_url',
   'contact_email',
   'website_url',
   'heading_font',

--- a/src/app/api/settings/upload-business-image/route.ts
+++ b/src/app/api/settings/upload-business-image/route.ts
@@ -18,7 +18,7 @@ export const POST = withApiHandler(
       return NextResponse.json({ error: 'No file provided' }, { status: 400 })
     }
 
-    if (!type || !['header', 'logo', 'website_header'].includes(type)) {
+    if (!type || !['header', 'logo', 'website_header', 'archive_cover'].includes(type)) {
       return NextResponse.json({ error: 'Invalid type parameter' }, { status: 400 })
     }
 
@@ -44,7 +44,7 @@ export const POST = withApiHandler(
     const storage = new SupabaseImageStorage()
     const publicUrl = await storage.uploadBusinessImage(
       buffer,
-      type as 'header' | 'logo' | 'website_header',
+      type as 'header' | 'logo' | 'website_header' | 'archive_cover',
       publicationId
     )
 
@@ -52,10 +52,16 @@ export const POST = withApiHandler(
       return NextResponse.json({ error: 'Failed to upload image' }, { status: 500 })
     }
 
+    const label =
+      type === 'logo' ? 'Logo'
+      : type === 'website_header' ? 'Website header'
+      : type === 'archive_cover' ? 'Archive cover'
+      : 'Header'
+
     return NextResponse.json({
       success: true,
       url: publicUrl,
-      message: `${type === 'logo' ? 'Logo' : type === 'website_header' ? 'Website header' : 'Header'} image uploaded successfully`
+      message: `${label} image uploaded successfully`
     })
   }
 )

--- a/src/app/website/news/news-helpers.ts
+++ b/src/app/website/news/news-helpers.ts
@@ -61,6 +61,7 @@ export async function fetchNewsPageData(params: SearchParams): Promise<NewsPageD
 
   const settings = await getPublicationSettings(publicationId, [
     'website_header_url', 'logo_url', 'newsletter_name', 'business_name', 'tools_directory_enabled',
+    'archive_cover_image_url',
   ])
 
   const headerImageUrl = settings.website_header_url || '/logo.png'
@@ -105,7 +106,9 @@ export async function fetchNewsPageData(params: SearchParams): Promise<NewsPageD
 
   const { data: manualArticles } = await articlesQuery
 
-  const newsletterCoverImage = `${STORAGE_PUBLIC_URL}/img/c/ai_accounting_daily_cover_image.jpg`
+  const newsletterCoverImage =
+    settings.archive_cover_image_url ||
+    `${STORAGE_PUBLIC_URL}/img/c/ai_accounting_daily_cover_image.jpg`
   const newsItems: NewsItem[] = []
 
   if (!params.category || params.category === 'newsletter') {

--- a/src/app/website/page.tsx
+++ b/src/app/website/page.tsx
@@ -41,10 +41,13 @@ export default async function WebsiteHome() {
     'website_callout_text',
     'website_heading',
     'website_subheading',
+    'archive_cover_image_url',
   ])
 
-  // Newsletter cover image
-  const newsletterCoverImage = `${STORAGE_PUBLIC_URL}/img/c/ai_accounting_daily_cover_image.jpg`
+  // Newsletter cover image (per-publication, with fallback)
+  const newsletterCoverImage =
+    websiteSettings.archive_cover_image_url ||
+    `${STORAGE_PUBLIC_URL}/img/c/ai_accounting_daily_cover_image.jpg`
 
   // Fetch newsletters (filtered by publication)
   const { data: newsletters } = await supabaseAdmin

--- a/src/components/settings/BusinessSettings.tsx
+++ b/src/components/settings/BusinessSettings.tsx
@@ -11,6 +11,7 @@ export default function BusinessSettings({ publicationId }: { publicationId: str
     uploadingHeader,
     uploadingLogo,
     uploadingWebsiteHeader,
+    uploadingArchiveCover,
     message,
     handleSave,
     handleImageUpload,
@@ -99,6 +100,22 @@ export default function BusinessSettings({ publicationId }: { publicationId: str
               className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
               disabled={uploadingWebsiteHeader} />
             {uploadingWebsiteHeader && <span className="text-sm text-gray-500">Uploading...</span>}
+          </div>
+        </div>
+        <div className="mt-6">
+          <label className="block text-sm font-medium text-gray-700 mb-2">Issues Archive Cover Image</label>
+          <p className="text-xs text-gray-500 mb-2">This image appears on each newsletter issue card in the website archive. Recommended size: 1200 x 675.</p>
+          {settings.archive_cover_image_url && (
+            <div className="mb-2 p-4 rounded border">
+              <img src={settings.archive_cover_image_url} alt="Archive cover preview" className="max-w-md h-32 object-contain mx-auto" />
+            </div>
+          )}
+          <div className="flex items-center space-x-2">
+            <input type="file" accept="image/*"
+              onChange={(e) => { const file = e.target.files?.[0]; if (file) handleImageUpload(file, 'archive_cover') }}
+              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+              disabled={uploadingArchiveCover} />
+            {uploadingArchiveCover && <span className="text-sm text-gray-500">Uploading...</span>}
           </div>
         </div>
       </div>

--- a/src/components/settings/useBusinessSettings.ts
+++ b/src/components/settings/useBusinessSettings.ts
@@ -12,6 +12,7 @@ export interface BusinessSettingsState {
   header_image_url: string
   website_header_url: string
   logo_url: string
+  archive_cover_image_url: string
   contact_email: string
   website_url: string
   heading_font: string
@@ -36,6 +37,7 @@ const defaultSettings: BusinessSettingsState = {
   header_image_url: '',
   website_header_url: '',
   logo_url: '',
+  archive_cover_image_url: '',
   contact_email: '',
   website_url: '',
   heading_font: 'Arial, sans-serif',
@@ -68,6 +70,7 @@ export function useBusinessSettings(publicationId: string) {
   const [uploadingHeader, setUploadingHeader] = useState(false)
   const [uploadingLogo, setUploadingLogo] = useState(false)
   const [uploadingWebsiteHeader, setUploadingWebsiteHeader] = useState(false)
+  const [uploadingArchiveCover, setUploadingArchiveCover] = useState(false)
   const [message, setMessage] = useState('')
 
   useEffect(() => {
@@ -113,8 +116,12 @@ export function useBusinessSettings(publicationId: string) {
     }
   }
 
-  const handleImageUpload = async (file: File, type: 'header' | 'logo' | 'website_header') => {
-    const setUploading = type === 'header' ? setUploadingHeader : type === 'logo' ? setUploadingLogo : setUploadingWebsiteHeader
+  const handleImageUpload = async (file: File, type: 'header' | 'logo' | 'website_header' | 'archive_cover') => {
+    const setUploading =
+      type === 'header' ? setUploadingHeader
+      : type === 'logo' ? setUploadingLogo
+      : type === 'website_header' ? setUploadingWebsiteHeader
+      : setUploadingArchiveCover
     setMessage('')
 
     try {
@@ -135,9 +142,18 @@ export function useBusinessSettings(publicationId: string) {
 
       const data = await uploadResponse.json()
 
-      const fieldName = type === 'header' ? 'header_image_url' : type === 'logo' ? 'logo_url' : 'website_header_url'
+      const fieldName =
+        type === 'header' ? 'header_image_url'
+        : type === 'logo' ? 'logo_url'
+        : type === 'website_header' ? 'website_header_url'
+        : 'archive_cover_image_url'
+      const label =
+        type === 'header' ? 'Header'
+        : type === 'logo' ? 'Logo'
+        : type === 'website_header' ? 'Website Header'
+        : 'Archive Cover'
       setSettings(prev => ({ ...prev, [fieldName]: data.url }))
-      setMessage(data.message || `${type === 'header' ? 'Header' : type === 'logo' ? 'Logo' : 'Website Header'} image uploaded successfully!`)
+      setMessage(data.message || `${label} image uploaded successfully!`)
       setTimeout(async () => {
         await handleSave()
       }, 500)
@@ -163,6 +179,7 @@ export function useBusinessSettings(publicationId: string) {
     uploadingHeader,
     uploadingLogo,
     uploadingWebsiteHeader,
+    uploadingArchiveCover,
     message,
     handleSave,
     handleImageUpload,

--- a/src/lib/supabase-image-storage.ts
+++ b/src/lib/supabase-image-storage.ts
@@ -89,14 +89,18 @@ export class SupabaseImageStorage {
    */
   async uploadBusinessImage(
     buffer: Buffer,
-    type: 'header' | 'logo' | 'website_header',
+    type: 'header' | 'logo' | 'website_header' | 'archive_cover',
     publicationId: string
   ): Promise<string | null> {
     try {
       if (buffer.length > MAX_FILE_SIZE) return null
 
-      const optimized = await optimizeBuffer(buffer, { preset: 'header' })
-      const prefix = type === 'logo' ? PREFIX.businessLogo : PREFIX.businessHeader
+      const preset = type === 'archive_cover' ? 'newsletter' : 'header'
+      const optimized = await optimizeBuffer(buffer, { preset })
+      const prefix =
+        type === 'logo' ? PREFIX.businessLogo
+        : type === 'archive_cover' ? PREFIX.cover
+        : PREFIX.businessHeader
       const timestamp = Date.now()
       const objectPath = `${prefix}/${publicationId}-${timestamp}.png`
 


### PR DESCRIPTION
## Summary

Batch promotion of staging to master. Notable changes included:

- **Publication-specific archive cover image** (2ad3e670): New `archive_cover_image_url` setting; each publication can upload its own archive image via Business Settings. Falls back to prior hardcoded image when unset.
- **AdSense / Meta Pixel / CMP in SSR HTML** (#207)
- **SparkLoop publication_id propagation on recs page** (#206)
- **SparkLoop API key rotation and subscribe outage handling** (#205)
- **RSS Output (Sent) feed variant for article modules** (516f4ca8, 9adadcde)
- **Scoring: transaction_type placeholder + rated_after filter** (#203)
- **Rescore-module-posts rated_before filter** (#202)
- Planning docs: analytics/metrics standardization spec, PR 1 foundation library implementation plan

## Test plan

- [ ] Verify staging deployment (aiprodaily-staging) renders archive cards with publication-specific image when `archive_cover_image_url` is set
- [ ] Verify fallback image still displays for publications without the setting configured
- [ ] Upload a new archive cover image via Business Settings UI and confirm it saves and renders
- [ ] Spot-check SparkLoop recs flow, AdSense/Pixel script rendering, and RSS feed variants on staging before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added archive cover image upload and configuration in Business Settings
  * Archive cover image now displays on the news/issues page when configured

* **Documentation**
  * Added analytics & metrics standardization design specifications
  * Added analytics foundation work specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->