### PR TITLE
Subscribe page A/B testing + content-as-pages refactor

### DIFF
--- a/db/migrations/20260424_seed_default_subscribe_pages.sql
+++ b/db/migrations/20260424_seed_default_subscribe_pages.sql
@@ -1,0 +1,59 @@
+-- Migration: Seed default subscribe_pages from publication_settings
+-- Date: 2026-04-24
+-- Purpose: One-time backfill. For each active publication that has any of
+--          subscribe_heading / subscribe_subheading / subscribe_tagline set
+--          and does NOT already have a default subscribe_page, create one
+--          from those setting values and mark it as default. Idempotent.
+--
+-- Safe to re-run: the NOT EXISTS guard ensures we never overwrite a page
+-- the admin has already marked as default.
+
+INSERT INTO subscribe_pages (publication_id, name, content, is_default)
+SELECT
+  s.publication_id,
+  'Current (seeded)',
+  jsonb_strip_nulls(jsonb_build_object(
+    'heading',    s.heading,
+    'subheading', s.subheading,
+    'tagline',    s.tagline
+  )),
+  true
+FROM (
+  SELECT
+    p.id AS publication_id,
+    -- publication_settings values may be JSON-stringified (wrapped in quotes).
+    -- Strip leading/trailing double quotes to match the runtime read path
+    -- in getPublicationSetting().
+    NULLIF(
+      TRIM(BOTH '"' FROM (
+        SELECT value FROM publication_settings
+        WHERE publication_id = p.id AND key = 'subscribe_heading'
+      )),
+      ''
+    ) AS heading,
+    NULLIF(
+      TRIM(BOTH '"' FROM (
+        SELECT value FROM publication_settings
+        WHERE publication_id = p.id AND key = 'subscribe_subheading'
+      )),
+      ''
+    ) AS subheading,
+    NULLIF(
+      TRIM(BOTH '"' FROM (
+        SELECT value FROM publication_settings
+        WHERE publication_id = p.id AND key = 'subscribe_tagline'
+      )),
+      ''
+    ) AS tagline
+  FROM publications p
+  WHERE p.is_active = true
+    AND NOT EXISTS (
+      SELECT 1 FROM subscribe_pages sp
+      WHERE sp.publication_id = p.id
+        AND sp.is_default = true
+        AND sp.is_archived = false
+    )
+) s
+WHERE s.heading IS NOT NULL
+   OR s.subheading IS NOT NULL
+   OR s.tagline IS NOT NULL;

--- a/db/migrations/20260424_subscribe_ab_tests.sql
+++ b/db/migrations/20260424_subscribe_ab_tests.sql
@@ -1,0 +1,134 @@
+-- Migration: Subscribe page A/B testing system
+-- Date: 2026-04-24
+-- Purpose: Allow defining multiple /subscribe content variants ("pages"),
+--          grouping them into time-bound tests with weighted random traffic
+--          split, and tracking page_view + 4 conversion event types per
+--          variant for comparison. Stats are scoped per test_id, so reusing
+--          the same page in a new test starts fresh counters.
+
+-- ============================================================
+-- 1. subscribe_pages — reusable content presets
+-- ============================================================
+CREATE TABLE IF NOT EXISTS subscribe_pages (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  publication_id  UUID NOT NULL REFERENCES publications(id) ON DELETE CASCADE,
+  name            TEXT NOT NULL,
+  content         JSONB NOT NULL DEFAULT '{}'::jsonb,
+  is_archived     BOOLEAN NOT NULL DEFAULT false,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscribe_pages_pub
+  ON subscribe_pages(publication_id, is_archived);
+
+ALTER TABLE subscribe_pages ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 2. subscribe_ab_tests — test definitions
+-- ============================================================
+CREATE TABLE IF NOT EXISTS subscribe_ab_tests (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  publication_id  UUID NOT NULL REFERENCES publications(id) ON DELETE CASCADE,
+  name            TEXT NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'draft'
+                  CHECK (status IN ('draft','active','ended')),
+  start_date      TIMESTAMPTZ NULL,
+  end_date        TIMESTAMPTZ NULL,
+  started_at      TIMESTAMPTZ NULL,
+  ended_at        TIMESTAMPTZ NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscribe_ab_tests_pub_status
+  ON subscribe_ab_tests(publication_id, status);
+
+-- Enforce a single 'active' test per publication.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_subscribe_ab_tests_one_active_per_pub
+  ON subscribe_ab_tests(publication_id) WHERE status = 'active';
+
+ALTER TABLE subscribe_ab_tests ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 3. subscribe_ab_test_variants — pages-in-test, with weights
+-- ============================================================
+CREATE TABLE IF NOT EXISTS subscribe_ab_test_variants (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  test_id       UUID NOT NULL REFERENCES subscribe_ab_tests(id) ON DELETE CASCADE,
+  page_id       UUID NOT NULL REFERENCES subscribe_pages(id),
+  label         TEXT NOT NULL,
+  weight        INT  NOT NULL DEFAULT 50 CHECK (weight >= 0 AND weight <= 1000),
+  display_order INT  NOT NULL DEFAULT 0,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscribe_ab_test_variants_test
+  ON subscribe_ab_test_variants(test_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_subscribe_ab_test_variants_label
+  ON subscribe_ab_test_variants(test_id, label);
+
+ALTER TABLE subscribe_ab_test_variants ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 4. subscribe_ab_assignments — sticky per-visitor assignment + email link
+-- ============================================================
+CREATE TABLE IF NOT EXISTS subscribe_ab_assignments (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  test_id          UUID NOT NULL REFERENCES subscribe_ab_tests(id) ON DELETE CASCADE,
+  variant_id       UUID NOT NULL REFERENCES subscribe_ab_test_variants(id),
+  publication_id   UUID NOT NULL REFERENCES publications(id) ON DELETE CASCADE,
+  visitor_id       TEXT NOT NULL,
+  subscriber_email TEXT NULL,
+  ip_address       TEXT NULL,
+  user_agent       TEXT NULL,
+  is_bot_ua        BOOLEAN NOT NULL DEFAULT false,
+  assigned_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_subscribe_ab_assignments_test_visitor
+  ON subscribe_ab_assignments(test_id, visitor_id);
+
+CREATE INDEX IF NOT EXISTS idx_subscribe_ab_assignments_email
+  ON subscribe_ab_assignments(test_id, subscriber_email)
+  WHERE subscriber_email IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_subscribe_ab_assignments_pub
+  ON subscribe_ab_assignments(publication_id, assigned_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_subscribe_ab_assignments_pub_email
+  ON subscribe_ab_assignments(publication_id, subscriber_email)
+  WHERE subscriber_email IS NOT NULL;
+
+ALTER TABLE subscribe_ab_assignments ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 5. subscribe_ab_events — granular event log (stats source)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS subscribe_ab_events (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  test_id          UUID NOT NULL REFERENCES subscribe_ab_tests(id) ON DELETE CASCADE,
+  variant_id       UUID NOT NULL REFERENCES subscribe_ab_test_variants(id),
+  publication_id   UUID NOT NULL REFERENCES publications(id) ON DELETE CASCADE,
+  visitor_id       TEXT NULL,
+  subscriber_email TEXT NULL,
+  event_type       TEXT NOT NULL
+                   CHECK (event_type IN
+                     ('page_view','signup','reached_offers','completed_info','sparkloop_signup')),
+  ip_address       TEXT NULL,
+  is_bot_ua        BOOLEAN NOT NULL DEFAULT false,
+  metadata         JSONB NOT NULL DEFAULT '{}'::jsonb,
+  occurred_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscribe_ab_events_test_type
+  ON subscribe_ab_events(test_id, event_type, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_subscribe_ab_events_test_variant
+  ON subscribe_ab_events(test_id, variant_id, event_type);
+
+CREATE INDEX IF NOT EXISTS idx_subscribe_ab_events_pub
+  ON subscribe_ab_events(publication_id, occurred_at DESC);
+
+ALTER TABLE subscribe_ab_events ENABLE ROW LEVEL SECURITY;

--- a/db/migrations/20260424_subscribe_pages_default_flag.sql
+++ b/db/migrations/20260424_subscribe_pages_default_flag.sql
@@ -1,0 +1,14 @@
+-- Migration: Add is_default flag to subscribe_pages
+-- Date: 2026-04-24
+-- Purpose: Allow marking one subscribe_page per publication as the "default"
+--          content rendered on /subscribe when no A/B test is active.
+--          Replaces publication_settings.subscribe_{heading,subheading,tagline}
+--          as the editable source of truth (old keys remain as fallback).
+
+ALTER TABLE subscribe_pages
+  ADD COLUMN IF NOT EXISTS is_default BOOLEAN NOT NULL DEFAULT false;
+
+-- At most one default page per publication. Archived pages can't be default.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_subscribe_pages_one_default_per_pub
+  ON subscribe_pages(publication_id)
+  WHERE is_default = true AND is_archived = false;

--- a/src/app/api/ab-tests/[id]/route.ts
+++ b/src/app/api/ab-tests/[id]/route.ts
@@ -97,8 +97,19 @@ export const PATCH = withApiHandler(
       patch.status = 'active'
       patch.started_at = new Date().toISOString()
     } else if (parsed.action === 'end') {
+      // Only stamp ended_at when ending a test that was actually active.
+      // Drafts that were never started can be ended (cancelled) but get no
+      // ended_at — there's no run to bookend.
+      if (existing.status === 'ended') {
+        return NextResponse.json(
+          { error: 'Test is already ended.' },
+          { status: 400 }
+        )
+      }
       patch.status = 'ended'
-      patch.ended_at = new Date().toISOString()
+      if (existing.status === 'active') {
+        patch.ended_at = new Date().toISOString()
+      }
     }
 
     const { data, error } = await supabaseAdmin

--- a/src/app/api/ab-tests/[id]/route.ts
+++ b/src/app/api/ab-tests/[id]/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withApiHandler } from '@/lib/api-handler'
+import { supabaseAdmin } from '@/lib/supabase'
+
+const patchSchema = z.object({
+  publication_id: z.string().uuid(),
+  action: z.enum(['start', 'end']).optional(),
+  name: z.string().min(1).max(160).optional(),
+  start_date: z.string().datetime().nullable().optional(),
+  end_date: z.string().datetime().nullable().optional(),
+})
+
+export const GET = withApiHandler(
+  {
+    authTier: 'authenticated',
+    logContext: 'ab-tests-get',
+    requirePublicationId: true,
+    inputSchema: z.object({ publication_id: z.string().uuid() }),
+  },
+  async ({ publicationId, params }) => {
+    const { data: test, error } = await supabaseAdmin
+      .from('subscribe_ab_tests')
+      .select('id, publication_id, name, status, start_date, end_date, started_at, ended_at, created_at, updated_at')
+      .eq('id', params.id)
+      .eq('publication_id', publicationId!)
+      .maybeSingle()
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    if (!test) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    const { data: variants } = await supabaseAdmin
+      .from('subscribe_ab_test_variants')
+      .select(`
+        id, test_id, page_id, label, weight, display_order, created_at,
+        page:subscribe_pages!inner(id, name, content, is_archived)
+      `)
+      .eq('test_id', test.id)
+      .order('display_order', { ascending: true })
+
+    return NextResponse.json({
+      success: true,
+      test,
+      variants: (variants || []).map((v: any) => ({
+        ...v,
+        page: Array.isArray(v.page) ? v.page[0] : v.page,
+      })),
+    })
+  }
+)
+
+export const PATCH = withApiHandler(
+  {
+    authTier: 'authenticated',
+    logContext: 'ab-tests-patch',
+    requirePublicationId: true,
+    inputSchema: patchSchema,
+  },
+  async ({ input, publicationId, params }) => {
+    const parsed = input as z.infer<typeof patchSchema>
+
+    const { data: existing } = await supabaseAdmin
+      .from('subscribe_ab_tests')
+      .select('id, status')
+      .eq('id', params.id)
+      .eq('publication_id', publicationId!)
+      .maybeSingle()
+
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() }
+
+    if (parsed.name !== undefined) patch.name = parsed.name
+    if (parsed.start_date !== undefined) patch.start_date = parsed.start_date
+    if (parsed.end_date !== undefined) patch.end_date = parsed.end_date
+
+    if (parsed.action === 'start') {
+      if (existing.status === 'ended') {
+        return NextResponse.json(
+          { error: 'Cannot restart a test that has already ended. Create a new test.' },
+          { status: 400 }
+        )
+      }
+      const { data: activeOther } = await supabaseAdmin
+        .from('subscribe_ab_tests')
+        .select('id')
+        .eq('publication_id', publicationId!)
+        .eq('status', 'active')
+        .neq('id', params.id)
+        .maybeSingle()
+      if (activeOther) {
+        return NextResponse.json(
+          { error: 'Another test is already active for this publication' },
+          { status: 409 }
+        )
+      }
+      patch.status = 'active'
+      patch.started_at = new Date().toISOString()
+    } else if (parsed.action === 'end') {
+      patch.status = 'ended'
+      patch.ended_at = new Date().toISOString()
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('subscribe_ab_tests')
+      .update(patch)
+      .eq('id', params.id)
+      .eq('publication_id', publicationId!)
+      .select('id, publication_id, name, status, start_date, end_date, started_at, ended_at, created_at, updated_at')
+      .maybeSingle()
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+    return NextResponse.json({ success: true, test: data })
+  }
+)

--- a/src/app/api/ab-tests/[id]/stats/route.ts
+++ b/src/app/api/ab-tests/[id]/stats/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withApiHandler } from '@/lib/api-handler'
+import { supabaseAdmin } from '@/lib/supabase'
+import { isIPExcluded, type IPExclusion } from '@/lib/ip-utils'
+import type { SubscribeAbEventType, VariantStatsRow } from '@/lib/ab-tests'
+
+const EVENT_KEYS: SubscribeAbEventType[] = [
+  'page_view',
+  'signup',
+  'reached_offers',
+  'completed_info',
+  'sparkloop_signup',
+]
+
+export const GET = withApiHandler(
+  {
+    authTier: 'authenticated',
+    logContext: 'ab-tests-stats',
+    requirePublicationId: true,
+    inputSchema: z.object({
+      publication_id: z.string().uuid(),
+      exclude_ips: z.enum(['true', 'false']).optional(),
+    }),
+  },
+  async ({ input, publicationId, params }) => {
+    const excludeIps = (input as any).exclude_ips !== 'false'
+
+    // Load the test and its variants (tenant-scoped)
+    const { data: test } = await supabaseAdmin
+      .from('subscribe_ab_tests')
+      .select('id, name, status, started_at, ended_at')
+      .eq('id', params.id)
+      .eq('publication_id', publicationId!)
+      .maybeSingle()
+
+    if (!test) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    const { data: variants } = await supabaseAdmin
+      .from('subscribe_ab_test_variants')
+      .select(`
+        id, label, weight, display_order, page_id,
+        page:subscribe_pages!inner(id, name)
+      `)
+      .eq('test_id', test.id)
+      .order('display_order', { ascending: true })
+
+    if (!variants || variants.length === 0) {
+      return NextResponse.json({ success: true, test, variants: [], stats: [] })
+    }
+
+    // Load exclusions (publication-scoped) once
+    const { data: exclusionRows } = await supabaseAdmin
+      .from('excluded_ips')
+      .select('ip_address, is_range, cidr_prefix')
+      .eq('publication_id', publicationId!)
+
+    const exclusions: IPExclusion[] = (exclusionRows || []) as IPExclusion[]
+
+    // Stream events in bounded pages — enough for expected volumes, filter in JS.
+    // (Stats are per-test so even long-running tests are bounded.)
+    const rows: Array<{ variant_id: string; event_type: string; ip_address: string | null; is_bot_ua: boolean }> = []
+    const PAGE = 1000
+    let offset = 0
+    // Safety ceiling — 500k events per test would far exceed practical needs.
+    while (offset < 500_000) {
+      const { data: chunk, error } = await supabaseAdmin
+        .from('subscribe_ab_events')
+        .select('variant_id, event_type, ip_address, is_bot_ua')
+        .eq('test_id', test.id)
+        .eq('is_bot_ua', false)
+        .order('occurred_at', { ascending: true })
+        .range(offset, offset + PAGE - 1)
+
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+      if (!chunk || chunk.length === 0) break
+
+      rows.push(...chunk)
+      if (chunk.length < PAGE) break
+      offset += PAGE
+    }
+
+    // Aggregate
+    type StatsWithDisplay = VariantStatsRow & { page_name: string; display_order: number }
+    const stats: Record<string, StatsWithDisplay> = {}
+    for (const v of variants) {
+      const pageObj: any = Array.isArray((v as any).page) ? (v as any).page[0] : (v as any).page
+      stats[v.id] = {
+        variant_id: v.id,
+        label: v.label,
+        weight: v.weight,
+        page_views: 0,
+        signups: 0,
+        reached_offers: 0,
+        completed_info: 0,
+        sparkloop_signups: 0,
+        page_name: pageObj?.name || '',
+        display_order: v.display_order,
+      }
+    }
+
+    let excludedCount = 0
+    for (const row of rows) {
+      if (excludeIps && isIPExcluded(row.ip_address, exclusions)) {
+        excludedCount++
+        continue
+      }
+      const s = stats[row.variant_id]
+      if (!s) continue
+
+      const key: Record<SubscribeAbEventType, keyof VariantStatsRow> = {
+        page_view: 'page_views',
+        signup: 'signups',
+        reached_offers: 'reached_offers',
+        completed_info: 'completed_info',
+        sparkloop_signup: 'sparkloop_signups',
+      }
+      const field = key[row.event_type as SubscribeAbEventType]
+      if (field) {
+        ;(s as any)[field] = ((s as any)[field] as number) + 1
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      test,
+      stats: Object.values(stats),
+      meta: {
+        event_types: EVENT_KEYS,
+        excluded_by_ip: excludedCount,
+        total_events_considered: rows.length,
+      },
+    })
+  }
+)

--- a/src/app/api/ab-tests/[id]/stats/route.ts
+++ b/src/app/api/ab-tests/[id]/stats/route.ts
@@ -13,18 +13,33 @@ const EVENT_KEYS: SubscribeAbEventType[] = [
   'sparkloop_signup',
 ]
 
+// Map event_type -> VariantStatsRow counter field. Hoisted so we don't
+// recreate the object on every row during aggregation.
+const EVENT_TYPE_TO_STAT_FIELD: Record<SubscribeAbEventType, keyof VariantStatsRow> = {
+  page_view: 'page_views',
+  signup: 'signups',
+  reached_offers: 'reached_offers',
+  completed_info: 'completed_info',
+  sparkloop_signup: 'sparkloop_signups',
+}
+
+const MAX_EVENTS_PER_TEST = 500_000
+
+const statsInputSchema = z.object({
+  publication_id: z.string().uuid(),
+  exclude_ips: z.enum(['true', 'false']).optional(),
+})
+
 export const GET = withApiHandler(
   {
     authTier: 'authenticated',
     logContext: 'ab-tests-stats',
     requirePublicationId: true,
-    inputSchema: z.object({
-      publication_id: z.string().uuid(),
-      exclude_ips: z.enum(['true', 'false']).optional(),
-    }),
+    inputSchema: statsInputSchema,
   },
-  async ({ input, publicationId, params }) => {
-    const excludeIps = (input as any).exclude_ips !== 'false'
+  async ({ input, publicationId, params, logger }) => {
+    const { exclude_ips } = input as z.infer<typeof statsInputSchema>
+    const excludeIps = exclude_ips !== 'false'
 
     // Load the test and its variants (tenant-scoped)
     const { data: test } = await supabaseAdmin
@@ -62,8 +77,8 @@ export const GET = withApiHandler(
     const rows: Array<{ variant_id: string; event_type: string; ip_address: string | null; is_bot_ua: boolean }> = []
     const PAGE = 1000
     let offset = 0
-    // Safety ceiling — 500k events per test would far exceed practical needs.
-    while (offset < 500_000) {
+    let truncated = false
+    while (offset < MAX_EVENTS_PER_TEST) {
       const { data: chunk, error } = await supabaseAdmin
         .from('subscribe_ab_events')
         .select('variant_id, event_type, ip_address, is_bot_ua')
@@ -78,6 +93,14 @@ export const GET = withApiHandler(
       rows.push(...chunk)
       if (chunk.length < PAGE) break
       offset += PAGE
+
+      if (offset >= MAX_EVENTS_PER_TEST) {
+        truncated = true
+        logger.warn(
+          { testId: test.id, loaded: rows.length, cap: MAX_EVENTS_PER_TEST },
+          'Stats aggregation hit event cap — results are partial'
+        )
+      }
     }
 
     // Aggregate
@@ -108,14 +131,7 @@ export const GET = withApiHandler(
       const s = stats[row.variant_id]
       if (!s) continue
 
-      const key: Record<SubscribeAbEventType, keyof VariantStatsRow> = {
-        page_view: 'page_views',
-        signup: 'signups',
-        reached_offers: 'reached_offers',
-        completed_info: 'completed_info',
-        sparkloop_signup: 'sparkloop_signups',
-      }
-      const field = key[row.event_type as SubscribeAbEventType]
+      const field = EVENT_TYPE_TO_STAT_FIELD[row.event_type as SubscribeAbEventType]
       if (field) {
         ;(s as any)[field] = ((s as any)[field] as number) + 1
       }
@@ -129,6 +145,7 @@ export const GET = withApiHandler(
         event_types: EVENT_KEYS,
         excluded_by_ip: excludedCount,
         total_events_considered: rows.length,
+        truncated,
       },
     })
   }

--- a/src/app/api/ab-tests/route.ts
+++ b/src/app/api/ab-tests/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withApiHandler } from '@/lib/api-handler'
+import { supabaseAdmin } from '@/lib/supabase'
+
+const listSchema = z.object({
+  publication_id: z.string().uuid(),
+  status: z.enum(['draft', 'active', 'ended']).optional(),
+})
+
+const variantInput = z.object({
+  page_id: z.string().uuid(),
+  label: z.string().min(1).max(40),
+  weight: z.number().int().min(0).max(1000).default(50),
+  display_order: z.number().int().min(0).default(0),
+})
+
+const createSchema = z.object({
+  publication_id: z.string().uuid(),
+  name: z.string().min(1).max(160),
+  variants: z.array(variantInput).min(2),
+  start_date: z.string().datetime().optional().nullable(),
+  end_date: z.string().datetime().optional().nullable(),
+  activate: z.boolean().optional(),
+})
+
+export const GET = withApiHandler(
+  {
+    authTier: 'authenticated',
+    logContext: 'ab-tests-list',
+    requirePublicationId: true,
+    inputSchema: listSchema,
+  },
+  async ({ input, publicationId }) => {
+    const parsed = input as z.infer<typeof listSchema>
+
+    let query = supabaseAdmin
+      .from('subscribe_ab_tests')
+      .select('id, publication_id, name, status, start_date, end_date, started_at, ended_at, created_at, updated_at')
+      .eq('publication_id', publicationId!)
+      .order('created_at', { ascending: false })
+
+    if (parsed.status) query = query.eq('status', parsed.status)
+
+    const { data, error } = await query
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+    return NextResponse.json({ success: true, tests: data || [] })
+  }
+)
+
+export const POST = withApiHandler(
+  {
+    authTier: 'authenticated',
+    logContext: 'ab-tests-create',
+    requirePublicationId: true,
+    inputSchema: createSchema,
+  },
+  async ({ input, publicationId }) => {
+    const parsed = input as z.infer<typeof createSchema>
+
+    // Verify variant labels are unique within this test
+    const labelSet = new Set(parsed.variants.map(v => v.label))
+    if (labelSet.size !== parsed.variants.length) {
+      return NextResponse.json(
+        { error: 'Variant labels must be unique within a test' },
+        { status: 400 }
+      )
+    }
+
+    // Verify all referenced pages belong to this publication (tenant isolation)
+    const pageIds = Array.from(new Set(parsed.variants.map(v => v.page_id)))
+    const { data: pages } = await supabaseAdmin
+      .from('subscribe_pages')
+      .select('id')
+      .eq('publication_id', publicationId!)
+      .in('id', pageIds)
+
+    if (!pages || pages.length !== pageIds.length) {
+      return NextResponse.json(
+        { error: 'One or more page_ids do not belong to this publication' },
+        { status: 400 }
+      )
+    }
+
+    // If starting as active, refuse when another active test exists
+    if (parsed.activate) {
+      const { data: existing } = await supabaseAdmin
+        .from('subscribe_ab_tests')
+        .select('id')
+        .eq('publication_id', publicationId!)
+        .eq('status', 'active')
+        .maybeSingle()
+      if (existing) {
+        return NextResponse.json(
+          { error: 'Another test is already active for this publication' },
+          { status: 409 }
+        )
+      }
+    }
+
+    const now = new Date().toISOString()
+    const { data: test, error: testErr } = await supabaseAdmin
+      .from('subscribe_ab_tests')
+      .insert({
+        publication_id: publicationId!,
+        name: parsed.name,
+        status: parsed.activate ? 'active' : 'draft',
+        start_date: parsed.start_date ?? null,
+        end_date: parsed.end_date ?? null,
+        started_at: parsed.activate ? now : null,
+      })
+      .select('id, publication_id, name, status, start_date, end_date, started_at, ended_at, created_at, updated_at')
+      .single()
+
+    if (testErr || !test) {
+      return NextResponse.json({ error: testErr?.message || 'Create failed' }, { status: 500 })
+    }
+
+    const variantRows = parsed.variants.map(v => ({
+      test_id: test.id,
+      page_id: v.page_id,
+      label: v.label,
+      weight: v.weight,
+      display_order: v.display_order,
+    }))
+
+    const { error: varErr } = await supabaseAdmin
+      .from('subscribe_ab_test_variants')
+      .insert(variantRows)
+
+    if (varErr) {
+      // Roll back the test if variant insert failed
+      await supabaseAdmin.from('subscribe_ab_tests').delete().eq('id', test.id)
+      return NextResponse.json({ error: varErr.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true, test })
+  }
+)

--- a/src/app/api/ab-tests/route.ts
+++ b/src/app/api/ab-tests/route.ts
@@ -69,16 +69,18 @@ export const POST = withApiHandler(
     }
 
     // Verify all referenced pages belong to this publication (tenant isolation)
+    // and are not archived — archived pages can't be used in new tests.
     const pageIds = Array.from(new Set(parsed.variants.map(v => v.page_id)))
     const { data: pages } = await supabaseAdmin
       .from('subscribe_pages')
       .select('id')
       .eq('publication_id', publicationId!)
+      .eq('is_archived', false)
       .in('id', pageIds)
 
     if (!pages || pages.length !== pageIds.length) {
       return NextResponse.json(
-        { error: 'One or more page_ids do not belong to this publication' },
+        { error: 'One or more page_ids do not belong to this publication or are archived' },
         { status: 400 }
       )
     }

--- a/src/app/api/cron/ab-test-scheduler/route.ts
+++ b/src/app/api/cron/ab-test-scheduler/route.ts
@@ -1,0 +1,92 @@
+import { withApiHandler } from '@/lib/api-handler'
+import { NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase'
+
+/**
+ * Auto-start tests whose start_date has passed, and auto-end tests whose
+ * end_date has passed. Respects the single-active-test-per-publication
+ * constraint by skipping starts when another test is already active.
+ *
+ * Manual start/end from the dashboard continues to work independently.
+ */
+export const POST = withApiHandler(
+  { authTier: 'system', logContext: 'ab-test-scheduler' },
+  async ({ logger }) => {
+    const now = new Date().toISOString()
+    let startedCount = 0
+    let endedCount = 0
+
+    // 1. End tests past their end_date
+    {
+      const { data: toEnd } = await supabaseAdmin
+        .from('subscribe_ab_tests')
+        .select('id, publication_id, name, end_date')
+        .eq('status', 'active')
+        .not('end_date', 'is', null)
+        .lte('end_date', now)
+
+      for (const t of toEnd || []) {
+        const { error } = await supabaseAdmin
+          .from('subscribe_ab_tests')
+          .update({ status: 'ended', ended_at: now, updated_at: now })
+          .eq('id', t.id)
+          .eq('status', 'active') // guard against races
+        if (error) {
+          logger.error({ err: error, testId: t.id }, 'Failed to end test')
+        } else {
+          endedCount++
+          logger.info({ testId: t.id, pubId: t.publication_id, name: t.name }, 'Auto-ended test')
+        }
+      }
+    }
+
+    // 2. Start draft tests past their start_date (only if no active test for that pub)
+    {
+      const { data: toStart } = await supabaseAdmin
+        .from('subscribe_ab_tests')
+        .select('id, publication_id, name, start_date')
+        .eq('status', 'draft')
+        .not('start_date', 'is', null)
+        .lte('start_date', now)
+
+      for (const t of toStart || []) {
+        const { data: active } = await supabaseAdmin
+          .from('subscribe_ab_tests')
+          .select('id')
+          .eq('publication_id', t.publication_id)
+          .eq('status', 'active')
+          .maybeSingle()
+
+        if (active) {
+          logger.info(
+            { testId: t.id, pubId: t.publication_id },
+            'Skipped auto-start: another test is already active'
+          )
+          continue
+        }
+
+        const { error } = await supabaseAdmin
+          .from('subscribe_ab_tests')
+          .update({ status: 'active', started_at: now, updated_at: now })
+          .eq('id', t.id)
+          .eq('status', 'draft') // guard against races
+        if (error) {
+          logger.error({ err: error, testId: t.id }, 'Failed to start test')
+        } else {
+          startedCount++
+          logger.info({ testId: t.id, pubId: t.publication_id, name: t.name }, 'Auto-started test')
+        }
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      started: startedCount,
+      ended: endedCount,
+      timestamp: now,
+    })
+  }
+)
+
+export const GET = POST
+export const maxDuration = 60

--- a/src/app/api/cron/ab-test-scheduler/route.ts
+++ b/src/app/api/cron/ab-test-scheduler/route.ts
@@ -18,12 +18,20 @@ export const POST = withApiHandler(
 
     // 1. End tests past their end_date
     {
-      const { data: toEnd } = await supabaseAdmin
+      const { data: toEnd, error: toEndErr } = await supabaseAdmin
         .from('subscribe_ab_tests')
         .select('id, publication_id, name, end_date')
         .eq('status', 'active')
         .not('end_date', 'is', null)
         .lte('end_date', now)
+
+      if (toEndErr) {
+        logger.error({ err: toEndErr, now }, 'Failed to load tests to end')
+        return NextResponse.json(
+          { success: false, error: toEndErr.message, phase: 'load_to_end' },
+          { status: 500 }
+        )
+      }
 
       for (const t of toEnd || []) {
         const { error } = await supabaseAdmin
@@ -42,20 +50,43 @@ export const POST = withApiHandler(
 
     // 2. Start draft tests past their start_date (only if no active test for that pub)
     {
-      const { data: toStart } = await supabaseAdmin
+      const { data: toStart, error: toStartErr } = await supabaseAdmin
         .from('subscribe_ab_tests')
         .select('id, publication_id, name, start_date')
         .eq('status', 'draft')
         .not('start_date', 'is', null)
         .lte('start_date', now)
 
+      if (toStartErr) {
+        logger.error({ err: toStartErr, now }, 'Failed to load tests to start')
+        return NextResponse.json(
+          { success: false, error: toStartErr.message, phase: 'load_to_start', ended: endedCount },
+          { status: 500 }
+        )
+      }
+
+      // Track publications we've already started in this run so we don't try
+      // two drafts for the same publication and produce a benign-but-noisy
+      // unique-violation race.
+      const startedPubs = new Set<string>()
+
       for (const t of toStart || []) {
-        const { data: active } = await supabaseAdmin
+        if (startedPubs.has(t.publication_id)) {
+          logger.info({ testId: t.id, pubId: t.publication_id }, 'Skipped auto-start: another draft already started this run')
+          continue
+        }
+
+        const { data: active, error: activeErr } = await supabaseAdmin
           .from('subscribe_ab_tests')
           .select('id')
           .eq('publication_id', t.publication_id)
           .eq('status', 'active')
           .maybeSingle()
+
+        if (activeErr) {
+          logger.error({ err: activeErr, testId: t.id, pubId: t.publication_id }, 'Failed active-test lookup; skipping')
+          continue
+        }
 
         if (active) {
           logger.info(
@@ -71,9 +102,19 @@ export const POST = withApiHandler(
           .eq('id', t.id)
           .eq('status', 'draft') // guard against races
         if (error) {
-          logger.error({ err: error, testId: t.id }, 'Failed to start test')
+          // 23505 = unique_violation (the partial unique index on active tests).
+          // Treat as a benign race loss, not a failure.
+          if ((error as { code?: string }).code === '23505') {
+            logger.info(
+              { testId: t.id, pubId: t.publication_id },
+              'Skipped auto-start: another test won the race'
+            )
+          } else {
+            logger.error({ err: error, testId: t.id }, 'Failed to start test')
+          }
         } else {
           startedCount++
+          startedPubs.add(t.publication_id)
           logger.info({ testId: t.id, pubId: t.publication_id, name: t.name }, 'Auto-started test')
         }
       }

--- a/src/app/api/sparkloop/subscribe/route.ts
+++ b/src/app/api/sparkloop/subscribe/route.ts
@@ -1,12 +1,19 @@
 import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { createHash } from 'crypto'
+import { cookies } from 'next/headers'
 import { createSparkLoopServiceForPublication } from '@/lib/sparkloop-client'
 import { supabaseAdmin } from '@/lib/supabase'
 import { MailerLiteService } from '@/lib/mailerlite'
 import { PUBLICATION_ID } from '@/lib/config'
 import { getEmailProviderSettings } from '@/lib/publication-settings'
 import { updateBeehiivSubscriberField } from '@/lib/beehiiv'
+import {
+  attributeByVisitor,
+  attributeBySubscriberEmail,
+  recordEvent,
+  VISITOR_COOKIE,
+} from '@/lib/ab-tests'
 
 /**
  * POST /api/sparkloop/subscribe
@@ -225,6 +232,36 @@ export const POST = withApiHandler(
     } catch (providerError) {
       console.error('[SparkLoop Subscribe] Email provider update error:', providerError)
       // Don't fail the request for email provider errors
+    }
+
+    // Record A/B sparkloop_signup conversion only on actual SparkLoop success.
+    // Cookie may or may not be present (user can land on /subscribe/recommendations
+    // without going through /subscribe first) — fall back to email-based lookup.
+    if (subscribeResult.success) {
+      try {
+        const cookieStore = await cookies()
+        const visitorId = cookieStore.get(VISITOR_COOKIE)?.value || null
+
+        const attribution = visitorId
+          ? await attributeByVisitor(publicationId, visitorId)
+          : await attributeBySubscriberEmail(publicationId, email)
+
+        if (attribution) {
+          await recordEvent(attribution.testId, attribution.variantId, 'sparkloop_signup', {
+            publicationId,
+            visitorId,
+            subscriberEmail: email,
+            ipAddress: ipAddress || null,
+            userAgent: userAgent || null,
+            metadata: {
+              ref_codes: activeRefCodes,
+              submission_source: submissionSource,
+            },
+          })
+        }
+      } catch (abError) {
+        console.error('[SparkLoop Subscribe] A/B sparkloop_signup event failed:', abError)
+      }
     }
 
     if (subscribeResult.success) {

--- a/src/app/api/subscribe-pages/[id]/route.ts
+++ b/src/app/api/subscribe-pages/[id]/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withApiHandler } from '@/lib/api-handler'
+import { supabaseAdmin } from '@/lib/supabase'
+
+const updateSchema = z.object({
+  publication_id: z.string().uuid(),
+  name: z.string().min(1).max(120).optional(),
+  content: z.record(z.string(), z.string().optional()).optional(),
+  is_archived: z.boolean().optional(),
+})
+
+export const GET = withApiHandler(
+  {
+    authTier: 'authenticated',
+    logContext: 'subscribe-pages-get',
+    requirePublicationId: true,
+    inputSchema: z.object({ publication_id: z.string().uuid() }),
+  },
+  async ({ publicationId, params }) => {
+    const { data, error } = await supabaseAdmin
+      .from('subscribe_pages')
+      .select('id, publication_id, name, content, is_archived, created_at, updated_at')
+      .eq('id', params.id)
+      .eq('publication_id', publicationId!)
+      .maybeSingle()
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    if (!data) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    return NextResponse.json({ success: true, page: data })
+  }
+)
+
+export const PUT = withApiHandler(
+  {
+    authTier: 'authenticated',
+    logContext: 'subscribe-pages-update',
+    requirePublicationId: true,
+    inputSchema: updateSchema,
+  },
+  async ({ input, publicationId, params }) => {
+    const parsed = input as z.infer<typeof updateSchema>
+
+    const patch: Record<string, unknown> = {
+      updated_at: new Date().toISOString(),
+    }
+    if (parsed.name !== undefined) patch.name = parsed.name
+    if (parsed.content !== undefined) patch.content = parsed.content
+    if (parsed.is_archived !== undefined) patch.is_archived = parsed.is_archived
+
+    const { data, error } = await supabaseAdmin
+      .from('subscribe_pages')
+      .update(patch)
+      .eq('id', params.id)
+      .eq('publication_id', publicationId!)
+      .select('id, publication_id, name, content, is_archived, created_at, updated_at')
+      .maybeSingle()
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    if (!data) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    return NextResponse.json({ success: true, page: data })
+  }
+)
+
+export const DELETE = withApiHandler(
+  {
+    authTier: 'authenticated',
+    logContext: 'subscribe-pages-delete',
+    requirePublicationId: true,
+    inputSchema: z.object({ publication_id: z.string().uuid() }),
+  },
+  async ({ publicationId, params }) => {
+    // Soft delete: archive rather than hard-delete so historical A/B tests still
+    // resolve the page row they reference.
+    const { error } = await supabaseAdmin
+      .from('subscribe_pages')
+      .update({ is_archived: true, updated_at: new Date().toISOString() })
+      .eq('id', params.id)
+      .eq('publication_id', publicationId!)
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+    return NextResponse.json({ success: true })
+  }
+)

--- a/src/app/api/subscribe-pages/[id]/route.ts
+++ b/src/app/api/subscribe-pages/[id]/route.ts
@@ -8,6 +8,7 @@ const updateSchema = z.object({
   name: z.string().min(1).max(120).optional(),
   content: z.record(z.string(), z.string().optional()).optional(),
   is_archived: z.boolean().optional(),
+  is_default: z.boolean().optional(),
 })
 
 export const GET = withApiHandler(
@@ -20,7 +21,7 @@ export const GET = withApiHandler(
   async ({ publicationId, params }) => {
     const { data, error } = await supabaseAdmin
       .from('subscribe_pages')
-      .select('id, publication_id, name, content, is_archived, created_at, updated_at')
+      .select('id, publication_id, name, content, is_archived, is_default, created_at, updated_at')
       .eq('id', params.id)
       .eq('publication_id', publicationId!)
       .maybeSingle()
@@ -42,19 +43,48 @@ export const PUT = withApiHandler(
   async ({ input, publicationId, params }) => {
     const parsed = input as z.infer<typeof updateSchema>
 
+    // Look up current state so we can enforce default/archive invariants
+    const { data: current } = await supabaseAdmin
+      .from('subscribe_pages')
+      .select('id, is_default')
+      .eq('id', params.id)
+      .eq('publication_id', publicationId!)
+      .maybeSingle()
+
+    if (!current) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    // Can't archive the current default — user must mark another page default first
+    if (parsed.is_archived === true && current.is_default) {
+      return NextResponse.json(
+        { error: 'Cannot archive the default page. Mark another page as default first.' },
+        { status: 400 }
+      )
+    }
+
+    // If promoting this row to default, clear any existing default in the same publication
+    if (parsed.is_default === true && !current.is_default) {
+      await supabaseAdmin
+        .from('subscribe_pages')
+        .update({ is_default: false, updated_at: new Date().toISOString() })
+        .eq('publication_id', publicationId!)
+        .eq('is_default', true)
+        .neq('id', params.id)
+    }
+
     const patch: Record<string, unknown> = {
       updated_at: new Date().toISOString(),
     }
     if (parsed.name !== undefined) patch.name = parsed.name
     if (parsed.content !== undefined) patch.content = parsed.content
     if (parsed.is_archived !== undefined) patch.is_archived = parsed.is_archived
+    if (parsed.is_default !== undefined) patch.is_default = parsed.is_default
 
     const { data, error } = await supabaseAdmin
       .from('subscribe_pages')
       .update(patch)
       .eq('id', params.id)
       .eq('publication_id', publicationId!)
-      .select('id, publication_id, name, content, is_archived, created_at, updated_at')
+      .select('id, publication_id, name, content, is_archived, is_default, created_at, updated_at')
       .maybeSingle()
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 })
@@ -74,6 +104,21 @@ export const DELETE = withApiHandler(
   async ({ publicationId, params }) => {
     // Soft delete: archive rather than hard-delete so historical A/B tests still
     // resolve the page row they reference.
+    const { data: current } = await supabaseAdmin
+      .from('subscribe_pages')
+      .select('is_default')
+      .eq('id', params.id)
+      .eq('publication_id', publicationId!)
+      .maybeSingle()
+
+    if (!current) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    if (current.is_default) {
+      return NextResponse.json(
+        { error: 'Cannot archive the default page. Mark another page as default first.' },
+        { status: 400 }
+      )
+    }
+
     const { error } = await supabaseAdmin
       .from('subscribe_pages')
       .update({ is_archived: true, updated_at: new Date().toISOString() })

--- a/src/app/api/subscribe-pages/[id]/route.ts
+++ b/src/app/api/subscribe-pages/[id]/route.ts
@@ -119,13 +119,24 @@ export const DELETE = withApiHandler(
       )
     }
 
-    const { error } = await supabaseAdmin
+    // Belt-and-suspenders: also include `is_default = false` in the WHERE so a
+    // promotion racing this delete can't archive the new default before we see it.
+    const { data: archived, error } = await supabaseAdmin
       .from('subscribe_pages')
       .update({ is_archived: true, updated_at: new Date().toISOString() })
       .eq('id', params.id)
       .eq('publication_id', publicationId!)
+      .eq('is_default', false)
+      .select('id')
+      .maybeSingle()
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    if (!archived) {
+      return NextResponse.json(
+        { error: 'Cannot archive the default page. Mark another page as default first.' },
+        { status: 409 }
+      )
+    }
 
     return NextResponse.json({ success: true })
   }

--- a/src/app/api/subscribe-pages/route.ts
+++ b/src/app/api/subscribe-pages/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withApiHandler } from '@/lib/api-handler'
+import { supabaseAdmin } from '@/lib/supabase'
+
+const contentSchema = z.record(z.string(), z.string().optional()).optional()
+
+const listSchema = z.object({
+  publication_id: z.string().uuid(),
+  include_archived: z.enum(['true', 'false']).optional(),
+})
+
+const createSchema = z.object({
+  publication_id: z.string().uuid(),
+  name: z.string().min(1).max(120),
+  content: contentSchema,
+})
+
+export const GET = withApiHandler(
+  {
+    authTier: 'authenticated',
+    logContext: 'subscribe-pages-list',
+    requirePublicationId: true,
+    inputSchema: listSchema,
+  },
+  async ({ input, publicationId }) => {
+    const includeArchived = (input as z.infer<typeof listSchema>).include_archived === 'true'
+
+    let query = supabaseAdmin
+      .from('subscribe_pages')
+      .select('id, publication_id, name, content, is_archived, created_at, updated_at')
+      .eq('publication_id', publicationId!)
+      .order('updated_at', { ascending: false })
+
+    if (!includeArchived) {
+      query = query.eq('is_archived', false)
+    }
+
+    const { data, error } = await query
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true, pages: data || [] })
+  }
+)
+
+export const POST = withApiHandler(
+  {
+    authTier: 'authenticated',
+    logContext: 'subscribe-pages-create',
+    requirePublicationId: true,
+    inputSchema: createSchema,
+  },
+  async ({ input, publicationId }) => {
+    const parsed = input as z.infer<typeof createSchema>
+
+    const { data, error } = await supabaseAdmin
+      .from('subscribe_pages')
+      .insert({
+        publication_id: publicationId!,
+        name: parsed.name,
+        content: parsed.content ?? {},
+      })
+      .select('id, publication_id, name, content, is_archived, created_at, updated_at')
+      .single()
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true, page: data })
+  }
+)

--- a/src/app/api/subscribe-pages/route.ts
+++ b/src/app/api/subscribe-pages/route.ts
@@ -14,6 +14,7 @@ const createSchema = z.object({
   publication_id: z.string().uuid(),
   name: z.string().min(1).max(120),
   content: contentSchema,
+  is_default: z.boolean().optional(),
 })
 
 export const GET = withApiHandler(
@@ -28,8 +29,9 @@ export const GET = withApiHandler(
 
     let query = supabaseAdmin
       .from('subscribe_pages')
-      .select('id, publication_id, name, content, is_archived, created_at, updated_at')
+      .select('id, publication_id, name, content, is_archived, is_default, created_at, updated_at')
       .eq('publication_id', publicationId!)
+      .order('is_default', { ascending: false })
       .order('updated_at', { ascending: false })
 
     if (!includeArchived) {
@@ -55,14 +57,24 @@ export const POST = withApiHandler(
   async ({ input, publicationId }) => {
     const parsed = input as z.infer<typeof createSchema>
 
+    // If marking as default, clear any existing default for this publication first
+    if (parsed.is_default) {
+      await supabaseAdmin
+        .from('subscribe_pages')
+        .update({ is_default: false, updated_at: new Date().toISOString() })
+        .eq('publication_id', publicationId!)
+        .eq('is_default', true)
+    }
+
     const { data, error } = await supabaseAdmin
       .from('subscribe_pages')
       .insert({
         publication_id: publicationId!,
         name: parsed.name,
         content: parsed.content ?? {},
+        is_default: parsed.is_default ?? false,
       })
-      .select('id, publication_id, name, content, is_archived, created_at, updated_at')
+      .select('id, publication_id, name, content, is_archived, is_default, created_at, updated_at')
       .single()
 
     if (error) {

--- a/src/app/api/subscribe/personalize/route.ts
+++ b/src/app/api/subscribe/personalize/route.ts
@@ -1,9 +1,15 @@
 import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
-import { headers } from 'next/headers'
+import { headers, cookies } from 'next/headers'
 import axios from 'axios'
 import { getPublicationByDomain, getEmailProviderSettings } from '@/lib/publication-settings'
 import { SendGridService } from '@/lib/sendgrid'
+import {
+  attributeByVisitor,
+  attributeBySubscriberEmail,
+  recordEvent,
+  VISITOR_COOKIE,
+} from '@/lib/ab-tests'
 
 // MailerLite API client
 const MAILERLITE_API_BASE = 'https://connect.mailerlite.com/api'
@@ -218,6 +224,33 @@ export const POST = withApiHandler(
           throw new Error(mlError.response?.data?.message || 'Failed to update subscriber')
         }
       }
+    }
+
+    // Record A/B test completed_info conversion
+    try {
+      const cookieStore = await cookies()
+      const visitorId = cookieStore.get(VISITOR_COOKIE)?.value || null
+
+      const attribution = visitorId
+        ? await attributeByVisitor(publicationId, visitorId)
+        : await attributeBySubscriberEmail(publicationId, email)
+
+      if (attribution) {
+        const userAgent = request.headers.get('user-agent')
+        const ipAddress =
+          request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+          request.headers.get('x-real-ip') ||
+          null
+        await recordEvent(attribution.testId, attribution.variantId, 'completed_info', {
+          publicationId,
+          visitorId,
+          subscriberEmail: email,
+          ipAddress,
+          userAgent,
+        })
+      }
+    } catch (abError) {
+      console.error('[Personalize] A/B completed_info event failed:', abError)
     }
 
     return NextResponse.json({

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -1,10 +1,16 @@
 import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
-import { headers } from 'next/headers'
+import { headers, cookies } from 'next/headers'
 import axios from 'axios'
 import { getPublicationByDomain, getPublicationSetting, getEmailProviderSettings } from '@/lib/publication-settings'
 import { SendGridService } from '@/lib/sendgrid'
 import { verifyEmail, buildKickboxFields } from '@/lib/kickbox'
+import {
+  attributeByVisitor,
+  attachEmailToAssignment,
+  recordEvent,
+  VISITOR_COOKIE,
+} from '@/lib/ab-tests'
 
 // MailerLite API client
 const MAILERLITE_API_BASE = 'https://connect.mailerlite.com/api'
@@ -241,6 +247,27 @@ export const POST = withApiHandler(
           }, { status: 500 })
         }
       }
+    }
+
+    // Record A/B test signup conversion (no-op when no active test / no cookie)
+    try {
+      const cookieStore = await cookies()
+      const visitorId = cookieStore.get(VISITOR_COOKIE)?.value || null
+      if (visitorId) {
+        const attribution = await attributeByVisitor(publicationId, visitorId)
+        if (attribution) {
+          await attachEmailToAssignment(attribution.testId, visitorId, email)
+          await recordEvent(attribution.testId, attribution.variantId, 'signup', {
+            publicationId,
+            visitorId,
+            subscriberEmail: email,
+            ipAddress,
+            userAgent,
+          })
+        }
+      }
+    } catch (abError) {
+      console.error('[Subscribe] A/B signup event failed:', abError)
     }
 
     const successResponse: Record<string, any> = {

--- a/src/app/dashboard/[slug]/ab-tests/[id]/page.tsx
+++ b/src/app/dashboard/[slug]/ab-tests/[id]/page.tsx
@@ -1,0 +1,240 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useParams, useRouter } from 'next/navigation'
+import Layout from '@/components/Layout'
+
+interface Test {
+  id: string
+  name: string
+  status: 'draft' | 'active' | 'ended'
+  start_date: string | null
+  end_date: string | null
+  started_at: string | null
+  ended_at: string | null
+  created_at: string
+}
+
+interface VariantWithPage {
+  id: string
+  label: string
+  weight: number
+  display_order: number
+  page: { id: string; name: string; content: Record<string, string | undefined> }
+}
+
+interface StatsRow {
+  variant_id: string
+  label: string
+  weight: number
+  page_name?: string
+  page_views: number
+  signups: number
+  reached_offers: number
+  completed_info: number
+  sparkloop_signups: number
+}
+
+interface Newsletter { id: string; slug: string; name: string }
+
+const MIN_VIEWS_FOR_RATE = 50
+
+function rate(numer: number, denom: number): string {
+  if (denom < MIN_VIEWS_FOR_RATE) return '—'
+  return `${((numer / denom) * 100).toFixed(1)}%`
+}
+
+function StatusPill({ status }: { status: Test['status'] }) {
+  const cls =
+    status === 'active'
+      ? 'bg-green-100 text-green-800'
+      : status === 'draft'
+      ? 'bg-gray-100 text-gray-700'
+      : 'bg-slate-200 text-slate-600'
+  return <span className={`px-2 py-0.5 rounded text-xs font-medium ${cls}`}>{status}</span>
+}
+
+export default function AbTestDetailPage() {
+  const { slug, id } = useParams() as { slug: string; id: string }
+  const router = useRouter()
+  const [newsletter, setNewsletter] = useState<Newsletter | null>(null)
+  const [test, setTest] = useState<Test | null>(null)
+  const [variants, setVariants] = useState<VariantWithPage[]>([])
+  const [stats, setStats] = useState<StatsRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+
+  const publicationId = newsletter?.id
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch('/api/newsletters')
+      const json = await res.json()
+      const found = (json.newsletters || []).find((n: Newsletter) => n.slug === slug)
+      setNewsletter(found || null)
+    }
+    load()
+  }, [slug])
+
+  useEffect(() => {
+    if (!publicationId) return
+    fetchAll()
+  }, [publicationId, id])
+
+  async function fetchAll() {
+    if (!publicationId) return
+    setLoading(true)
+    const [tRes, sRes] = await Promise.all([
+      fetch(`/api/ab-tests/${id}?publication_id=${publicationId}`),
+      fetch(`/api/ab-tests/${id}/stats?publication_id=${publicationId}`),
+    ])
+    const t = await tRes.json()
+    const s = await sRes.json()
+    setTest(t.test || null)
+    setVariants(t.variants || [])
+    setStats(s.stats || [])
+    setLoading(false)
+  }
+
+  async function lifecycle(action: 'start' | 'end') {
+    if (!publicationId || !test) return
+    if (action === 'end' && !confirm('End this test? Further visitors will not count toward it.')) return
+    setBusy(true)
+    try {
+      const res = await fetch(`/api/ab-tests/${test.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ publication_id: publicationId, action }),
+      })
+      if (!res.ok) {
+        const err = await res.json()
+        throw new Error(err.error || `${action} failed`)
+      }
+      await fetchAll()
+    } catch (e: any) {
+      alert(e.message || 'Failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function reuseInNewTest() {
+    if (!test) return
+    // Send user to /new — they'll re-pick the pages. Simple + keeps code paths unified.
+    router.push(`/dashboard/${slug}/ab-tests/new`)
+  }
+
+  if (loading) {
+    return <Layout><div className="text-center py-16 text-gray-500">Loading…</div></Layout>
+  }
+  if (!test) {
+    return <Layout><div className="text-center py-16 text-gray-500">Test not found.</div></Layout>
+  }
+
+  const totalPageViews = stats.reduce((sum, s) => sum + s.page_views, 0)
+
+  return (
+    <Layout>
+      <div className="px-4 py-6 sm:px-0 max-w-5xl">
+        <nav className="flex" aria-label="Breadcrumb">
+          <ol className="flex items-center space-x-2">
+            <li><Link href={`/dashboard/${slug}/ab-tests`} className="text-gray-500 hover:text-gray-700">A/B Tests</Link></li>
+            <li><span className="text-gray-500">/</span></li>
+            <li><span className="text-gray-900 font-medium truncate max-w-md inline-block">{test.name}</span></li>
+          </ol>
+        </nav>
+
+        <div className="flex items-center justify-between mt-2 mb-4">
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold text-gray-900">{test.name}</h1>
+              <StatusPill status={test.status} />
+            </div>
+            <div className="text-xs text-gray-500 mt-1">
+              Created {new Date(test.created_at).toLocaleString()}
+              {test.started_at && ` • Started ${new Date(test.started_at).toLocaleString()}`}
+              {test.ended_at && ` • Ended ${new Date(test.ended_at).toLocaleString()}`}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {test.status === 'draft' && (
+              <button
+                onClick={() => lifecycle('start')}
+                disabled={busy}
+                className="px-3 py-2 bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
+              >
+                Start Test
+              </button>
+            )}
+            {test.status === 'active' && (
+              <button
+                onClick={() => lifecycle('end')}
+                disabled={busy}
+                className="px-3 py-2 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+              >
+                End Test
+              </button>
+            )}
+            {test.status === 'ended' && (
+              <button
+                onClick={reuseInNewTest}
+                className="px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              >
+                Use pages in new test
+              </button>
+            )}
+          </div>
+        </div>
+
+        {totalPageViews < MIN_VIEWS_FOR_RATE && (
+          <div className="mb-4 text-xs text-gray-500">
+            Conversion rates will appear once a variant reaches {MIN_VIEWS_FOR_RATE} page views.
+          </div>
+        )}
+
+        <div className="overflow-x-auto bg-white border rounded-lg">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50 text-gray-600">
+              <tr>
+                <th className="text-left px-3 py-2">Variant</th>
+                <th className="text-left px-3 py-2">Page</th>
+                <th className="text-right px-3 py-2">Weight</th>
+                <th className="text-right px-3 py-2">Page Views</th>
+                <th className="text-right px-3 py-2">Signups</th>
+                <th className="text-right px-3 py-2">Signup %</th>
+                <th className="text-right px-3 py-2">Reached Offers</th>
+                <th className="text-right px-3 py-2">Completed Info</th>
+                <th className="text-right px-3 py-2">SparkLoop Signups</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {variants.map(v => {
+                const s = stats.find(r => r.variant_id === v.id)
+                const pageViews = s?.page_views || 0
+                const signups = s?.signups || 0
+                return (
+                  <tr key={v.id}>
+                    <td className="px-3 py-2 font-medium">{v.label}</td>
+                    <td className="px-3 py-2 text-gray-700">{v.page?.name || '—'}</td>
+                    <td className="px-3 py-2 text-right">{v.weight}</td>
+                    <td className="px-3 py-2 text-right">{pageViews}</td>
+                    <td className="px-3 py-2 text-right">{signups}</td>
+                    <td className="px-3 py-2 text-right">{rate(signups, pageViews)}</td>
+                    <td className="px-3 py-2 text-right">{s?.reached_offers ?? 0}</td>
+                    <td className="px-3 py-2 text-right">{s?.completed_info ?? 0}</td>
+                    <td className="px-3 py-2 text-right">{s?.sparkloop_signups ?? 0}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <p className="text-xs text-gray-500 mt-4">
+          Bot user-agents are excluded automatically. IPs listed in the excluded_ips table are filtered from all counts above.
+        </p>
+      </div>
+    </Layout>
+  )
+}

--- a/src/app/dashboard/[slug]/ab-tests/[id]/page.tsx
+++ b/src/app/dashboard/[slug]/ab-tests/[id]/page.tsx
@@ -85,16 +85,24 @@ export default function AbTestDetailPage() {
   async function fetchAll() {
     if (!publicationId) return
     setLoading(true)
-    const [tRes, sRes] = await Promise.all([
-      fetch(`/api/ab-tests/${id}?publication_id=${publicationId}`),
-      fetch(`/api/ab-tests/${id}/stats?publication_id=${publicationId}`),
-    ])
-    const t = await tRes.json()
-    const s = await sRes.json()
-    setTest(t.test || null)
-    setVariants(t.variants || [])
-    setStats(s.stats || [])
-    setLoading(false)
+    try {
+      const [tRes, sRes] = await Promise.all([
+        fetch(`/api/ab-tests/${id}?publication_id=${publicationId}`),
+        fetch(`/api/ab-tests/${id}/stats?publication_id=${publicationId}`),
+      ])
+      const t = await tRes.json()
+      const s = await sRes.json()
+      setTest(t.test || null)
+      setVariants(t.variants || [])
+      setStats(s.stats || [])
+    } catch (err) {
+      console.error('[AbTestDetail] fetch failed', err)
+      setTest(null)
+      setVariants([])
+      setStats([])
+    } finally {
+      setLoading(false)
+    }
   }
 
   async function lifecycle(action: 'start' | 'end') {

--- a/src/app/dashboard/[slug]/ab-tests/new/page.tsx
+++ b/src/app/dashboard/[slug]/ab-tests/new/page.tsx
@@ -59,7 +59,19 @@ export default function NewAbTestPage() {
   }
 
   function addVariant() {
-    const nextLabel = String.fromCharCode(65 + variants.length) // C, D, …
+    const used = new Set(variants.map(v => v.label.trim()))
+    let nextLabel = ''
+    // Prefer the first unused uppercase letter A..Z
+    for (let i = 0; i < 26; i++) {
+      const candidate = String.fromCharCode(65 + i)
+      if (!used.has(candidate)) { nextLabel = candidate; break }
+    }
+    // 26+ variants — fall back to V<n> incrementing until unique
+    if (!nextLabel) {
+      let n = 1
+      while (used.has(`V${n}`)) n++
+      nextLabel = `V${n}`
+    }
     setVariants(v => [...v, { page_id: '', label: nextLabel, weight: 50 }])
   }
 
@@ -107,7 +119,8 @@ export default function NewAbTestPage() {
     }
   }
 
-  const usablePages = pages.filter(p => p) // active list already from API
+  // The API already filters out archived pages by default.
+  const usablePages = pages
 
   return (
     <Layout>

--- a/src/app/dashboard/[slug]/ab-tests/new/page.tsx
+++ b/src/app/dashboard/[slug]/ab-tests/new/page.tsx
@@ -1,0 +1,241 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useParams, useRouter } from 'next/navigation'
+import Layout from '@/components/Layout'
+
+interface SubscribePage {
+  id: string
+  name: string
+}
+interface Newsletter { id: string; slug: string; name: string }
+
+interface VariantRow {
+  page_id: string
+  label: string
+  weight: number
+}
+
+export default function NewAbTestPage() {
+  const { slug } = useParams() as { slug: string }
+  const router = useRouter()
+  const [newsletter, setNewsletter] = useState<Newsletter | null>(null)
+  const [pages, setPages] = useState<SubscribePage[]>([])
+  const [name, setName] = useState('')
+  const [variants, setVariants] = useState<VariantRow[]>([
+    { page_id: '', label: 'A', weight: 50 },
+    { page_id: '', label: 'B', weight: 50 },
+  ])
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [activate, setActivate] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  const publicationId = newsletter?.id
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch('/api/newsletters')
+      const json = await res.json()
+      const found = (json.newsletters || []).find((n: Newsletter) => n.slug === slug)
+      setNewsletter(found || null)
+    }
+    load()
+  }, [slug])
+
+  useEffect(() => {
+    if (!publicationId) return
+    async function loadPages() {
+      const res = await fetch(`/api/subscribe-pages?publication_id=${publicationId}`)
+      const json = await res.json()
+      setPages(json.pages || [])
+    }
+    loadPages()
+  }, [publicationId])
+
+  function setVariant(idx: number, patch: Partial<VariantRow>) {
+    setVariants(v => v.map((row, i) => (i === idx ? { ...row, ...patch } : row)))
+  }
+
+  function addVariant() {
+    const nextLabel = String.fromCharCode(65 + variants.length) // C, D, …
+    setVariants(v => [...v, { page_id: '', label: nextLabel, weight: 50 }])
+  }
+
+  function removeVariant(idx: number) {
+    if (variants.length <= 2) return
+    setVariants(v => v.filter((_, i) => i !== idx))
+  }
+
+  async function submit() {
+    if (!publicationId) return
+    if (!name.trim()) { alert('Name is required'); return }
+    if (variants.some(v => !v.page_id)) { alert('Every variant needs a page selected'); return }
+    const labels = new Set(variants.map(v => v.label.trim()))
+    if (labels.size !== variants.length) { alert('Variant labels must be unique'); return }
+
+    setBusy(true)
+    try {
+      const res = await fetch('/api/ab-tests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          publication_id: publicationId,
+          name,
+          variants: variants.map((v, i) => ({
+            page_id: v.page_id,
+            label: v.label.trim(),
+            weight: Number(v.weight) || 0,
+            display_order: i,
+          })),
+          start_date: startDate ? new Date(startDate).toISOString() : null,
+          end_date: endDate ? new Date(endDate).toISOString() : null,
+          activate,
+        }),
+      })
+      if (!res.ok) {
+        const err = await res.json()
+        throw new Error(err.error || 'Create failed')
+      }
+      const data = await res.json()
+      router.push(`/dashboard/${slug}/ab-tests/${data.test.id}`)
+    } catch (e: any) {
+      alert(e.message || 'Failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const usablePages = pages.filter(p => p) // active list already from API
+
+  return (
+    <Layout>
+      <div className="px-4 py-6 sm:px-0 max-w-3xl">
+        <nav className="flex" aria-label="Breadcrumb">
+          <ol className="flex items-center space-x-2">
+            <li><Link href={`/dashboard/${slug}/ab-tests`} className="text-gray-500 hover:text-gray-700">A/B Tests</Link></li>
+            <li><span className="text-gray-500">/</span></li>
+            <li><span className="text-gray-900 font-medium">New</span></li>
+          </ol>
+        </nav>
+        <h1 className="text-2xl font-bold text-gray-900 mt-2 mb-4">New A/B Test</h1>
+
+        {usablePages.length < 2 && (
+          <div className="mb-4 p-3 rounded border border-yellow-300 bg-yellow-50 text-sm text-yellow-900">
+            You need at least two subscribe pages to run a test.{' '}
+            <Link href={`/dashboard/${slug}/subscribe-pages`} className="underline">Create pages →</Link>
+          </div>
+        )}
+
+        <div className="bg-white border rounded-lg p-5 space-y-5">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Test name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full border rounded px-3 py-2"
+              placeholder="e.g. Heading tone Oct 2026"
+            />
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-sm font-medium text-gray-700">Variants</label>
+              <button onClick={addVariant} className="text-sm text-blue-600 hover:underline">+ Add variant</button>
+            </div>
+            <div className="space-y-2">
+              {variants.map((v, i) => (
+                <div key={i} className="grid grid-cols-12 gap-2 items-center">
+                  <input
+                    type="text"
+                    value={v.label}
+                    onChange={(e) => setVariant(i, { label: e.target.value })}
+                    className="col-span-2 border rounded px-2 py-1"
+                    placeholder="A"
+                  />
+                  <select
+                    value={v.page_id}
+                    onChange={(e) => setVariant(i, { page_id: e.target.value })}
+                    className="col-span-6 border rounded px-2 py-1"
+                  >
+                    <option value="">-- pick page --</option>
+                    {usablePages.map(p => (
+                      <option key={p.id} value={p.id}>{p.name}</option>
+                    ))}
+                  </select>
+                  <div className="col-span-3 flex items-center gap-1">
+                    <input
+                      type="number"
+                      min="0"
+                      max="1000"
+                      value={v.weight}
+                      onChange={(e) => setVariant(i, { weight: Number(e.target.value) })}
+                      className="w-full border rounded px-2 py-1"
+                    />
+                    <span className="text-xs text-gray-500">wt</span>
+                  </div>
+                  <button
+                    onClick={() => removeVariant(i)}
+                    disabled={variants.length <= 2}
+                    className="col-span-1 text-xs text-red-600 disabled:text-gray-300"
+                    aria-label="Remove variant"
+                  >
+                    ✕
+                  </button>
+                </div>
+              ))}
+            </div>
+            <p className="text-xs text-gray-500 mt-2">
+              Traffic is split in proportion to each variant&apos;s weight. Equal weights = even split.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Start date (optional)</label>
+              <input
+                type="datetime-local"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="w-full border rounded px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">End date (optional)</label>
+              <input
+                type="datetime-local"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                className="w-full border rounded px-3 py-2"
+              />
+            </div>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={activate}
+              onChange={(e) => setActivate(e.target.checked)}
+            />
+            Start the test immediately (otherwise saved as draft)
+          </label>
+
+          <div className="flex justify-end gap-3">
+            <Link href={`/dashboard/${slug}/ab-tests`} className="px-4 py-2 text-gray-700 hover:bg-gray-100 rounded">
+              Cancel
+            </Link>
+            <button
+              onClick={submit}
+              disabled={busy || usablePages.length < 2}
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+            >
+              {busy ? 'Saving…' : 'Create Test'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  )
+}

--- a/src/app/dashboard/[slug]/ab-tests/page.tsx
+++ b/src/app/dashboard/[slug]/ab-tests/page.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import Layout from '@/components/Layout'
+
+interface AbTest {
+  id: string
+  name: string
+  status: 'draft' | 'active' | 'ended'
+  start_date: string | null
+  end_date: string | null
+  started_at: string | null
+  ended_at: string | null
+  created_at: string
+}
+
+interface Newsletter { id: string; slug: string; name: string }
+
+function StatusPill({ status }: { status: AbTest['status'] }) {
+  const cls =
+    status === 'active'
+      ? 'bg-green-100 text-green-800'
+      : status === 'draft'
+      ? 'bg-gray-100 text-gray-700'
+      : 'bg-slate-200 text-slate-600'
+  return <span className={`px-2 py-0.5 rounded text-xs font-medium ${cls}`}>{status}</span>
+}
+
+export default function AbTestsDashboardPage() {
+  const { slug } = useParams() as { slug: string }
+  const [newsletter, setNewsletter] = useState<Newsletter | null>(null)
+  const [tests, setTests] = useState<AbTest[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const publicationId = newsletter?.id
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch('/api/newsletters')
+      const json = await res.json()
+      const found = (json.newsletters || []).find((n: Newsletter) => n.slug === slug)
+      setNewsletter(found || null)
+    }
+    load()
+  }, [slug])
+
+  useEffect(() => {
+    if (!publicationId) return
+    async function fetchTests() {
+      setLoading(true)
+      const res = await fetch(`/api/ab-tests?publication_id=${publicationId}`)
+      const json = await res.json()
+      setTests(json.tests || [])
+      setLoading(false)
+    }
+    fetchTests()
+  }, [publicationId])
+
+  return (
+    <Layout>
+      <div className="px-4 py-6 sm:px-0">
+        <div className="flex justify-between items-center mb-6">
+          <div>
+            <nav className="flex" aria-label="Breadcrumb">
+              <ol className="flex items-center space-x-2">
+                <li><Link href={`/dashboard/${slug}`} className="text-gray-500 hover:text-gray-700">Dashboard</Link></li>
+                <li><span className="text-gray-500">/</span></li>
+                <li><span className="text-gray-900 font-medium">A/B Tests</span></li>
+              </ol>
+            </nav>
+            <h1 className="text-2xl font-bold text-gray-900 mt-2">Subscribe Page A/B Tests</h1>
+            <p className="text-gray-600">Compare subscribe-page variants. Stats reset per test.</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <Link href={`/dashboard/${slug}/subscribe-pages`} className="text-sm text-brand-primary hover:underline">
+              Manage pages →
+            </Link>
+            <Link
+              href={`/dashboard/${slug}/ab-tests/new`}
+              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            >
+              New Test
+            </Link>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="text-center py-12 text-gray-500">Loading…</div>
+        ) : tests.length === 0 ? (
+          <div className="text-center py-12 text-gray-500 border border-dashed rounded-lg">
+            No tests yet.
+          </div>
+        ) : (
+          <ul className="divide-y border rounded-lg bg-white">
+            {tests.map(t => (
+              <li key={t.id} className="px-4 py-3">
+                <Link href={`/dashboard/${slug}/ab-tests/${t.id}`} className="flex items-center justify-between hover:bg-gray-50 -mx-4 px-4 py-1 rounded">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-gray-900">{t.name}</span>
+                      <StatusPill status={t.status} />
+                    </div>
+                    <div className="text-xs text-gray-500 mt-0.5">
+                      Created {new Date(t.created_at).toLocaleDateString()}
+                      {t.started_at && ` • Started ${new Date(t.started_at).toLocaleDateString()}`}
+                      {t.ended_at && ` • Ended ${new Date(t.ended_at).toLocaleDateString()}`}
+                    </div>
+                  </div>
+                  <span className="text-brand-primary text-sm">View →</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Layout>
+  )
+}

--- a/src/app/dashboard/[slug]/ab-tests/page.tsx
+++ b/src/app/dashboard/[slug]/ab-tests/page.tsx
@@ -38,10 +38,18 @@ export default function AbTestsDashboardPage() {
 
   useEffect(() => {
     async function load() {
-      const res = await fetch('/api/newsletters')
-      const json = await res.json()
-      const found = (json.newsletters || []).find((n: Newsletter) => n.slug === slug)
-      setNewsletter(found || null)
+      try {
+        const res = await fetch('/api/newsletters')
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const json = await res.json()
+        const found = (json.newsletters || []).find((n: Newsletter) => n.slug === slug)
+        setNewsletter(found || null)
+        if (!found) setLoading(false)
+      } catch (err) {
+        console.error('[AbTestsList] newsletter load failed', err)
+        setNewsletter(null)
+        setLoading(false)
+      }
     }
     load()
   }, [slug])
@@ -50,10 +58,16 @@ export default function AbTestsDashboardPage() {
     if (!publicationId) return
     async function fetchTests() {
       setLoading(true)
-      const res = await fetch(`/api/ab-tests?publication_id=${publicationId}`)
-      const json = await res.json()
-      setTests(json.tests || [])
-      setLoading(false)
+      try {
+        const res = await fetch(`/api/ab-tests?publication_id=${publicationId}`)
+        const json = await res.json()
+        setTests(json.tests || [])
+      } catch (err) {
+        console.error('[AbTestsList] fetchTests failed', err)
+        setTests([])
+      } finally {
+        setLoading(false)
+      }
     }
     fetchTests()
   }, [publicationId])

--- a/src/app/dashboard/[slug]/subscribe-pages/page.tsx
+++ b/src/app/dashboard/[slug]/subscribe-pages/page.tsx
@@ -11,6 +11,7 @@ interface SubscribePage {
   name: string
   content: Record<string, string | undefined>
   is_archived: boolean
+  is_default: boolean
   created_at: string
   updated_at: string
 }
@@ -36,7 +37,11 @@ export default function SubscribePagesDashboardPage() {
   const [loading, setLoading] = useState(true)
   const [editing, setEditing] = useState<SubscribePage | null>(null)
   const [creating, setCreating] = useState(false)
-  const [form, setForm] = useState<{ name: string; content: Record<string, string> }>({ name: '', content: {} })
+  const [form, setForm] = useState<{ name: string; content: Record<string, string>; is_default: boolean }>({
+    name: '',
+    content: {},
+    is_default: false,
+  })
   const [busy, setBusy] = useState(false)
 
   const publicationId = newsletter?.id
@@ -67,7 +72,9 @@ export default function SubscribePagesDashboardPage() {
 
   function openCreate() {
     setEditing(null)
-    setForm({ name: '', content: {} })
+    // If no page is default yet, suggest making the first one default
+    const suggestDefault = !pages.some(p => p.is_default && !p.is_archived)
+    setForm({ name: '', content: {}, is_default: suggestDefault })
     setCreating(true)
   }
 
@@ -79,13 +86,14 @@ export default function SubscribePagesDashboardPage() {
       content: Object.fromEntries(
         Object.entries(p.content || {}).map(([k, v]) => [k, v ?? ''])
       ) as Record<string, string>,
+      is_default: p.is_default,
     })
   }
 
   function closeForm() {
     setEditing(null)
     setCreating(false)
-    setForm({ name: '', content: {} })
+    setForm({ name: '', content: {}, is_default: false })
   }
 
   async function submit() {
@@ -108,6 +116,7 @@ export default function SubscribePagesDashboardPage() {
             publication_id: publicationId,
             name: form.name,
             content: cleanContent,
+            is_default: form.is_default,
           }),
         })
         if (!res.ok) {
@@ -122,6 +131,7 @@ export default function SubscribePagesDashboardPage() {
             publication_id: publicationId,
             name: form.name,
             content: cleanContent,
+            is_default: form.is_default,
           }),
         })
         if (!res.ok) {
@@ -138,8 +148,27 @@ export default function SubscribePagesDashboardPage() {
     }
   }
 
+  async function setAsDefault(p: SubscribePage) {
+    if (!publicationId) return
+    const res = await fetch(`/api/subscribe-pages/${p.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ publication_id: publicationId, is_default: true }),
+    })
+    if (!res.ok) {
+      const err = await res.json()
+      alert(err.error || 'Failed to set default')
+      return
+    }
+    await fetchPages()
+  }
+
   async function archive(p: SubscribePage) {
     if (!publicationId) return
+    if (p.is_default) {
+      alert('Mark another page as default before archiving this one.')
+      return
+    }
     if (!confirm(`Archive "${p.name}"? Existing tests referencing it keep working.`)) return
     const res = await fetch(`/api/subscribe-pages/${p.id}?publication_id=${publicationId}`, { method: 'DELETE' })
     if (!res.ok) {
@@ -151,6 +180,7 @@ export default function SubscribePagesDashboardPage() {
   }
 
   const visiblePages = useMemo(() => pages.filter(p => !p.is_archived), [pages])
+  const hasDefault = useMemo(() => visiblePages.some(p => p.is_default), [visiblePages])
 
   return (
     <Layout>
@@ -165,7 +195,10 @@ export default function SubscribePagesDashboardPage() {
               </ol>
             </nav>
             <h1 className="text-2xl font-bold text-gray-900 mt-2">Subscribe Pages</h1>
-            <p className="text-gray-600">Reusable /subscribe content presets you can run A/B tests against.</p>
+            <p className="text-gray-600">
+              The <strong>default</strong> page is what visitors see on /subscribe when no A/B test is running.
+              A/B tests pick 2+ pages to compare.
+            </p>
           </div>
           <div className="flex items-center gap-3">
             <Link
@@ -183,25 +216,54 @@ export default function SubscribePagesDashboardPage() {
           </div>
         </div>
 
+        {!hasDefault && visiblePages.length > 0 && (
+          <div className="mb-4 p-3 rounded border border-yellow-300 bg-yellow-50 text-sm text-yellow-900">
+            No page is currently marked as <strong>default</strong>. /subscribe will fall back to your publication_settings values.
+            Set a page as default to manage content from here instead.
+          </div>
+        )}
+
         {loading ? (
           <div className="text-center py-12 text-gray-500">Loading…</div>
         ) : visiblePages.length === 0 ? (
           <div className="text-center py-12 text-gray-500 border border-dashed rounded-lg">
-            No pages yet. Create one to start A/B testing your /subscribe page.
+            No pages yet. Create one to manage your /subscribe content and start A/B testing.
           </div>
         ) : (
           <ul className="divide-y border rounded-lg bg-white">
             {visiblePages.map(p => (
               <li key={p.id} className="flex items-center justify-between px-4 py-3">
-                <div>
-                  <div className="font-medium text-gray-900">{p.name}</div>
-                  <div className="text-sm text-gray-500 truncate max-w-xl">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-gray-900">{p.name}</span>
+                    {p.is_default && (
+                      <span className="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
+                        Default
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-sm text-gray-500 truncate max-w-xl mt-0.5">
                     {p.content?.heading || <span className="italic">(uses publication default heading)</span>}
                   </div>
                 </div>
-                <div className="flex items-center gap-3">
+                <div className="flex items-center gap-3 flex-shrink-0">
+                  {!p.is_default && (
+                    <button
+                      onClick={() => setAsDefault(p)}
+                      className="text-sm text-green-700 hover:underline"
+                    >
+                      Set as Default
+                    </button>
+                  )}
                   <button onClick={() => openEdit(p)} className="text-sm text-blue-600 hover:underline">Edit</button>
-                  <button onClick={() => archive(p)} className="text-sm text-red-600 hover:underline">Archive</button>
+                  <button
+                    onClick={() => archive(p)}
+                    className={`text-sm ${p.is_default ? 'text-gray-300 cursor-not-allowed' : 'text-red-600 hover:underline'}`}
+                    disabled={p.is_default}
+                    title={p.is_default ? 'Default page cannot be archived' : ''}
+                  >
+                    Archive
+                  </button>
                 </div>
               </li>
             ))}
@@ -223,6 +285,15 @@ export default function SubscribePagesDashboardPage() {
                 className="w-full border rounded px-3 py-2 mb-4"
                 placeholder="e.g. Bold heading / Control / v3"
               />
+
+              <label className="flex items-center gap-2 text-sm text-gray-700 mb-4">
+                <input
+                  type="checkbox"
+                  checked={form.is_default}
+                  onChange={(e) => setForm({ ...form, is_default: e.target.checked })}
+                />
+                Use as the default /subscribe page (replaces any current default)
+              </label>
 
               <div className="space-y-3">
                 <p className="text-xs text-gray-500">

--- a/src/app/dashboard/[slug]/subscribe-pages/page.tsx
+++ b/src/app/dashboard/[slug]/subscribe-pages/page.tsx
@@ -1,0 +1,277 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import Layout from '@/components/Layout'
+
+interface SubscribePage {
+  id: string
+  publication_id: string
+  name: string
+  content: Record<string, string | undefined>
+  is_archived: boolean
+  created_at: string
+  updated_at: string
+}
+
+interface Newsletter {
+  id: string
+  slug: string
+  name: string
+}
+
+const CONTENT_FIELDS: Array<{ key: string; label: string; multiline?: boolean; placeholder?: string }> = [
+  { key: 'heading', label: 'Heading', multiline: true, placeholder: 'Master AI Tools, Prompts & News **in Just 3 Minutes a Day**' },
+  { key: 'subheading', label: 'Subheading', multiline: true, placeholder: 'Join 10,000+ professionals…' },
+  { key: 'tagline', label: 'Tagline', placeholder: 'FREE FOREVER' },
+  { key: 'logo_url', label: 'Logo URL (override)', placeholder: '' },
+  { key: 'cta_text', label: 'CTA button text (override)', placeholder: '' },
+]
+
+export default function SubscribePagesDashboardPage() {
+  const { slug } = useParams() as { slug: string }
+  const [newsletter, setNewsletter] = useState<Newsletter | null>(null)
+  const [pages, setPages] = useState<SubscribePage[]>([])
+  const [loading, setLoading] = useState(true)
+  const [editing, setEditing] = useState<SubscribePage | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [form, setForm] = useState<{ name: string; content: Record<string, string> }>({ name: '', content: {} })
+  const [busy, setBusy] = useState(false)
+
+  const publicationId = newsletter?.id
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch('/api/newsletters')
+      const json = await res.json()
+      const found = (json.newsletters || []).find((n: Newsletter) => n.slug === slug)
+      setNewsletter(found || null)
+    }
+    load()
+  }, [slug])
+
+  useEffect(() => {
+    if (!publicationId) return
+    fetchPages()
+  }, [publicationId])
+
+  async function fetchPages() {
+    if (!publicationId) return
+    setLoading(true)
+    const res = await fetch(`/api/subscribe-pages?publication_id=${publicationId}&include_archived=true`)
+    const json = await res.json()
+    setPages(json.pages || [])
+    setLoading(false)
+  }
+
+  function openCreate() {
+    setEditing(null)
+    setForm({ name: '', content: {} })
+    setCreating(true)
+  }
+
+  function openEdit(p: SubscribePage) {
+    setCreating(false)
+    setEditing(p)
+    setForm({
+      name: p.name,
+      content: Object.fromEntries(
+        Object.entries(p.content || {}).map(([k, v]) => [k, v ?? ''])
+      ) as Record<string, string>,
+    })
+  }
+
+  function closeForm() {
+    setEditing(null)
+    setCreating(false)
+    setForm({ name: '', content: {} })
+  }
+
+  async function submit() {
+    if (!publicationId) return
+    if (!form.name.trim()) { alert('Name is required'); return }
+    setBusy(true)
+    try {
+      // Strip empty strings so defaults fall through to publication_settings
+      const cleanContent: Record<string, string> = {}
+      for (const [k, v] of Object.entries(form.content)) {
+        const trimmed = (v || '').trim()
+        if (trimmed) cleanContent[k] = trimmed
+      }
+
+      if (creating) {
+        const res = await fetch('/api/subscribe-pages', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            publication_id: publicationId,
+            name: form.name,
+            content: cleanContent,
+          }),
+        })
+        if (!res.ok) {
+          const err = await res.json()
+          throw new Error(err.error || 'Create failed')
+        }
+      } else if (editing) {
+        const res = await fetch(`/api/subscribe-pages/${editing.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            publication_id: publicationId,
+            name: form.name,
+            content: cleanContent,
+          }),
+        })
+        if (!res.ok) {
+          const err = await res.json()
+          throw new Error(err.error || 'Update failed')
+        }
+      }
+      closeForm()
+      await fetchPages()
+    } catch (e: any) {
+      alert(e.message || 'Failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function archive(p: SubscribePage) {
+    if (!publicationId) return
+    if (!confirm(`Archive "${p.name}"? Existing tests referencing it keep working.`)) return
+    const res = await fetch(`/api/subscribe-pages/${p.id}?publication_id=${publicationId}`, { method: 'DELETE' })
+    if (!res.ok) {
+      const err = await res.json()
+      alert(err.error || 'Archive failed')
+      return
+    }
+    await fetchPages()
+  }
+
+  const visiblePages = useMemo(() => pages.filter(p => !p.is_archived), [pages])
+
+  return (
+    <Layout>
+      <div className="px-4 py-6 sm:px-0">
+        <div className="flex justify-between items-center mb-6">
+          <div>
+            <nav className="flex" aria-label="Breadcrumb">
+              <ol className="flex items-center space-x-2">
+                <li><Link href={`/dashboard/${slug}`} className="text-gray-500 hover:text-gray-700">Dashboard</Link></li>
+                <li><span className="text-gray-500">/</span></li>
+                <li><span className="text-gray-900 font-medium">Subscribe Pages</span></li>
+              </ol>
+            </nav>
+            <h1 className="text-2xl font-bold text-gray-900 mt-2">Subscribe Pages</h1>
+            <p className="text-gray-600">Reusable /subscribe content presets you can run A/B tests against.</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <Link
+              href={`/dashboard/${slug}/ab-tests`}
+              className="text-sm text-brand-primary hover:underline"
+            >
+              View A/B Tests →
+            </Link>
+            <button
+              onClick={openCreate}
+              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            >
+              New Page
+            </button>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="text-center py-12 text-gray-500">Loading…</div>
+        ) : visiblePages.length === 0 ? (
+          <div className="text-center py-12 text-gray-500 border border-dashed rounded-lg">
+            No pages yet. Create one to start A/B testing your /subscribe page.
+          </div>
+        ) : (
+          <ul className="divide-y border rounded-lg bg-white">
+            {visiblePages.map(p => (
+              <li key={p.id} className="flex items-center justify-between px-4 py-3">
+                <div>
+                  <div className="font-medium text-gray-900">{p.name}</div>
+                  <div className="text-sm text-gray-500 truncate max-w-xl">
+                    {p.content?.heading || <span className="italic">(uses publication default heading)</span>}
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <button onClick={() => openEdit(p)} className="text-sm text-blue-600 hover:underline">Edit</button>
+                  <button onClick={() => archive(p)} className="text-sm text-red-600 hover:underline">Archive</button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {(creating || editing) && (
+          <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+            <div className="bg-white rounded-lg w-full max-w-2xl p-6 max-h-[90vh] overflow-y-auto">
+              <h2 className="text-xl font-bold mb-4">
+                {creating ? 'New Subscribe Page' : `Edit: ${editing?.name}`}
+              </h2>
+
+              <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+              <input
+                type="text"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                className="w-full border rounded px-3 py-2 mb-4"
+                placeholder="e.g. Bold heading / Control / v3"
+              />
+
+              <div className="space-y-3">
+                <p className="text-xs text-gray-500">
+                  Leave a field blank to fall through to the publication default.
+                </p>
+                {CONTENT_FIELDS.map(f => (
+                  <div key={f.key}>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">{f.label}</label>
+                    {f.multiline ? (
+                      <textarea
+                        value={form.content[f.key] || ''}
+                        onChange={(e) => setForm({ ...form, content: { ...form.content, [f.key]: e.target.value } })}
+                        className="w-full border rounded px-3 py-2"
+                        rows={2}
+                        placeholder={f.placeholder}
+                      />
+                    ) : (
+                      <input
+                        type="text"
+                        value={form.content[f.key] || ''}
+                        onChange={(e) => setForm({ ...form, content: { ...form.content, [f.key]: e.target.value } })}
+                        className="w-full border rounded px-3 py-2"
+                        placeholder={f.placeholder}
+                      />
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex justify-end gap-3 mt-6">
+                <button
+                  onClick={closeForm}
+                  disabled={busy}
+                  className="px-4 py-2 text-gray-700 hover:bg-gray-100 rounded"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={submit}
+                  disabled={busy}
+                  className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {busy ? 'Saving…' : creating ? 'Create' : 'Save'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </Layout>
+  )
+}

--- a/src/app/dashboard/[slug]/subscribe-pages/page.tsx
+++ b/src/app/dashboard/[slug]/subscribe-pages/page.tsx
@@ -48,10 +48,18 @@ export default function SubscribePagesDashboardPage() {
 
   useEffect(() => {
     async function load() {
-      const res = await fetch('/api/newsletters')
-      const json = await res.json()
-      const found = (json.newsletters || []).find((n: Newsletter) => n.slug === slug)
-      setNewsletter(found || null)
+      try {
+        const res = await fetch('/api/newsletters')
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const json = await res.json()
+        const found = (json.newsletters || []).find((n: Newsletter) => n.slug === slug)
+        setNewsletter(found || null)
+        if (!found) setLoading(false)
+      } catch (err) {
+        console.error('[SubscribePages] newsletter load failed', err)
+        setNewsletter(null)
+        setLoading(false)
+      }
     }
     load()
   }, [slug])
@@ -64,10 +72,16 @@ export default function SubscribePagesDashboardPage() {
   async function fetchPages() {
     if (!publicationId) return
     setLoading(true)
-    const res = await fetch(`/api/subscribe-pages?publication_id=${publicationId}&include_archived=true`)
-    const json = await res.json()
-    setPages(json.pages || [])
-    setLoading(false)
+    try {
+      const res = await fetch(`/api/subscribe-pages?publication_id=${publicationId}&include_archived=true`)
+      const json = await res.json()
+      setPages(json.pages || [])
+    } catch (err) {
+      console.error('[SubscribePages] fetchPages failed', err)
+      setPages([])
+    } finally {
+      setLoading(false)
+    }
   }
 
   function openCreate() {

--- a/src/app/website/news/news-helpers.ts
+++ b/src/app/website/news/news-helpers.ts
@@ -1,7 +1,7 @@
 import { supabaseAdmin } from '@/lib/supabase'
 import { headers } from 'next/headers'
 import { getPublicationByDomain, getPublicationSettings } from '@/lib/publication-settings'
-import { STORAGE_PUBLIC_URL } from '@/lib/config'
+import { resolveArchiveCoverImage } from '@/lib/archive-cover'
 
 interface SearchParams {
   category?: string
@@ -106,9 +106,6 @@ export async function fetchNewsPageData(params: SearchParams): Promise<NewsPageD
 
   const { data: manualArticles } = await articlesQuery
 
-  const newsletterCoverImage =
-    settings.archive_cover_image_url ||
-    `${STORAGE_PUBLIC_URL}/img/c/ai_accounting_daily_cover_image.jpg`
   const newsItems: NewsItem[] = []
 
   if (!params.category || params.category === 'newsletter') {
@@ -119,7 +116,7 @@ export async function fetchNewsPageData(params: SearchParams): Promise<NewsPageD
         title: nl.subject_line || `Newsletter - ${nl.issue_date}`,
         date: nl.issue_date,
         category: 'Newsletter',
-        image_url: newsletterCoverImage,
+        image_url: resolveArchiveCoverImage(nl, settings.archive_cover_image_url),
         metadata: nl.metadata as NewsItem['metadata']
       })
     })

--- a/src/app/website/page.tsx
+++ b/src/app/website/page.tsx
@@ -4,7 +4,7 @@ import { Footer } from "@/components/salient/Footer"
 import { LatestNewsList } from "@/components/website/latest-news-list"
 import { supabaseAdmin } from "@/lib/supabase"
 import { resolvePublicationFromRequest, getPublicationSettings } from '@/lib/publication-settings'
-import { STORAGE_PUBLIC_URL } from '@/lib/config'
+import { resolveArchiveCoverImage } from '@/lib/archive-cover'
 
 // Force dynamic rendering to fetch fresh data
 export const dynamic = 'force-dynamic'
@@ -43,11 +43,6 @@ export default async function WebsiteHome() {
     'website_subheading',
     'archive_cover_image_url',
   ])
-
-  // Newsletter cover image (per-publication, with fallback)
-  const newsletterCoverImage =
-    websiteSettings.archive_cover_image_url ||
-    `${STORAGE_PUBLIC_URL}/img/c/ai_accounting_daily_cover_image.jpg`
 
   // Fetch newsletters (filtered by publication)
   const { data: newsletters } = await supabaseAdmin
@@ -88,7 +83,7 @@ export default async function WebsiteHome() {
       title: nl.subject_line || `Newsletter - ${nl.issue_date}`,
       date: nl.issue_date,
       category: 'Newsletter',
-      image_url: newsletterCoverImage,
+      image_url: resolveArchiveCoverImage(nl, websiteSettings.archive_cover_image_url),
       metadata: nl.metadata as NewsItem['metadata']
     })
   })

--- a/src/app/website/subscribe/offers/page.tsx
+++ b/src/app/website/subscribe/offers/page.tsx
@@ -1,6 +1,12 @@
-import { headers } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { getPublicationByDomain, getPublicationSettings } from '@/lib/publication-settings'
 import { OffersContent } from './offers-content'
+import {
+  attributeByVisitor,
+  recordEvent,
+  VISITOR_COOKIE,
+} from '@/lib/ab-tests'
+import { checkUserAgent } from '@/lib/bot-detection/ua-detector'
 
 // Force dynamic rendering to fetch fresh data
 export const dynamic = 'force-dynamic'
@@ -23,6 +29,30 @@ export default async function OffersPage() {
   const logoUrl = settings.logo_url || '/logo.png'
   const newsletterName = settings.newsletter_name || 'AI Accounting Daily'
   const afteroffersFormId = settings.afteroffers_form_id || ''
+
+  // Record reached_offers conversion if an active A/B test assignment exists
+  try {
+    const cookieStore = await cookies()
+    const visitorId = cookieStore.get(VISITOR_COOKIE)?.value
+    const userAgent = headersList.get('user-agent')
+    if (visitorId && !checkUserAgent(userAgent).isBot) {
+      const attribution = await attributeByVisitor(publicationId, visitorId)
+      if (attribution) {
+        const ipAddress =
+          headersList.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+          headersList.get('x-real-ip') ||
+          null
+        await recordEvent(attribution.testId, attribution.variantId, 'reached_offers', {
+          publicationId,
+          visitorId,
+          ipAddress,
+          userAgent,
+        })
+      }
+    }
+  } catch (abError) {
+    console.error('[Offers] A/B reached_offers event failed:', abError)
+  }
 
   return (
     <main className="min-h-[100dvh] bg-white">

--- a/src/app/website/subscribe/page.tsx
+++ b/src/app/website/subscribe/page.tsx
@@ -3,6 +3,7 @@ import { Container } from "@/components/salient/Container"
 import { SubscribeForm } from "./subscribe-form"
 import { renderStyledHeading } from "@/components/StyledHeading"
 import { resolvePublicationFromRequest, getPublicationSettings } from '@/lib/publication-settings'
+import { supabaseAdmin } from '@/lib/supabase'
 import {
   getActiveTestForPublication,
   getDefaultPageForPublication,
@@ -15,8 +16,41 @@ import { checkUserAgent } from '@/lib/bot-detection/ua-detector'
 // Force dynamic rendering to fetch fresh data
 export const dynamic = 'force-dynamic'
 
-export default async function SubscribePage() {
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Resolve a publication from optional query-param overrides, else fall back
+ * to the request's host header. Exists so staging/preview URLs can target a
+ * specific publication without DNS changes:
+ *   /website/subscribe?pub_slug=accounting
+ *   /website/subscribe?publication_id=<uuid>
+ */
+async function resolvePublicationId(
+  searchParams: { publication_id?: string; pub_slug?: string }
+): Promise<string> {
+  if (searchParams.publication_id && UUID_RE.test(searchParams.publication_id)) {
+    return searchParams.publication_id
+  }
+  if (searchParams.pub_slug) {
+    const { data } = await supabaseAdmin
+      .from('publications')
+      .select('id')
+      .eq('slug', searchParams.pub_slug)
+      .eq('is_active', true)
+      .maybeSingle()
+    if (data?.id) return data.id
+  }
   const { publicationId } = await resolvePublicationFromRequest()
+  return publicationId
+}
+
+export default async function SubscribePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ publication_id?: string; pub_slug?: string }>
+}) {
+  const sp = await searchParams
+  const publicationId = await resolvePublicationId(sp)
 
   // Fetch publication-level defaults (used when no variant overrides exist)
   const settings = await getPublicationSettings(publicationId, [

--- a/src/app/website/subscribe/page.tsx
+++ b/src/app/website/subscribe/page.tsx
@@ -92,14 +92,15 @@ export default async function SubscribePage({
       if (assignment) {
         variantContent = (assignment.variant.page.content || {}) as Record<string, string | undefined>
 
-        // Only record page_view events for real visitors (skip obvious bots).
+        // Fire-and-forget: don't block TTFB on the event insert. Errors are
+        // logged inside recordEvent. Skip obvious bots to keep stats clean.
         if (!uaCheck.isBot) {
-          await recordEvent(active.test.id, assignment.variant.id, 'page_view', {
+          void recordEvent(active.test.id, assignment.variant.id, 'page_view', {
             publicationId,
             visitorId,
             ipAddress,
             userAgent,
-          })
+          }).catch((err) => console.error('[Subscribe] page_view recordEvent threw:', err))
         }
       }
     }

--- a/src/app/website/subscribe/page.tsx
+++ b/src/app/website/subscribe/page.tsx
@@ -1,7 +1,15 @@
+import { cookies, headers } from 'next/headers'
 import { Container } from "@/components/salient/Container"
 import { SubscribeForm } from "./subscribe-form"
 import { renderStyledHeading } from "@/components/StyledHeading"
 import { resolvePublicationFromRequest, getPublicationSettings } from '@/lib/publication-settings'
+import {
+  getActiveTestForPublication,
+  ensureAssignment,
+  recordEvent,
+  VISITOR_COOKIE,
+} from '@/lib/ab-tests'
+import { checkUserAgent } from '@/lib/bot-detection/ua-detector'
 
 // Force dynamic rendering to fetch fresh data
 export const dynamic = 'force-dynamic'
@@ -9,7 +17,7 @@ export const dynamic = 'force-dynamic'
 export default async function SubscribePage() {
   const { publicationId } = await resolvePublicationFromRequest()
 
-  // Fetch settings from publication_settings
+  // Fetch publication-level defaults (used when no variant overrides exist)
   const settings = await getPublicationSettings(publicationId, [
     'logo_url',
     'newsletter_name',
@@ -18,11 +26,55 @@ export default async function SubscribePage() {
     'subscribe_tagline',
   ])
 
-  const logoUrl = settings.logo_url || '/logo.png'
+  // Resolve A/B test (if any) and assign a sticky variant
+  const active = await getActiveTestForPublication(publicationId)
+
+  let variantContent: Record<string, string | undefined> = {}
+  if (active) {
+    const cookieStore = await cookies()
+    const headerList = await headers()
+    const visitorId = cookieStore.get(VISITOR_COOKIE)?.value
+    const userAgent = headerList.get('user-agent')
+    const ipAddress =
+      headerList.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      headerList.get('x-real-ip') ||
+      null
+    const uaCheck = checkUserAgent(userAgent)
+
+    if (visitorId) {
+      const assignment = await ensureAssignment(active, visitorId, {
+        ipAddress,
+        userAgent,
+        isBotUa: uaCheck.isBot,
+      })
+
+      if (assignment) {
+        variantContent = (assignment.variant.page.content || {}) as Record<string, string | undefined>
+
+        // Only record page_view events for real visitors (skip obvious bots).
+        if (!uaCheck.isBot) {
+          await recordEvent(active.test.id, assignment.variant.id, 'page_view', {
+            publicationId,
+            visitorId,
+            ipAddress,
+            userAgent,
+          })
+        }
+      }
+    }
+  }
+
+  const logoUrl = variantContent.logo_url || settings.logo_url || '/logo.png'
   const newsletterName = settings.newsletter_name || 'AI Accounting Daily'
-  const heading = settings.subscribe_heading || 'Master AI Tools, Prompts & News **in Just 3 Minutes a Day**'
-  const subheading = settings.subscribe_subheading || 'Join 10,000+ accounting professionals staying current as AI reshapes bookkeeping, tax, and advisory work.'
-  const tagline = settings.subscribe_tagline || 'FREE FOREVER'
+  const heading =
+    variantContent.heading ||
+    settings.subscribe_heading ||
+    'Master AI Tools, Prompts & News **in Just 3 Minutes a Day**'
+  const subheading =
+    variantContent.subheading ||
+    settings.subscribe_subheading ||
+    'Join 10,000+ accounting professionals staying current as AI reshapes bookkeeping, tax, and advisory work.'
+  const tagline = variantContent.tagline || settings.subscribe_tagline || 'FREE FOREVER'
 
   return (
     <main className="min-h-[100dvh] bg-white px-4">

--- a/src/app/website/subscribe/page.tsx
+++ b/src/app/website/subscribe/page.tsx
@@ -5,6 +5,7 @@ import { renderStyledHeading } from "@/components/StyledHeading"
 import { resolvePublicationFromRequest, getPublicationSettings } from '@/lib/publication-settings'
 import {
   getActiveTestForPublication,
+  getDefaultPageForPublication,
   ensureAssignment,
   recordEvent,
   VISITOR_COOKIE,
@@ -26,8 +27,14 @@ export default async function SubscribePage() {
     'subscribe_tagline',
   ])
 
-  // Resolve A/B test (if any) and assign a sticky variant
-  const active = await getActiveTestForPublication(publicationId)
+  // Resolve A/B test (if any) and assign a sticky variant.
+  // Also load the default subscribe page — used as the base when no test is
+  // active, and as the fallback for any variant field left blank.
+  const [active, defaultPage] = await Promise.all([
+    getActiveTestForPublication(publicationId),
+    getDefaultPageForPublication(publicationId),
+  ])
+  const defaultContent = (defaultPage?.content || {}) as Record<string, string | undefined>
 
   let variantContent: Record<string, string | undefined> = {}
   if (active) {
@@ -64,17 +71,24 @@ export default async function SubscribePage() {
     }
   }
 
-  const logoUrl = variantContent.logo_url || settings.logo_url || '/logo.png'
+  // Fallback chain for each field: active variant → default page → publication_settings → hardcoded
+  const logoUrl = variantContent.logo_url || defaultContent.logo_url || settings.logo_url || '/logo.png'
   const newsletterName = settings.newsletter_name || 'AI Accounting Daily'
   const heading =
     variantContent.heading ||
+    defaultContent.heading ||
     settings.subscribe_heading ||
     'Master AI Tools, Prompts & News **in Just 3 Minutes a Day**'
   const subheading =
     variantContent.subheading ||
+    defaultContent.subheading ||
     settings.subscribe_subheading ||
     'Join 10,000+ accounting professionals staying current as AI reshapes bookkeeping, tax, and advisory work.'
-  const tagline = variantContent.tagline || settings.subscribe_tagline || 'FREE FOREVER'
+  const tagline =
+    variantContent.tagline ||
+    defaultContent.tagline ||
+    settings.subscribe_tagline ||
+    'FREE FOREVER'
 
   return (
     <main className="min-h-[100dvh] bg-white px-4">

--- a/src/components/settings/WebsiteSettings.tsx
+++ b/src/components/settings/WebsiteSettings.tsx
@@ -1,9 +1,22 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { useWebsiteSettings } from './useWebsiteSettings'
 
 export default function WebsiteSettings({ publicationId }: { publicationId: string }) {
   const { settings, setSettings, loading, saving, message, websiteBaseUrl, handleSave } = useWebsiteSettings(publicationId)
+  const [pubSlug, setPubSlug] = useState<string>('')
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch('/api/newsletters')
+      if (!res.ok) return
+      const json = await res.json()
+      const pub = (json.newsletters || []).find((n: { id: string; slug: string }) => n.id === publicationId)
+      if (pub?.slug) setPubSlug(pub.slug)
+    }
+    load()
+  }, [publicationId])
 
   if (loading) {
     return <div className="text-gray-500">Loading website settings...</div>
@@ -53,15 +66,26 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
         </div>
       </div>
 
-      {/* Subscribe Page */}
-      <div className="border rounded-lg p-4 space-y-4">
+      {/* Subscribe Page — managed via Subscribe Pages */}
+      <div className="border rounded-lg p-4 space-y-3">
         <div className="flex items-center justify-between">
           <h3 className="font-medium text-gray-900">Subscribe Page</h3>
           <a href={`${websiteBaseUrl}/subscribe`} target="_blank" rel="noopener noreferrer" className="text-xs text-blue-600 hover:text-blue-800">View Page &rarr;</a>
         </div>
-        <SettingsTextarea label="Heading" value={settings.subscribe_heading} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_heading: v }))} placeholder={"Master AI Tools, Prompts & News\n**in Just 3 Minutes a Day**"} rows={2} hint="Use Enter for line breaks. Wrap text in **double asterisks** for gradient underline style." />
-        <SettingsTextarea label="Subheadline" value={settings.subscribe_subheading} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_subheading: v }))} placeholder="Join 10,000+ accounting professionals staying current as AI reshapes bookkeeping, tax, and advisory work." rows={2} />
-        <SettingsInput label="Tagline" value={settings.subscribe_tagline} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_tagline: v }))} placeholder="FREE FOREVER" hint="Shown below the subscribe form. Leave empty to hide." />
+        <p className="text-sm text-gray-600">
+          Subscribe page content is now managed as reusable <strong>pages</strong> so you can A/B test variants
+          and pick a default. Edit the default page to change what visitors see today.
+        </p>
+        {pubSlug ? (
+          <a
+            href={`/dashboard/${pubSlug}/subscribe-pages`}
+            className="inline-block bg-blue-600 text-white px-4 py-2 rounded text-sm font-medium hover:bg-blue-700"
+          >
+            Manage Subscribe Pages →
+          </a>
+        ) : (
+          <span className="text-xs text-gray-400">Loading…</span>
+        )}
       </div>
 
       {/* Subscribe Info Page */}

--- a/src/lib/ab-tests/index.ts
+++ b/src/lib/ab-tests/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './subscribe-test-selector'

--- a/src/lib/ab-tests/subscribe-test-selector.ts
+++ b/src/lib/ab-tests/subscribe-test-selector.ts
@@ -25,10 +25,6 @@ interface RecordEventCtx {
 }
 
 /**
- * Returns the single active subscribe A/B test for a publication, with
- * variants joined to their page presets. Returns null when no test is active.
- */
-/**
  * Returns the default (non-archived) subscribe page for a publication, or null
  * if none is marked as default. Used as the base content when no A/B test is
  * active, before falling back to publication_settings.
@@ -51,6 +47,10 @@ export async function getDefaultPageForPublication(
   return (data as SubscribePage) || null
 }
 
+/**
+ * Returns the single active subscribe A/B test for a publication, with
+ * variants joined to their page presets. Returns null when no test is active.
+ */
 export async function getActiveTestForPublication(
   publicationId: string
 ): Promise<ActiveSubscribeAbTest | null> {
@@ -115,6 +115,11 @@ function pickWeightedVariant(
  * Look up an existing assignment for this visitor in this test, or create
  * one with a freshly picked variant. Idempotent under concurrent requests
  * via the (test_id, visitor_id) unique constraint.
+ *
+ * If a stale assignment points at a variant that no longer exists in the test
+ * (variant deleted/edited), the assignment is migrated in-place via UPDATE
+ * to a freshly-picked current variant — not re-inserted (which would violate
+ * the unique constraint).
  */
 export async function ensureAssignment(
   active: ActiveSubscribeAbTest,
@@ -133,7 +138,27 @@ export async function ensureAssignment(
   if (existing?.variant_id) {
     const v = variants.find((vv) => vv.id === existing.variant_id)
     if (v) return { variant: v, isNew: false }
-    // Fallthrough: variant id no longer matches a current variant → re-assign
+
+    // Stale row — variant id no longer matches a current variant. Migrate
+    // in-place rather than INSERT (which would violate the unique constraint).
+    const repick = pickWeightedVariant(variants)
+    const { error: updErr } = await supabaseAdmin
+      .from('subscribe_ab_assignments')
+      .update({
+        variant_id: repick.id,
+        ip_address: ctx.ipAddress,
+        user_agent: ctx.userAgent,
+        is_bot_ua: ctx.isBotUa,
+      })
+      .eq('test_id', test.id)
+      .eq('visitor_id', visitorId)
+
+    if (updErr) {
+      console.error('[SubscribeAB] Stale assignment migration failed:', updErr.message)
+      return null
+    }
+    console.warn(`[SubscribeAB] Migrated stale assignment ${visitorId} -> variant ${repick.id}`)
+    return { variant: repick, isNew: false }
   }
 
   const picked = pickWeightedVariant(variants)

--- a/src/lib/ab-tests/subscribe-test-selector.ts
+++ b/src/lib/ab-tests/subscribe-test-selector.ts
@@ -1,0 +1,252 @@
+import { supabaseAdmin } from '../supabase'
+import { checkUserAgent } from '../bot-detection/ua-detector'
+import type {
+  ActiveSubscribeAbTest,
+  SubscribeAbEventType,
+  SubscribeAbTest,
+  SubscribeAbTestVariantWithPage,
+} from './types'
+
+export const VISITOR_COOKIE = 'subv_vid'
+
+interface AssignmentResult {
+  variant: SubscribeAbTestVariantWithPage
+  isNew: boolean
+}
+
+interface RecordEventCtx {
+  publicationId: string
+  visitorId?: string | null
+  subscriberEmail?: string | null
+  ipAddress?: string | null
+  userAgent?: string | null
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Returns the single active subscribe A/B test for a publication, with
+ * variants joined to their page presets. Returns null when no test is active.
+ */
+export async function getActiveTestForPublication(
+  publicationId: string
+): Promise<ActiveSubscribeAbTest | null> {
+  const { data: test, error: testErr } = await supabaseAdmin
+    .from('subscribe_ab_tests')
+    .select('id, publication_id, name, status, start_date, end_date, started_at, ended_at, created_at, updated_at')
+    .eq('publication_id', publicationId)
+    .eq('status', 'active')
+    .maybeSingle()
+
+  if (testErr) {
+    console.error('[SubscribeAB] Error loading active test:', testErr.message)
+    return null
+  }
+  if (!test) return null
+
+  const { data: variants, error: varErr } = await supabaseAdmin
+    .from('subscribe_ab_test_variants')
+    .select(`
+      id, test_id, page_id, label, weight, display_order, created_at,
+      page:subscribe_pages!inner(id, publication_id, name, content, is_archived, created_at, updated_at)
+    `)
+    .eq('test_id', test.id)
+    .order('display_order', { ascending: true })
+
+  if (varErr) {
+    console.error('[SubscribeAB] Error loading variants:', varErr.message)
+    return null
+  }
+  if (!variants || variants.length === 0) return null
+
+  return {
+    test: test as SubscribeAbTest,
+    // Supabase joins return the related row as an array when the FK relationship
+    // is reverse-defined; normalize to a single object.
+    variants: variants.map((v: any) => ({
+      ...v,
+      page: Array.isArray(v.page) ? v.page[0] : v.page,
+    })) as SubscribeAbTestVariantWithPage[],
+  }
+}
+
+/**
+ * Pick a variant by weighted random over the variants' weight values.
+ * Falls back to the first variant if all weights are 0.
+ */
+function pickWeightedVariant(
+  variants: SubscribeAbTestVariantWithPage[]
+): SubscribeAbTestVariantWithPage {
+  const totalWeight = variants.reduce((sum, v) => sum + Math.max(0, v.weight), 0)
+  if (totalWeight <= 0) return variants[0]
+
+  let pick = Math.random() * totalWeight
+  for (const v of variants) {
+    pick -= Math.max(0, v.weight)
+    if (pick <= 0) return v
+  }
+  return variants[variants.length - 1]
+}
+
+/**
+ * Look up an existing assignment for this visitor in this test, or create
+ * one with a freshly picked variant. Idempotent under concurrent requests
+ * via the (test_id, visitor_id) unique constraint.
+ */
+export async function ensureAssignment(
+  active: ActiveSubscribeAbTest,
+  visitorId: string,
+  ctx: { ipAddress: string | null; userAgent: string | null; isBotUa: boolean }
+): Promise<AssignmentResult | null> {
+  const { test, variants } = active
+
+  const { data: existing } = await supabaseAdmin
+    .from('subscribe_ab_assignments')
+    .select('variant_id')
+    .eq('test_id', test.id)
+    .eq('visitor_id', visitorId)
+    .maybeSingle()
+
+  if (existing?.variant_id) {
+    const v = variants.find((vv) => vv.id === existing.variant_id)
+    if (v) return { variant: v, isNew: false }
+    // Fallthrough: variant id no longer matches a current variant → re-assign
+  }
+
+  const picked = pickWeightedVariant(variants)
+
+  const { error: insertErr } = await supabaseAdmin
+    .from('subscribe_ab_assignments')
+    .insert({
+      test_id: test.id,
+      variant_id: picked.id,
+      publication_id: test.publication_id,
+      visitor_id: visitorId,
+      ip_address: ctx.ipAddress,
+      user_agent: ctx.userAgent,
+      is_bot_ua: ctx.isBotUa,
+    })
+
+  if (insertErr) {
+    // Race-condition: another request inserted first; re-read.
+    const { data: retry } = await supabaseAdmin
+      .from('subscribe_ab_assignments')
+      .select('variant_id')
+      .eq('test_id', test.id)
+      .eq('visitor_id', visitorId)
+      .maybeSingle()
+    if (retry?.variant_id) {
+      const v = variants.find((vv) => vv.id === retry.variant_id)
+      if (v) return { variant: v, isNew: false }
+    }
+    console.error('[SubscribeAB] Assignment insert failed:', insertErr.message)
+    return null
+  }
+
+  return { variant: picked, isNew: true }
+}
+
+/**
+ * Insert a single event row scoped to (test_id, variant_id). No-ops if
+ * variantId is missing.
+ */
+export async function recordEvent(
+  testId: string,
+  variantId: string | null,
+  eventType: SubscribeAbEventType,
+  ctx: RecordEventCtx
+): Promise<void> {
+  if (!variantId) return
+
+  const isBotUa = ctx.userAgent ? checkUserAgent(ctx.userAgent).isBot : false
+
+  const { error } = await supabaseAdmin
+    .from('subscribe_ab_events')
+    .insert({
+      test_id: testId,
+      variant_id: variantId,
+      publication_id: ctx.publicationId,
+      visitor_id: ctx.visitorId ?? null,
+      subscriber_email: ctx.subscriberEmail ?? null,
+      event_type: eventType,
+      ip_address: ctx.ipAddress ?? null,
+      is_bot_ua: isBotUa,
+      metadata: ctx.metadata ?? {},
+    })
+
+  if (error) {
+    console.error(`[SubscribeAB] Event insert failed (${eventType}):`, error.message)
+  }
+}
+
+/**
+ * Record subscriber email on the assignment row (called after first signup).
+ * Used to attribute later conversions (SparkLoop webhook) by email.
+ */
+export async function attachEmailToAssignment(
+  testId: string,
+  visitorId: string,
+  email: string
+): Promise<void> {
+  if (!email) return
+  const { error } = await supabaseAdmin
+    .from('subscribe_ab_assignments')
+    .update({ subscriber_email: email })
+    .eq('test_id', testId)
+    .eq('visitor_id', visitorId)
+
+  if (error) {
+    console.error('[SubscribeAB] attachEmailToAssignment failed:', error.message)
+  }
+}
+
+/**
+ * Resolve (test_id, variant_id) for a given subscriber email scoped to a
+ * publication's currently active test. Used by the SparkLoop webhook path
+ * where the visitor cookie is no longer present.
+ */
+export async function attributeBySubscriberEmail(
+  publicationId: string,
+  email: string
+): Promise<{ testId: string; variantId: string; visitorId: string } | null> {
+  if (!email) return null
+
+  const active = await getActiveTestForPublication(publicationId)
+  if (!active) return null
+
+  const { data } = await supabaseAdmin
+    .from('subscribe_ab_assignments')
+    .select('test_id, variant_id, visitor_id')
+    .eq('test_id', active.test.id)
+    .eq('subscriber_email', email)
+    .order('assigned_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (!data) return null
+  return { testId: data.test_id, variantId: data.variant_id, visitorId: data.visitor_id }
+}
+
+/**
+ * Resolve (test_id, variant_id) for a request that arrives with a visitor
+ * cookie but no active context (e.g. /api/subscribe POST). Returns the
+ * variant only if it belongs to the publication's currently active test.
+ */
+export async function attributeByVisitor(
+  publicationId: string,
+  visitorId: string
+): Promise<{ testId: string; variantId: string } | null> {
+  if (!visitorId) return null
+
+  const active = await getActiveTestForPublication(publicationId)
+  if (!active) return null
+
+  const { data } = await supabaseAdmin
+    .from('subscribe_ab_assignments')
+    .select('test_id, variant_id')
+    .eq('test_id', active.test.id)
+    .eq('visitor_id', visitorId)
+    .maybeSingle()
+
+  if (!data) return null
+  return { testId: data.test_id, variantId: data.variant_id }
+}

--- a/src/lib/ab-tests/subscribe-test-selector.ts
+++ b/src/lib/ab-tests/subscribe-test-selector.ts
@@ -5,6 +5,7 @@ import type {
   SubscribeAbEventType,
   SubscribeAbTest,
   SubscribeAbTestVariantWithPage,
+  SubscribePage,
 } from './types'
 
 export const VISITOR_COOKIE = 'subv_vid'
@@ -27,6 +28,29 @@ interface RecordEventCtx {
  * Returns the single active subscribe A/B test for a publication, with
  * variants joined to their page presets. Returns null when no test is active.
  */
+/**
+ * Returns the default (non-archived) subscribe page for a publication, or null
+ * if none is marked as default. Used as the base content when no A/B test is
+ * active, before falling back to publication_settings.
+ */
+export async function getDefaultPageForPublication(
+  publicationId: string
+): Promise<SubscribePage | null> {
+  const { data, error } = await supabaseAdmin
+    .from('subscribe_pages')
+    .select('id, publication_id, name, content, is_archived, is_default, created_at, updated_at')
+    .eq('publication_id', publicationId)
+    .eq('is_default', true)
+    .eq('is_archived', false)
+    .maybeSingle()
+
+  if (error) {
+    console.error('[SubscribeAB] Error loading default page:', error.message)
+    return null
+  }
+  return (data as SubscribePage) || null
+}
+
 export async function getActiveTestForPublication(
   publicationId: string
 ): Promise<ActiveSubscribeAbTest | null> {

--- a/src/lib/ab-tests/types.ts
+++ b/src/lib/ab-tests/types.ts
@@ -22,6 +22,7 @@ export interface SubscribePage {
   name: string
   content: SubscribePageContent
   is_archived: boolean
+  is_default: boolean
   created_at: string
   updated_at: string
 }

--- a/src/lib/ab-tests/types.ts
+++ b/src/lib/ab-tests/types.ts
@@ -1,0 +1,83 @@
+export type SubscribeAbTestStatus = 'draft' | 'active' | 'ended'
+
+export type SubscribeAbEventType =
+  | 'page_view'
+  | 'signup'
+  | 'reached_offers'
+  | 'completed_info'
+  | 'sparkloop_signup'
+
+export interface SubscribePageContent {
+  heading?: string
+  subheading?: string
+  tagline?: string
+  logo_url?: string
+  cta_text?: string
+  [key: string]: string | undefined
+}
+
+export interface SubscribePage {
+  id: string
+  publication_id: string
+  name: string
+  content: SubscribePageContent
+  is_archived: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface SubscribeAbTest {
+  id: string
+  publication_id: string
+  name: string
+  status: SubscribeAbTestStatus
+  start_date: string | null
+  end_date: string | null
+  started_at: string | null
+  ended_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface SubscribeAbTestVariant {
+  id: string
+  test_id: string
+  page_id: string
+  label: string
+  weight: number
+  display_order: number
+  created_at: string
+}
+
+export interface SubscribeAbTestVariantWithPage extends SubscribeAbTestVariant {
+  page: SubscribePage
+}
+
+export interface ActiveSubscribeAbTest {
+  test: SubscribeAbTest
+  variants: SubscribeAbTestVariantWithPage[]
+}
+
+export interface SubscribeAbAssignment {
+  id: string
+  test_id: string
+  variant_id: string
+  publication_id: string
+  visitor_id: string
+  subscriber_email: string | null
+  ip_address: string | null
+  user_agent: string | null
+  is_bot_ua: boolean
+  assigned_at: string
+}
+
+export interface VariantStatsRow {
+  variant_id: string
+  label: string
+  weight: number
+  page_views: number
+  signups: number
+  reached_offers: number
+  completed_info: number
+  sparkloop_signups: number
+}

--- a/src/lib/archive-cover.ts
+++ b/src/lib/archive-cover.ts
@@ -1,0 +1,19 @@
+import { STORAGE_PUBLIC_URL } from './config'
+
+export const DEFAULT_ARCHIVE_COVER_IMAGE =
+  `${STORAGE_PUBLIC_URL}/img/c/ai_accounting_daily_cover_image.jpg`
+
+export interface ArchiveCoverNewsletter {
+  metadata?: Record<string, any> | null
+}
+
+// Priority (current): publication default → hardcoded fallback.
+// Future: per-issue image (e.g. from nl.metadata.cover_image_url) slots in
+// as the first branch here without changing call sites.
+export function resolveArchiveCoverImage(
+  newsletter: ArchiveCoverNewsletter,
+  publicationDefault?: string | null
+): string {
+  void newsletter
+  return publicationDefault || DEFAULT_ARCHIVE_COVER_IMAGE
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -82,6 +82,34 @@ async function lookupPublicationByDomain(hostname: string): Promise<CachedPub | 
   }
 }
 
+/**
+ * Attach a stable anonymous visitor_id cookie on any subscribe-related
+ * request so server-rendered A/B variant assignment is sticky. Applied
+ * on every middleware return path, on every domain — required so that
+ * staging/preview URLs (e.g. aiprodaily-staging.vercel.app/website/subscribe)
+ * can exercise the A/B flow without DNS changes.
+ */
+function attachVisitorCookie(request: NextRequest, response: NextResponse): NextResponse {
+  const path = request.nextUrl.pathname
+  const isSubscribePath =
+    path === '/subscribe' ||
+    path.startsWith('/subscribe/') ||
+    path === '/website/subscribe' ||
+    path.startsWith('/website/subscribe/')
+  if (!isSubscribePath) return response
+
+  const existing = request.cookies.get('subv_vid')?.value
+  if (!existing) {
+    response.cookies.set('subv_vid', crypto.randomUUID(), {
+      maxAge: 60 * 60 * 24 * 365, // 1 year
+      sameSite: 'lax',
+      path: '/',
+      secure: process.env.NODE_ENV === 'production',
+    })
+  }
+  return response
+}
+
 // Custom middleware logic for non-tools routes
 async function customMiddleware(request: NextRequest): Promise<NextResponse> {
   const hostname = request.headers.get('host') || ''
@@ -120,27 +148,11 @@ async function customMiddleware(request: NextRequest): Promise<NextResponse> {
       requestHeaders.set('x-newsletter-slug', publication.slug)
       requestHeaders.set('x-newsletter-id', publication.id)
 
-      const response = NextResponse.rewrite(rewriteUrl, {
+      return NextResponse.rewrite(rewriteUrl, {
         request: {
           headers: requestHeaders,
         },
       })
-
-      // Ensure every visitor on subscribe-related routes carries a stable
-      // anonymous visitor_id so server-rendered A/B variant assignment is sticky.
-      if (url.pathname === '/subscribe' || url.pathname.startsWith('/subscribe/')) {
-        const existing = request.cookies.get('subv_vid')?.value
-        if (!existing) {
-          response.cookies.set('subv_vid', crypto.randomUUID(), {
-            maxAge: 60 * 60 * 24 * 365, // 1 year
-            sameSite: 'lax',
-            path: '/',
-            secure: process.env.NODE_ENV === 'production',
-          })
-        }
-      }
-
-      return response
     }
   }
 
@@ -280,16 +292,21 @@ export default clerkMiddleware(async (auth, request) => {
     method: request.method
   })
 
-  // Handle /tools and /account routes with Clerk
+  let response: NextResponse
   if (isToolsRoute(request) || isAccountRoute(request)) {
     // Don't use auth.protect() here - the submit page has SignedIn/SignedOut
     // components that handle authentication state gracefully
     // Let Clerk process the request to provide auth context
-    return NextResponse.next()
+    response = NextResponse.next()
+  } else {
+    // For all other routes, use custom middleware logic
+    response = await customMiddleware(request)
   }
 
-  // For all other routes, use custom middleware logic
-  return customMiddleware(request)
+  // Centralized: ensure subscribe-related requests carry a visitor_id cookie
+  // regardless of which branch produced the response. This makes /website/subscribe*
+  // testable on preview URLs without DNS changes.
+  return attachVisitorCookie(request, response)
 })
 
 export const config = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -102,6 +102,7 @@ function attachVisitorCookie(request: NextRequest, response: NextResponse): Next
   if (!existing) {
     response.cookies.set('subv_vid', crypto.randomUUID(), {
       maxAge: 60 * 60 * 24 * 365, // 1 year
+      httpOnly: true,
       sameSite: 'lax',
       path: '/',
       secure: process.env.NODE_ENV === 'production',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -120,11 +120,27 @@ async function customMiddleware(request: NextRequest): Promise<NextResponse> {
       requestHeaders.set('x-newsletter-slug', publication.slug)
       requestHeaders.set('x-newsletter-id', publication.id)
 
-      return NextResponse.rewrite(rewriteUrl, {
+      const response = NextResponse.rewrite(rewriteUrl, {
         request: {
           headers: requestHeaders,
         },
       })
+
+      // Ensure every visitor on subscribe-related routes carries a stable
+      // anonymous visitor_id so server-rendered A/B variant assignment is sticky.
+      if (url.pathname === '/subscribe' || url.pathname.startsWith('/subscribe/')) {
+        const existing = request.cookies.get('subv_vid')?.value
+        if (!existing) {
+          response.cookies.set('subv_vid', crypto.randomUUID(), {
+            maxAge: 60 * 60 * 24 * 365, // 1 year
+            sameSite: 'lax',
+            path: '/',
+            secure: process.env.NODE_ENV === 'production',
+          })
+        }
+      }
+
+      return response
     }
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -63,6 +63,10 @@
     {
       "path": "/api/cron/cleanup-metrics",
       "schedule": "0 3 * * *"
+    },
+    {
+      "path": "/api/cron/ab-test-scheduler",
+      "schedule": "*/15 * * * *"
     }
   ],
   "functions": {


### PR DESCRIPTION
## Summary

Introduces a full subscribe-page A/B testing system and reworks how `/subscribe` content is managed — content now lives in a `subscribe_pages` table (one marked as the default) instead of loose `publication_settings` keys. Admins can create multiple pages, mark one as default, and run weighted A/B tests comparing any two+ pages.

Also includes the original `resolveArchiveCoverImage` extraction from the first commit.

### What's new

- **5 new tables** with RLS: `subscribe_pages`, `subscribe_ab_tests`, `subscribe_ab_test_variants`, `subscribe_ab_assignments`, `subscribe_ab_events`. Partial unique indexes enforce one active test per publication and one default page per publication.
- **Selector library** (`src/lib/ab-tests/`) — sticky visitor assignment via cookie, weighted random variant pick, event recording, email/visitor-based conversion attribution.
- **Middleware** sets a `subv_vid` cookie on any `/subscribe*` or `/website/subscribe*` path across all domains so preview URLs work without DNS changes.
- **`/subscribe` page fallback chain**: active variant → default subscribe_page → publication_settings → hardcoded. No behavior change for publications with no pages/tests set up.
- **Conversion hooks** in `/api/subscribe`, `/api/subscribe/personalize`, `/api/sparkloop/subscribe`, and the `/subscribe/offers` render path — 5 event types recorded: `page_view`, `signup`, `reached_offers`, `completed_info`, `sparkloop_signup`.
- **CRUD APIs** for pages and tests + a stats endpoint with IP exclusion (reuses `excluded_ips` + `isIPExcluded`).
- **Dashboard UI** under `/dashboard/[slug]/subscribe-pages` and `/dashboard/[slug]/ab-tests/` — list, create-wizard, test detail with per-variant metrics.
- **Settings redesign**: the subscribe-page heading/subheading/tagline inputs in Website Settings are replaced with a link to the new Subscribe Pages dashboard.
- **Scheduler cron** (every 15 min) auto-starts tests past their `start_date` and ends tests past their `end_date`.
- **Archive cover helper** (original commit) extracts `resolveArchiveCoverImage` so future AI-generated covers can slot in without touching archive renderers.

### Migrations (auto-apply in order)

1. `20260424_subscribe_ab_tests.sql` — creates the 5 A/B tables
2. `20260424_subscribe_pages_default_flag.sql` — adds `is_default` column + partial unique index
3. `20260424_seed_default_subscribe_pages.sql` — one-time idempotent backfill: for each active publication with subscribe_* settings but no default page, creates a "Current (seeded)" page preserving the existing content

All three applied successfully on staging. Seed migration verified idempotent (skipped pub with existing default, no duplicates).

### Stats-freshness guarantee

Every event/assignment row is keyed by `test_id`. Reusing the same page in a new test starts with zero counters because the new test has a different `test_id`.

## Test plan

### Archive covers (original commit)
- [ ] Archive cards on the website homepage still render (publication default when set, hardcoded fallback otherwise)
- [ ] `/news` archive page renders the same cover images

### Subscribe-page defaults
- [ ] After seed migration, `SELECT ... FROM subscribe_pages WHERE is_default` returns one "Current (seeded)" row per active publication with their current heading/subheading/tagline
- [ ] `/subscribe` renders the same content as before the migration
- [ ] Settings → Website → Subscribe Page section shows a "Manage Subscribe Pages →" button (no inline content inputs)
- [ ] Editing the default page's content updates `/subscribe` on next load

### A/B test flow
- [ ] Create 2 pages, build a test, start it → visitors get sticky 50/50 split (cookie stays; same heading on refresh)
- [ ] Submit form → `signup` row in `subscribe_ab_events`, email attached to `subscribe_ab_assignments`
- [ ] Reach `/subscribe/offers` → `reached_offers` row recorded
- [ ] Submit `/subscribe/info` → `completed_info` row recorded
- [ ] Complete SparkLoop subscribe → `sparkloop_signup` row, even without cookie (email-based attribution)
- [ ] Dashboard stats panel shows per-variant counts and conversion rates (rates suppressed until 50 page views)
- [ ] Bot UA (e.g. Googlebot) → `is_bot_ua=true` on assignment; filtered from stats
- [ ] IP added to `excluded_ips` → disappears from stats
- [ ] End test → `/subscribe` reverts to default page; new test reusing same pages starts with zero counts
- [ ] Date-driven start/end works when cron runs (manual trigger on staging: `curl -H "Authorization: Bearer $CRON_SECRET" <host>/api/cron/ab-test-scheduler`)

### Staging preview URL (no DNS)
- [ ] `https://aiprodaily-staging.vercel.app/website/subscribe?pub_slug=<slug>` loads the correct publication's content
- [ ] `subv_vid` cookie gets set on first visit
- [ ] Sticky assignment works across refreshes

### Gates
- [ ] `npm run type-check` passes
- [ ] `npm run lint` within warning ceiling
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * A/B testing system for subscribe pages, including test creation, management, and performance analytics
  * Subscribe pages dashboard to create and manage multiple page variants per publication
  * Automatic scheduling of A/B tests based on configured start and end dates
  * Conversion event tracking throughout the subscription flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->