### PR TITLE
Subscribe page: optional phone field + dashboard preview

### DIFF
--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -33,7 +33,7 @@ export const POST = withApiHandler(
   { authTier: 'public', logContext: 'subscribe' },
   async ({ request, logger }) => {
     const body = await request.json()
-    const { email, facebook_pixel, name } = body
+    const { email, facebook_pixel, name, phone } = body
 
     if (!email || !email.includes('@')) {
       return NextResponse.json({
@@ -99,6 +99,14 @@ export const POST = withApiHandler(
     // Add Kickbox verification fields
     if (Object.keys(kickboxFields).length > 0) {
       Object.assign(customFields, kickboxFields)
+    }
+
+    // Optional phone number from the subscribe form (collected when the active
+    // subscribe_page has collect_phone = 'true'). Stored as a `phone` custom
+    // field on the subscriber — maps cleanly across MailerLite, SendGrid, and
+    // Beehiiv, which all accept arbitrary custom fields.
+    if (typeof phone === 'string' && phone.trim().length > 0) {
+      customFields.phone = phone.trim()
     }
 
     if (facebook_pixel) {

--- a/src/app/dashboard/[slug]/subscribe-pages/page.tsx
+++ b/src/app/dashboard/[slug]/subscribe-pages/page.tsx
@@ -335,6 +335,51 @@ export default function SubscribePagesDashboardPage() {
                     )}
                   </div>
                 ))}
+
+                {/* Phone number collection */}
+                <div className="border-t pt-3">
+                  <label className="flex items-center gap-2 text-sm font-medium text-gray-700">
+                    <input
+                      type="checkbox"
+                      checked={form.content.collect_phone === 'true'}
+                      onChange={(e) =>
+                        setForm({
+                          ...form,
+                          content: { ...form.content, collect_phone: e.target.checked ? 'true' : 'false' },
+                        })
+                      }
+                    />
+                    Collect phone number (optional field on the form)
+                  </label>
+                  {form.content.collect_phone === 'true' && (
+                    <div className="mt-3 space-y-3 pl-6">
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Phone field label</label>
+                        <input
+                          type="text"
+                          value={form.content.phone_label || ''}
+                          onChange={(e) =>
+                            setForm({ ...form, content: { ...form.content, phone_label: e.target.value } })
+                          }
+                          className="w-full border rounded px-3 py-2"
+                          placeholder="Phone (optional)"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Phone field placeholder</label>
+                        <input
+                          type="text"
+                          value={form.content.phone_placeholder || ''}
+                          onChange={(e) =>
+                            setForm({ ...form, content: { ...form.content, phone_placeholder: e.target.value } })
+                          }
+                          className="w-full border rounded px-3 py-2"
+                          placeholder="Your phone number"
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
               </div>
 
               <div className="flex justify-end gap-3 mt-6">

--- a/src/app/dashboard/[slug]/subscribe-pages/page.tsx
+++ b/src/app/dashboard/[slug]/subscribe-pages/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, useRef } from 'react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import Layout from '@/components/Layout'
@@ -30,6 +30,22 @@ const CONTENT_FIELDS: Array<{ key: string; label: string; multiline?: boolean; p
   { key: 'cta_text', label: 'CTA button text (override)', placeholder: '' },
 ]
 
+/**
+ * Build a `/website/subscribe?preview=<base64-JSON>&pub_slug=<slug>` URL the
+ * subscribe server component knows how to render in preview mode (no DB
+ * lookups for variant/default, no event recording, form submissions disabled).
+ */
+function buildPreviewUrl(slug: string, content: Record<string, string | undefined>): string {
+  // Strip undefined/empty so the preview matches what would actually be saved
+  const clean: Record<string, string> = {}
+  for (const [k, v] of Object.entries(content)) {
+    const trimmed = (v || '').trim()
+    if (trimmed) clean[k] = trimmed
+  }
+  const blob = btoa(JSON.stringify({ pub_slug: slug, content: clean }))
+  return `/website/subscribe?preview=${encodeURIComponent(blob)}`
+}
+
 export default function SubscribePagesDashboardPage() {
   const { slug } = useParams() as { slug: string }
   const [newsletter, setNewsletter] = useState<Newsletter | null>(null)
@@ -43,6 +59,9 @@ export default function SubscribePagesDashboardPage() {
     is_default: false,
   })
   const [busy, setBusy] = useState(false)
+  // Debounced preview URL — avoids thrashing the iframe on every keystroke
+  const [previewUrl, setPreviewUrl] = useState<string>('')
+  const previewTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const publicationId = newsletter?.id
 
@@ -196,6 +215,24 @@ export default function SubscribePagesDashboardPage() {
   const visiblePages = useMemo(() => pages.filter(p => !p.is_archived), [pages])
   const hasDefault = useMemo(() => visiblePages.some(p => p.is_default), [visiblePages])
 
+  // Debounce-update the preview iframe URL whenever the form content changes
+  // while the modal is open. 400ms feels responsive but doesn't reload the
+  // iframe on every keystroke.
+  useEffect(() => {
+    if (!creating && !editing) {
+      setPreviewUrl('')
+      return
+    }
+    if (previewTimer.current) clearTimeout(previewTimer.current)
+    previewTimer.current = setTimeout(() => {
+      setPreviewUrl(buildPreviewUrl(slug, form.content))
+    }, 400)
+    return () => {
+      if (previewTimer.current) clearTimeout(previewTimer.current)
+    }
+    // form.name doesn't affect the rendered subscribe page, so only watch content
+  }, [form.content, creating, editing, slug])
+
   return (
     <Layout>
       <div className="px-4 py-6 sm:px-0">
@@ -261,6 +298,14 @@ export default function SubscribePagesDashboardPage() {
                   </div>
                 </div>
                 <div className="flex items-center gap-3 flex-shrink-0">
+                  <a
+                    href={buildPreviewUrl(slug, p.content || {})}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-gray-600 hover:underline"
+                  >
+                    Preview
+                  </a>
                   {!p.is_default && (
                     <button
                       onClick={() => setAsDefault(p)}
@@ -286,7 +331,8 @@ export default function SubscribePagesDashboardPage() {
 
         {(creating || editing) && (
           <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-            <div className="bg-white rounded-lg w-full max-w-2xl p-6 max-h-[90vh] overflow-y-auto">
+            <div className="bg-white rounded-lg w-full max-w-6xl max-h-[90vh] overflow-hidden grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+              <div className="p-6 overflow-y-auto">
               <h2 className="text-xl font-bold mb-4">
                 {creating ? 'New Subscribe Page' : `Edit: ${editing?.name}`}
               </h2>
@@ -397,6 +443,39 @@ export default function SubscribePagesDashboardPage() {
                 >
                   {busy ? 'Saving…' : creating ? 'Create' : 'Save'}
                 </button>
+              </div>
+              </div>
+
+              {/* Live preview pane (right column on lg+, hidden on mobile to save room) */}
+              <div className="hidden lg:flex border-l flex-col bg-gray-50">
+                <div className="flex items-center justify-between px-4 py-2 border-b bg-white">
+                  <span className="text-sm font-medium text-gray-700">Live Preview</span>
+                  {previewUrl && (
+                    <a
+                      href={previewUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-600 hover:underline"
+                    >
+                      Open in new tab ↗
+                    </a>
+                  )}
+                </div>
+                <div className="flex-1 overflow-hidden">
+                  {previewUrl ? (
+                    <iframe
+                      key={previewUrl}
+                      src={previewUrl}
+                      title="Subscribe page preview"
+                      className="w-full h-full border-0"
+                      sandbox="allow-same-origin allow-scripts allow-forms"
+                    />
+                  ) : (
+                    <div className="flex items-center justify-center h-full text-sm text-gray-400">
+                      Loading preview…
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/website/subscribe/page.tsx
+++ b/src/app/website/subscribe/page.tsx
@@ -44,13 +44,39 @@ async function resolvePublicationId(
   return publicationId
 }
 
+/**
+ * Decode a base64-encoded JSON preview blob: { pub_slug?, content: {...} }.
+ * Returns null on any decode/parse failure (preview falls back to normal render).
+ */
+function decodePreviewBlob(raw: string | undefined): { pub_slug?: string; content: Record<string, string | undefined> } | null {
+  if (!raw) return null
+  try {
+    const json = Buffer.from(raw, 'base64').toString('utf-8')
+    const parsed = JSON.parse(json)
+    if (!parsed || typeof parsed !== 'object' || !parsed.content || typeof parsed.content !== 'object') {
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
 export default async function SubscribePage({
   searchParams,
 }: {
-  searchParams: Promise<{ publication_id?: string; pub_slug?: string }>
+  searchParams: Promise<{ publication_id?: string; pub_slug?: string; preview?: string }>
 }) {
   const sp = await searchParams
-  const publicationId = await resolvePublicationId(sp)
+  const preview = decodePreviewBlob(sp.preview)
+
+  // When previewing, the slug from the preview blob takes priority so the
+  // dashboard can preview any publication's page without separately passing it.
+  const resolvedFromParams = await resolvePublicationId({
+    publication_id: sp.publication_id,
+    pub_slug: preview?.pub_slug || sp.pub_slug,
+  })
+  const publicationId = resolvedFromParams
 
   // Fetch publication-level defaults (used when no variant overrides exist)
   const settings = await getPublicationSettings(publicationId, [
@@ -61,14 +87,17 @@ export default async function SubscribePage({
     'subscribe_tagline',
   ])
 
-  // Resolve A/B test (if any) and assign a sticky variant.
-  // Also load the default subscribe page — used as the base when no test is
-  // active, and as the fallback for any variant field left blank.
-  const [active, defaultPage] = await Promise.all([
-    getActiveTestForPublication(publicationId),
-    getDefaultPageForPublication(publicationId),
-  ])
+  // In preview mode we skip live A/B and default-page lookups entirely so the
+  // preview shows exactly the content the user is editing — no mixing in the
+  // currently-active variant. We also skip event recording and cookie writes.
+  const [active, defaultPage] = preview
+    ? [null, null]
+    : await Promise.all([
+        getActiveTestForPublication(publicationId),
+        getDefaultPageForPublication(publicationId),
+      ])
   const defaultContent = (defaultPage?.content || {}) as Record<string, string | undefined>
+  const previewContent = (preview?.content || {}) as Record<string, string | undefined>
 
   let variantContent: Record<string, string | undefined> = {}
   if (active) {
@@ -106,33 +135,40 @@ export default async function SubscribePage({
     }
   }
 
-  // Fallback chain for each field: active variant → default page → publication_settings → hardcoded
-  const logoUrl = variantContent.logo_url || defaultContent.logo_url || settings.logo_url || '/logo.png'
+  // Fallback chain for each field: preview (when set) → active variant → default page → publication_settings → hardcoded
+  const logoUrl =
+    previewContent.logo_url || variantContent.logo_url || defaultContent.logo_url || settings.logo_url || '/logo.png'
   const newsletterName = settings.newsletter_name || 'AI Accounting Daily'
   const heading =
+    previewContent.heading ||
     variantContent.heading ||
     defaultContent.heading ||
     settings.subscribe_heading ||
     'Master AI Tools, Prompts & News **in Just 3 Minutes a Day**'
   const subheading =
+    previewContent.subheading ||
     variantContent.subheading ||
     defaultContent.subheading ||
     settings.subscribe_subheading ||
     'Join 10,000+ accounting professionals staying current as AI reshapes bookkeeping, tax, and advisory work.'
   const tagline =
+    previewContent.tagline ||
     variantContent.tagline ||
     defaultContent.tagline ||
     settings.subscribe_tagline ||
     'FREE FOREVER'
 
   // Phone collection: stored as string 'true' in the JSONB content. Falls through
-  // the same variant → default → (no publication setting yet) chain.
+  // the same preview → variant → default → (no publication setting yet) chain.
   const collectPhone =
-    (variantContent.collect_phone || defaultContent.collect_phone || 'false') === 'true'
+    (previewContent.collect_phone || variantContent.collect_phone || defaultContent.collect_phone || 'false') === 'true'
   const phoneLabel =
-    variantContent.phone_label || defaultContent.phone_label || 'Phone (optional)'
+    previewContent.phone_label || variantContent.phone_label || defaultContent.phone_label || 'Phone (optional)'
   const phonePlaceholder =
-    variantContent.phone_placeholder || defaultContent.phone_placeholder || 'Your phone number'
+    previewContent.phone_placeholder ||
+    variantContent.phone_placeholder ||
+    defaultContent.phone_placeholder ||
+    'Your phone number'
 
   return (
     <main className="min-h-[100dvh] bg-white px-4">
@@ -170,6 +206,7 @@ export default async function SubscribePage({
                 collectPhone={collectPhone}
                 phoneLabel={phoneLabel}
                 phonePlaceholder={phonePlaceholder}
+                previewMode={Boolean(preview)}
               />
             </div>
           </div>

--- a/src/app/website/subscribe/page.tsx
+++ b/src/app/website/subscribe/page.tsx
@@ -125,6 +125,15 @@ export default async function SubscribePage({
     settings.subscribe_tagline ||
     'FREE FOREVER'
 
+  // Phone collection: stored as string 'true' in the JSONB content. Falls through
+  // the same variant → default → (no publication setting yet) chain.
+  const collectPhone =
+    (variantContent.collect_phone || defaultContent.collect_phone || 'false') === 'true'
+  const phoneLabel =
+    variantContent.phone_label || defaultContent.phone_label || 'Phone (optional)'
+  const phonePlaceholder =
+    variantContent.phone_placeholder || defaultContent.phone_placeholder || 'Your phone number'
+
   return (
     <main className="min-h-[100dvh] bg-white px-4">
       {/* Subscribe Section */}
@@ -154,7 +163,14 @@ export default async function SubscribePage({
 
             {/* Subscribe Form */}
             <div className="mt-6 sm:mt-10">
-              <SubscribeForm newsletterName={newsletterName} tagline={tagline} publicationId={publicationId} />
+              <SubscribeForm
+                newsletterName={newsletterName}
+                tagline={tagline}
+                publicationId={publicationId}
+                collectPhone={collectPhone}
+                phoneLabel={phoneLabel}
+                phonePlaceholder={phonePlaceholder}
+              />
             </div>
           </div>
         </Container>

--- a/src/app/website/subscribe/subscribe-form.tsx
+++ b/src/app/website/subscribe/subscribe-form.tsx
@@ -65,6 +65,7 @@ interface SubscribeFormProps {
   collectPhone?: boolean
   phoneLabel?: string
   phonePlaceholder?: string
+  previewMode?: boolean
 }
 
 export function SubscribeForm({
@@ -74,6 +75,7 @@ export function SubscribeForm({
   collectPhone = false,
   phoneLabel = 'Phone (optional)',
   phonePlaceholder = 'Your phone number',
+  previewMode = false,
 }: SubscribeFormProps) {
   const [email, setEmail] = useState('')
   const [phone, setPhone] = useState('')
@@ -114,6 +116,12 @@ export function SubscribeForm({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+
+    if (previewMode) {
+      // Preview pages render the form for visual inspection only — never POST.
+      setError('Preview mode — submissions are disabled.')
+      return
+    }
 
     if (!email || !email.includes('@')) {
       setError('Please enter a valid email address')
@@ -166,6 +174,11 @@ export function SubscribeForm({
   return (
     <>
       <div className="space-y-4">
+        {previewMode && (
+          <div className="mx-auto max-w-lg rounded-md bg-yellow-100 px-3 py-2 text-xs font-medium text-yellow-900 ring-1 ring-yellow-300">
+            Preview mode — form submissions are disabled.
+          </div>
+        )}
         <form onSubmit={handleSubmit} className="mx-auto w-full max-w-lg space-y-3">
           <div className="relative">
             <label htmlFor="email" className="sr-only">Email address</label>

--- a/src/app/website/subscribe/subscribe-form.tsx
+++ b/src/app/website/subscribe/subscribe-form.tsx
@@ -58,8 +58,25 @@ function generateAfterOffersClickId() {
   return `ao_${Date.now()}_${randomPart}`
 }
 
-export function SubscribeForm({ newsletterName = 'AI Accounting Daily', tagline = 'FREE FOREVER', publicationId }: { newsletterName?: string; tagline?: string; publicationId?: string }) {
+interface SubscribeFormProps {
+  newsletterName?: string
+  tagline?: string
+  publicationId?: string
+  collectPhone?: boolean
+  phoneLabel?: string
+  phonePlaceholder?: string
+}
+
+export function SubscribeForm({
+  newsletterName = 'AI Accounting Daily',
+  tagline = 'FREE FOREVER',
+  publicationId,
+  collectPhone = false,
+  phoneLabel = 'Phone (optional)',
+  phonePlaceholder = 'Your phone number',
+}: SubscribeFormProps) {
   const [email, setEmail] = useState('')
+  const [phone, setPhone] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [didYouMean, setDidYouMean] = useState('')
@@ -111,12 +128,14 @@ export function SubscribeForm({ newsletterName = 'AI Accounting Daily', tagline 
       // Get Facebook Pixel data at submit time
       const pixelData = getFacebookPixelData()
 
+      const trimmedPhone = phone.trim()
       const response = await fetch('/api/subscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           email,
-          facebook_pixel: pixelData
+          facebook_pixel: pixelData,
+          ...(trimmedPhone ? { phone: trimmedPhone } : {}),
         })
       })
 
@@ -147,8 +166,8 @@ export function SubscribeForm({ newsletterName = 'AI Accounting Daily', tagline 
   return (
     <>
       <div className="space-y-4">
-        <form onSubmit={handleSubmit} className="flex justify-center">
-          <div className="relative w-full max-w-lg">
+        <form onSubmit={handleSubmit} className="mx-auto w-full max-w-lg space-y-3">
+          <div className="relative">
             <label htmlFor="email" className="sr-only">Email address</label>
             <input
               type="email"
@@ -170,6 +189,24 @@ export function SubscribeForm({ newsletterName = 'AI Accounting Daily', tagline 
               {isSubmitting ? 'Loading...' : 'Subscribe'}
             </button>
           </div>
+
+          {collectPhone && (
+            <div className="relative">
+              <label htmlFor="phone" className="sr-only">{phoneLabel}</label>
+              <input
+                type="tel"
+                name="phone"
+                id="phone"
+                autoComplete="tel"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                disabled={isSubmitting}
+                placeholder={phonePlaceholder}
+                aria-label={phoneLabel}
+                className="w-full rounded-full border-0 bg-white px-5 py-4 text-slate-900 shadow-lg ring-1 ring-inset ring-slate-200 placeholder:text-slate-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6"
+              />
+            </div>
+          )}
         </form>
 
         {error && (

--- a/src/lib/ab-tests/types.ts
+++ b/src/lib/ab-tests/types.ts
@@ -13,6 +13,10 @@ export interface SubscribePageContent {
   tagline?: string
   logo_url?: string
   cta_text?: string
+  /** When 'true', renders an optional phone-number input below the email field. */
+  collect_phone?: string
+  phone_label?: string
+  phone_placeholder?: string
   [key: string]: string | undefined
 }
 


### PR DESCRIPTION
## Summary

Two follow-on enhancements for the subscribe-page system shipped in #209:

### 1. Optional phone-number collection (per page)

Each `subscribe_page` can now opt into collecting an optional phone number on the /subscribe form. When provided, the value flows through `/api/subscribe` as a `phone` custom field on the subscriber, stored by whichever email provider is configured (MailerLite, SendGrid, or Beehiiv — all three accept arbitrary custom fields with the same key).

- Extended `SubscribePageContent` with `collect_phone`, `phone_label`, `phone_placeholder` (string values in the JSONB content blob)
- Dashboard form: new "Collect phone number" checkbox that reveals two text inputs for the field label and placeholder
- `/subscribe` page: fields fall through the same preview → variant → default page → publication_settings chain
- `SubscribeForm`: renders an `<input type="tel">` below the email input only when `collect_phone` is true; submits it alongside email when non-empty
- `/api/subscribe`: accepts `phone`, trims, adds as `customFields.phone` which all three provider branches already pipe through

No DB migration required — stored in the existing `subscribe_pages.content` JSONB. Publications that haven't enabled it see no change.

### 2. Dashboard preview (saved + live-edit)

Two preview mechanisms, one server-side code path:

- `/subscribe` accepts `?preview=<base64-JSON>` carrying `{ pub_slug?, content }`. When present, skips A/B variant resolution, default-page lookup, cookie writes, and event recording. Renders the supplied content against the same component the real page uses, so the preview is pixel-identical.
- `SubscribeForm` gets a `previewMode` prop: shows a yellow banner and blocks `handleSubmit` so preview clicks never POST.

Dashboard (`/dashboard/[slug]/subscribe-pages`):

- Each page in the list has a **Preview** link that opens the saved content in a new tab.
- Edit modal grew to a two-column layout on `lg+` screens: form on the left, live iframe preview on the right. The preview URL is debounced 400ms from `form.content` changes so typing doesn't thrash the iframe. Includes an "Open in new tab" link for full-viewport inspection.

`buildPreviewUrl` strips empty/undefined values before encoding, so the preview matches what would actually be saved.

## Test plan

### Phone collection
- [ ] Edit a subscribe page, check "Collect phone number", set a label/placeholder, save → /subscribe (or preview) shows the phone field below email
- [ ] Submit form with email only → succeeds; no `phone` custom field on subscriber
- [ ] Submit form with email + phone → succeeds; subscriber has `phone` custom field with the value across MailerLite / SendGrid / Beehiiv (whichever is configured)
- [ ] Disable the toggle on a page that previously had it on → field disappears on next load
- [ ] A/B test with one variant collecting phone and the other not → both render correctly; signup events recorded for both

### Preview
- [ ] Click "Preview" on a saved page → opens in new tab with yellow banner; submitting the form is blocked
- [ ] Open Edit modal on lg+ screen → live preview iframe appears on the right; typing in heading updates the preview within ~400ms
- [ ] Toggle "Collect phone number" in the form → phone field appears in preview iframe
- [ ] Click "Open in new tab" from preview pane → same URL opens standalone
- [ ] Mobile / `<lg` viewport → preview pane hidden; form remains usable; list-row Preview link still works

### Regressions
- [ ] No A/B event rows recorded with `event_type='page_view'` from preview URLs (verify in `subscribe_ab_events`)
- [ ] `subv_vid` cookie NOT set when visiting a preview URL
- [ ] `npm run type-check`, `npm run lint`, `npm run build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)