### PR TITLE
feat(analytics): foundation library + metrics glossary (PR 1)

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -1,0 +1,113 @@
+# Metrics Glossary
+
+_Last updated: 2026-04-23_
+
+Canonical definitions for every KPI surfaced on analytics pages. Any PR that adds a dashboard metric must update this glossary. Compute functions live in `src/lib/analytics/metrics.ts`; data reads in `src/lib/dal/analytics.ts`.
+
+---
+
+## Issue CTR
+
+- **Formula:** `unique_clickers / delivered_count`
+- **Numerator source:** `link_clicks` (own event table), filtered by `isClickCountable` (`src/lib/analytics/bot-policy.ts`)
+- **Denominator source:** `email_metrics.delivered_count` (ESP-reported)
+- **Uniqueness rule:** one row per `(subscriber_email, link_url, issue_id)` — no time window; issue is the natural boundary
+- **Compute with:** `computeIssueCTR()` + `dal.getIssueEngagement()`
+- **Known quirks:** `email_metrics.click_rate` is an ESP-reported value and may differ — vendor bot filtering is opaque. Displayed separately as "ESP-reported Click Rate" for deliverability debugging.
+- **Owner:** @jake
+
+## Module CTR
+
+- **Formula:** `unique_clickers_in_module / module_recipients`
+- **Numerator source:** `link_clicks` rows with `link_section` matching the module, bot/IP filtered
+- **Denominator source:** defaults to `email_metrics.delivered_count`; segmented modules pass an explicit recipient count from the per-issue module-assignment table
+- **Uniqueness rule:** one row per `(subscriber_email, link_url, issue_id, link_section)`
+- **Compute with:** `computeModuleCTR()` + `dal.getModuleEngagement()`
+- **Known quirks:** distinct from Issue CTR — never compare directly. UI labels must say "Module CTR" when showing this.
+- **Owner:** @jake
+
+## Issue Open Rate
+
+- **Formula:** `unique_openers / delivered_count`
+- **Numerator source:** `email_metrics.opened_count` (ESP-reported — we do not run our own open pixel)
+- **Denominator source:** `email_metrics.delivered_count`
+- **Uniqueness rule:** vendor-defined
+- **Compute with:** `computeIssueOpenRate()`
+- **Known quirks:** ESP bot filtering is opaque. Apple Mail Privacy Protection inflates opens (~30–60% of Apple users).
+- **Owner:** @jake
+
+## Poll Response Rate
+
+- **Formula:** `unique_respondents / delivered_count`
+- **Numerator source:** `poll_responses` (the typed DAL read that feeds this formula lands in PR 3 when `/api/polls/analytics` is rewritten)
+- **Denominator source:** `email_metrics.delivered_count`
+- **Uniqueness rule:** one row per `(subscriber_email, poll_id)`
+- **Compute with:** `computePollResponseRate()`
+- **Owner:** @jake
+
+## Feedback Response Rate
+
+- **Formula:** `unique_respondents / delivered_count`
+- **Numerator source:** `feedback_responses`
+- **Denominator source:** `email_metrics.delivered_count`
+- **Uniqueness rule:** one row per `(subscriber_email, issue_id)`
+- **Compute with:** `computeFeedbackResponseRate()`
+- **Owner:** @jake
+
+## Ad CTR / AI App CTR / Tools Directory CTR
+
+All three are Module CTR specializations — `link_section` varies (`Ads`, `AI Apps`, `Tools`). Same formula, same dedup rule. Documented here as aliases; dashboards label them appropriately.
+
+## Delivered Count
+
+- **Source:** `email_metrics.delivered_count`
+- **Definition:** sent minus vendor-reported bounces
+- **Used as denominator for:** Issue CTR, Module CTR (default), Open Rate, Response Rates, Unsubscribe Rate
+
+## Bounce Rate
+
+- **Formula:** `bounced_count / sent_count`
+- **Source:** `email_metrics.bounced_count` / `email_metrics.sent_count`
+- **Compute with:** `computeBounceRate()`
+- **Owner:** @jake
+
+## Unsubscribe Rate
+
+- **Formula:** `unsubscribed_count / delivered_count`
+- **Source:** `email_metrics`
+- **Compute with:** `computeUnsubscribeRate()`
+- **Owner:** @jake
+
+---
+
+## Bot & IP Filter Policy
+
+A click counts toward metrics (`isClickCountable` returns `true`) unless any of:
+- `link_clicks.is_bot_ua = true` (UA matched a bot pattern at ingest)
+- `link_clicks.ip_address` is in `excluded_ips` (exact match)
+- `link_clicks.ip_address` matches any CIDR range in `excluded_ips`
+
+Historical rows with `is_bot_ua = NULL` are treated as not-a-bot (no backfill applied — see prior incident notes).
+
+ESP-reported counts (`opened_count`, `clicked_count`) inherit vendor filtering and **cannot** be re-filtered. `email_metrics.click_rate` therefore diverges from computed Issue CTR; this is expected.
+
+## Data Lineage
+
+| Metric | Upstream table(s) | Sync job |
+|--------|-------------------|----------|
+| Issue CTR | `link_clicks` | real-time insert by tracking endpoint |
+| Module CTR | `link_clicks` | real-time insert by tracking endpoint |
+| Open Rate / ESP Click Rate / Bounce / Unsubscribe | `email_metrics` | `/api/cron/import-email-metrics` (MailerLite) |
+| Poll Response Rate | `poll_responses` | real-time insert |
+| Feedback Response Rate | `feedback_responses` | real-time insert |
+
+## Freshness
+
+`email_metrics.imported_at` carries the last sync timestamp (renamed to `last_synced_at` in PR 2). Stale threshold: 12 hours (configurable via `app_settings.email_metrics_stale_threshold_hours`). Dashboards display "as of X" via `<FreshnessBadge>`.
+
+## Adding a New Metric
+
+1. Add the compute function to `src/lib/analytics/metrics.ts` with unit tests.
+2. Add a DAL read to `src/lib/dal/analytics.ts` with tests.
+3. Add a section to this glossary with formula, source, uniqueness rule, and owner.
+4. Link the glossary entry from the dashboard PR description.

--- a/src/lib/analytics/__tests__/bot-policy.test.ts
+++ b/src/lib/analytics/__tests__/bot-policy.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports that use them
+// ---------------------------------------------------------------------------
+const mockChain: Record<string, any> = {
+  select: vi.fn(function (this: any) { return mockChain }),
+  eq: vi.fn(function () { return mockChain }),
+}
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => mockChain),
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    correlationId: 'test-id',
+  })),
+}))
+
+import { ExcludedIpSet, isClickCountable, loadExcludedIps } from '../bot-policy'
+import type { LinkClickRow } from '../types'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockChain.select.mockReturnValue(mockChain)
+  mockChain.eq.mockReturnValue(mockChain)
+})
+
+describe('ExcludedIpSet', () => {
+  it('matches exact IPs', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '1.2.3.4', is_range: false, cidr_prefix: null },
+    ])
+    expect(set.has('1.2.3.4')).toBe(true)
+    expect(set.has('1.2.3.5')).toBe(false)
+  })
+
+  it('matches IPv4 CIDR ranges', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '10.0.0.0', is_range: true, cidr_prefix: 8 },
+    ])
+    expect(set.matchesCidr('10.1.2.3')).toBe(true)
+    expect(set.matchesCidr('11.1.2.3')).toBe(false)
+  })
+
+  it('handles null IP lookup gracefully', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '1.2.3.4', is_range: false, cidr_prefix: null },
+    ])
+    expect(set.has(null)).toBe(false)
+    expect(set.matchesCidr(null)).toBe(false)
+  })
+
+  it('is case-insensitive to IP casing (IPv6 safety)', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '2001:DB8::1', is_range: false, cidr_prefix: null },
+    ])
+    expect(set.has('2001:db8::1')).toBe(true)
+  })
+})
+
+describe('isClickCountable', () => {
+  const emptySet = new ExcludedIpSet([])
+
+  function row(overrides: Partial<LinkClickRow>): LinkClickRow {
+    return {
+      id: 'id-1',
+      publication_id: 'pub-1',
+      issue_id: 'issue-1',
+      subscriber_email: 'a@b.com',
+      link_url: 'https://example.com',
+      link_section: 'Articles',
+      ip_address: '1.1.1.1',
+      is_bot_ua: false,
+      ...overrides,
+    }
+  }
+
+  it('returns true for a normal human click', () => {
+    expect(isClickCountable(row({}), emptySet)).toBe(true)
+  })
+
+  it('returns false when is_bot_ua is true', () => {
+    expect(isClickCountable(row({ is_bot_ua: true }), emptySet)).toBe(false)
+  })
+
+  it('returns false when IP is in excluded set (exact match)', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '1.1.1.1', is_range: false, cidr_prefix: null },
+    ])
+    expect(isClickCountable(row({}), set)).toBe(false)
+  })
+
+  it('returns false when IP matches an excluded CIDR range', () => {
+    const set = new ExcludedIpSet([
+      { ip_address: '1.1.0.0', is_range: true, cidr_prefix: 16 },
+    ])
+    expect(isClickCountable(row({ ip_address: '1.1.5.200' }), set)).toBe(false)
+  })
+
+  it('treats null is_bot_ua as not-a-bot (historical rows)', () => {
+    expect(isClickCountable(row({ is_bot_ua: null }), emptySet)).toBe(true)
+  })
+})
+
+describe('loadExcludedIps', () => {
+  it('queries excluded_ips for the given publication and returns a populated set', async () => {
+    const { supabaseAdmin } = await import('@/lib/supabase')
+    vi.mocked(supabaseAdmin.from).mockReturnValueOnce({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({
+          data: [
+            { ip_address: '1.2.3.4', is_range: false, cidr_prefix: null },
+            { ip_address: '10.0.0.0', is_range: true, cidr_prefix: 8 },
+          ],
+          error: null,
+        }),
+      }),
+    } as any)
+
+    const set = await loadExcludedIps('pub-1')
+
+    expect(set.has('1.2.3.4')).toBe(true)
+    expect(set.matchesCidr('10.5.5.5')).toBe(true)
+  })
+
+  it('returns empty set on DB error', async () => {
+    const { supabaseAdmin } = await import('@/lib/supabase')
+    vi.mocked(supabaseAdmin.from).mockReturnValueOnce({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: null, error: { message: 'oops' } }),
+      }),
+    } as any)
+
+    const set = await loadExcludedIps('pub-1')
+
+    expect(set.has('1.2.3.4')).toBe(false)
+  })
+})

--- a/src/lib/analytics/__tests__/metrics.test.ts
+++ b/src/lib/analytics/__tests__/metrics.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeIssueCTR,
+  computeModuleCTR,
+  computeIssueOpenRate,
+  computePollResponseRate,
+  computeFeedbackResponseRate,
+  computeBounceRate,
+  computeUnsubscribeRate,
+} from '../metrics'
+
+describe('computeIssueCTR', () => {
+  it('returns unique clickers divided by delivered count', () => {
+    expect(computeIssueCTR({ uniqueClickers: 50, deliveredCount: 1000 })).toBe(0.05)
+  })
+
+  it('returns 0 when deliveredCount is 0', () => {
+    expect(computeIssueCTR({ uniqueClickers: 50, deliveredCount: 0 })).toBe(0)
+  })
+
+  it('returns 0 when uniqueClickers is 0', () => {
+    expect(computeIssueCTR({ uniqueClickers: 0, deliveredCount: 1000 })).toBe(0)
+  })
+
+  it('throws if inputs are negative', () => {
+    expect(() => computeIssueCTR({ uniqueClickers: -1, deliveredCount: 100 })).toThrow()
+    expect(() => computeIssueCTR({ uniqueClickers: 1, deliveredCount: -1 })).toThrow()
+  })
+
+  it('clamps to 1.0 if unique clickers exceed delivered (data anomaly)', () => {
+    expect(computeIssueCTR({ uniqueClickers: 1500, deliveredCount: 1000 })).toBe(1)
+  })
+})
+
+describe('computeModuleCTR', () => {
+  it('returns unique clickers divided by module recipients', () => {
+    expect(computeModuleCTR({ uniqueClickers: 30, moduleRecipients: 600 })).toBe(0.05)
+  })
+
+  it('returns 0 when moduleRecipients is 0', () => {
+    expect(computeModuleCTR({ uniqueClickers: 30, moduleRecipients: 0 })).toBe(0)
+  })
+
+  it('throws on negative inputs', () => {
+    expect(() => computeModuleCTR({ uniqueClickers: -1, moduleRecipients: 100 })).toThrow()
+  })
+})
+
+describe('computeIssueOpenRate', () => {
+  it('returns unique openers divided by delivered count', () => {
+    expect(computeIssueOpenRate({ uniqueOpeners: 500, deliveredCount: 1000 })).toBe(0.5)
+  })
+
+  it('returns 0 when deliveredCount is 0', () => {
+    expect(computeIssueOpenRate({ uniqueOpeners: 500, deliveredCount: 0 })).toBe(0)
+  })
+
+  it('clamps to 1.0 on data anomaly', () => {
+    expect(computeIssueOpenRate({ uniqueOpeners: 1500, deliveredCount: 1000 })).toBe(1)
+  })
+})
+
+describe('computePollResponseRate', () => {
+  it('returns unique respondents divided by delivered count', () => {
+    expect(computePollResponseRate({ uniqueRespondents: 100, deliveredCount: 1000 })).toBe(0.1)
+  })
+
+  it('returns 0 when deliveredCount is 0', () => {
+    expect(computePollResponseRate({ uniqueRespondents: 100, deliveredCount: 0 })).toBe(0)
+  })
+})
+
+describe('computeFeedbackResponseRate', () => {
+  it('returns unique respondents divided by delivered count', () => {
+    expect(computeFeedbackResponseRate({ uniqueRespondents: 200, deliveredCount: 1000 })).toBe(0.2)
+  })
+
+  it('returns 0 when deliveredCount is 0', () => {
+    expect(computeFeedbackResponseRate({ uniqueRespondents: 200, deliveredCount: 0 })).toBe(0)
+  })
+})
+
+describe('computeBounceRate', () => {
+  it('returns bounced count divided by sent count', () => {
+    expect(computeBounceRate({ bouncedCount: 20, sentCount: 1000 })).toBe(0.02)
+  })
+
+  it('returns 0 when sentCount is 0', () => {
+    expect(computeBounceRate({ bouncedCount: 20, sentCount: 0 })).toBe(0)
+  })
+})
+
+describe('computeUnsubscribeRate', () => {
+  it('returns unsubscribed count divided by delivered count', () => {
+    expect(computeUnsubscribeRate({ unsubscribedCount: 5, deliveredCount: 1000 })).toBe(0.005)
+  })
+
+  it('returns 0 when deliveredCount is 0', () => {
+    expect(computeUnsubscribeRate({ unsubscribedCount: 5, deliveredCount: 0 })).toBe(0)
+  })
+})

--- a/src/lib/analytics/__tests__/metrics.test.ts
+++ b/src/lib/analytics/__tests__/metrics.test.ts
@@ -27,6 +27,16 @@ describe('computeIssueCTR', () => {
     expect(() => computeIssueCTR({ uniqueClickers: 1, deliveredCount: -1 })).toThrow()
   })
 
+  it('throws on NaN inputs', () => {
+    expect(() => computeIssueCTR({ uniqueClickers: Number.NaN, deliveredCount: 100 })).toThrow()
+    expect(() => computeIssueCTR({ uniqueClickers: 100, deliveredCount: Number.NaN })).toThrow()
+  })
+
+  it('throws on Infinity inputs', () => {
+    expect(() => computeIssueCTR({ uniqueClickers: Number.POSITIVE_INFINITY, deliveredCount: 100 })).toThrow()
+    expect(() => computeIssueCTR({ uniqueClickers: 100, deliveredCount: Number.POSITIVE_INFINITY })).toThrow()
+  })
+
   it('clamps to 1.0 if unique clickers exceed delivered (data anomaly)', () => {
     expect(computeIssueCTR({ uniqueClickers: 1500, deliveredCount: 1000 })).toBe(1)
   })

--- a/src/lib/analytics/bot-policy.ts
+++ b/src/lib/analytics/bot-policy.ts
@@ -1,0 +1,100 @@
+/**
+ * Bot and IP filter policy for click analytics.
+ *
+ * Single source of truth for "should this click count?".
+ * Called by every DAL read that returns link_clicks aggregates.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { createLogger } from '@/lib/logger'
+import type { LinkClickRow, ExcludedIpRow } from './types'
+
+const log = createLogger({ module: 'analytics:bot-policy' })
+
+/**
+ * In-memory index of a publication's excluded IPs.
+ * Supports exact-match lookup (has) and CIDR-range match (matchesCidr).
+ * Case-insensitive; handles null lookups.
+ */
+export class ExcludedIpSet {
+  private readonly exactIps: Set<string>
+  private readonly ranges: Array<{ cidr: string; prefix: number }>
+
+  constructor(rows: ExcludedIpRow[]) {
+    this.exactIps = new Set()
+    this.ranges = []
+    for (const row of rows) {
+      if (row.is_range && row.cidr_prefix !== null) {
+        this.ranges.push({ cidr: row.ip_address, prefix: row.cidr_prefix })
+      } else {
+        this.exactIps.add(row.ip_address.toLowerCase())
+      }
+    }
+  }
+
+  has(ip: string | null): boolean {
+    if (!ip) return false
+    return this.exactIps.has(ip.toLowerCase())
+  }
+
+  matchesCidr(ip: string | null): boolean {
+    if (!ip) return false
+    for (const range of this.ranges) {
+      if (ipInCidr(ip, range.cidr, range.prefix)) return true
+    }
+    return false
+  }
+}
+
+/** Pure function — does a click count toward metrics? */
+export function isClickCountable(
+  row: Pick<LinkClickRow, 'is_bot_ua' | 'ip_address'>,
+  excludedIps: ExcludedIpSet
+): boolean {
+  if (row.is_bot_ua === true) return false
+  if (excludedIps.has(row.ip_address)) return false
+  if (excludedIps.matchesCidr(row.ip_address)) return false
+  return true
+}
+
+/** Load excluded IPs for a publication. Returns empty set on error. */
+export async function loadExcludedIps(publicationId: string): Promise<ExcludedIpSet> {
+  const { data, error } = await supabaseAdmin
+    .from('excluded_ips')
+    .select('ip_address, is_range, cidr_prefix')
+    .eq('publication_id', publicationId)
+
+  if (error || !data) {
+    log.error('Failed to load excluded_ips', { error, publicationId })
+    return new ExcludedIpSet([])
+  }
+  return new ExcludedIpSet(data as ExcludedIpRow[])
+}
+
+// ---------------------------------------------------------------------------
+// CIDR helpers (IPv4 only; IPv6 CIDR not currently used by excluded_ips)
+// ---------------------------------------------------------------------------
+
+function ipInCidr(ip: string, cidr: string, prefix: number): boolean {
+  if (ip.includes(':') || cidr.includes(':')) {
+    return false // IPv6 not supported for CIDR match
+  }
+  const ipInt = ipv4ToInt(ip)
+  const cidrInt = ipv4ToInt(cidr)
+  if (ipInt === null || cidrInt === null) return false
+  if (prefix < 0 || prefix > 32) return false
+  const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0
+  return (ipInt & mask) === (cidrInt & mask)
+}
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  let out = 0
+  for (const part of parts) {
+    const n = Number(part)
+    if (!Number.isInteger(n) || n < 0 || n > 255) return null
+    out = (out << 8) | n
+  }
+  return out >>> 0
+}

--- a/src/lib/analytics/bot-policy.ts
+++ b/src/lib/analytics/bot-policy.ts
@@ -65,7 +65,7 @@ export async function loadExcludedIps(publicationId: string): Promise<ExcludedIp
     .eq('publication_id', publicationId)
 
   if (error || !data) {
-    log.error('Failed to load excluded_ips', { error, publicationId })
+    log.error({ err: error, publicationId }, 'Failed to load excluded_ips')
     return new ExcludedIpSet([])
   }
   return new ExcludedIpSet(data as ExcludedIpRow[])

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Analytics library — barrel export.
+ * Consumers import from '@/lib/analytics'.
+ */
+
+export {
+  computeIssueCTR,
+  computeModuleCTR,
+  computeIssueOpenRate,
+  computePollResponseRate,
+  computeFeedbackResponseRate,
+  computeBounceRate,
+  computeUnsubscribeRate,
+} from './metrics'
+
+export {
+  ExcludedIpSet,
+  isClickCountable,
+  loadExcludedIps,
+} from './bot-policy'
+
+export type {
+  DeliveryCounts,
+  IssueEngagement,
+  ModuleEngagement,
+  LinkClickRow,
+  ExcludedIpRow,
+} from './types'

--- a/src/lib/analytics/metrics.ts
+++ b/src/lib/analytics/metrics.ts
@@ -12,8 +12,15 @@
  */
 
 function clampRate(numerator: number, denominator: number): number {
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator)) {
+    throw new RangeError(
+      `Metric inputs must be finite: numerator=${numerator}, denominator=${denominator}`
+    )
+  }
   if (numerator < 0 || denominator < 0) {
-    throw new RangeError(`Metric inputs must be non-negative: ${numerator}/${denominator}`)
+    throw new RangeError(
+      `Metric inputs must be non-negative: numerator=${numerator}, denominator=${denominator}`
+    )
   }
   if (denominator === 0) return 0
   const rate = numerator / denominator

--- a/src/lib/analytics/metrics.ts
+++ b/src/lib/analytics/metrics.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure metric formulas for the analytics layer.
+ *
+ * All functions are synchronous and dependency-free. Any DB access
+ * belongs in src/lib/dal/analytics.ts, which feeds typed rows into
+ * these formulas.
+ *
+ * Rules:
+ * - Division-by-zero returns 0 (so empty-issue dashboards render cleanly).
+ * - Negative inputs throw (signals a DAL bug; fail loud in dev/test).
+ * - Rates clamp to [0, 1] on data anomalies (e.g., vendor double-counting).
+ */
+
+function clampRate(numerator: number, denominator: number): number {
+  if (numerator < 0 || denominator < 0) {
+    throw new RangeError(`Metric inputs must be non-negative: ${numerator}/${denominator}`)
+  }
+  if (denominator === 0) return 0
+  const rate = numerator / denominator
+  return rate > 1 ? 1 : rate
+}
+
+export function computeIssueCTR(args: {
+  uniqueClickers: number
+  deliveredCount: number
+}): number {
+  return clampRate(args.uniqueClickers, args.deliveredCount)
+}
+
+export function computeModuleCTR(args: {
+  uniqueClickers: number
+  moduleRecipients: number
+}): number {
+  return clampRate(args.uniqueClickers, args.moduleRecipients)
+}
+
+export function computeIssueOpenRate(args: {
+  uniqueOpeners: number
+  deliveredCount: number
+}): number {
+  return clampRate(args.uniqueOpeners, args.deliveredCount)
+}
+
+export function computePollResponseRate(args: {
+  uniqueRespondents: number
+  deliveredCount: number
+}): number {
+  return clampRate(args.uniqueRespondents, args.deliveredCount)
+}
+
+export function computeFeedbackResponseRate(args: {
+  uniqueRespondents: number
+  deliveredCount: number
+}): number {
+  return clampRate(args.uniqueRespondents, args.deliveredCount)
+}
+
+export function computeBounceRate(args: {
+  bouncedCount: number
+  sentCount: number
+}): number {
+  return clampRate(args.bouncedCount, args.sentCount)
+}
+
+export function computeUnsubscribeRate(args: {
+  unsubscribedCount: number
+  deliveredCount: number
+}): number {
+  return clampRate(args.unsubscribedCount, args.deliveredCount)
+}

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Type definitions for the analytics metrics library.
+ * Shared between pure formulas (metrics.ts), bot policy (bot-policy.ts),
+ * and the DAL (src/lib/dal/analytics.ts).
+ */
+
+/**
+ * Email delivery counts sourced from email_metrics.
+ * Denominator for issue-level rates.
+ */
+export interface DeliveryCounts {
+  issueId: string
+  sentCount: number
+  deliveredCount: number
+  openedCount: number
+  clickedCount: number
+  bouncedCount: number
+  unsubscribedCount: number
+  /** ESP-reported open rate; displayed separately from computed open rate. */
+  espOpenRate: number | null
+  /** ESP-reported click rate; displayed separately from computed click rate. */
+  espClickRate: number | null
+  /** Timestamp of last sync from ESP. null for legacy rows. */
+  lastSyncedAt: string | null
+}
+
+/**
+ * Aggregated click/engagement metrics for a single issue.
+ * Always derived from link_clicks; bot/IP filter applied per excludeBots flag.
+ */
+export interface IssueEngagement {
+  issueId: string
+  publicationId: string
+  totalClicks: number
+  uniqueClickers: number
+  delivery: DeliveryCounts
+}
+
+/**
+ * Aggregated click metrics for a single module within an issue.
+ * moduleRecipients defaults to delivery.deliveredCount for non-segmented modules.
+ */
+export interface ModuleEngagement {
+  moduleId: string
+  issueId: string
+  publicationId: string
+  totalClicks: number
+  uniqueClickers: number
+  moduleRecipients: number
+}
+
+/** Columns on link_clicks used by bot policy and DAL reads. */
+export interface LinkClickRow {
+  id: string
+  publication_id: string
+  issue_id: string | null
+  subscriber_email: string
+  link_url: string
+  link_section: string
+  ip_address: string | null
+  is_bot_ua: boolean | null
+}
+
+/** Columns on excluded_ips used by bot policy. */
+export interface ExcludedIpRow {
+  ip_address: string
+  is_range: boolean
+  cidr_prefix: number | null
+}

--- a/src/lib/dal/__tests__/analytics.test.ts
+++ b/src/lib/dal/__tests__/analytics.test.ts
@@ -46,7 +46,7 @@ vi.mock('@/lib/analytics/bot-policy', () => ({
 }))
 
 import { supabaseAdmin } from '@/lib/supabase'
-import { getDeliveryCounts, getUniqueClickers } from '../analytics'
+import { getDeliveryCounts, getUniqueClickers, getIssueEngagement } from '../analytics'
 
 const PUB_ID = 'pub-test-123'
 const ISSUE_ID = 'issue-test-456'
@@ -146,5 +146,61 @@ describe('getUniqueClickers', () => {
     })
 
     expect(count).toBe(0)
+  })
+})
+
+describe('getIssueEngagement', () => {
+  it('returns null when delivery counts cannot be loaded', async () => {
+    // First call (delivery): returns no row
+    mockSingle.mockResolvedValueOnce({ data: null, error: null })
+
+    const result = await getIssueEngagement({
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      excludeBots: true,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('returns composed engagement with delivery + totals + uniques', async () => {
+    // Delivery counts call
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        issue_id: ISSUE_ID,
+        sent_count: 1000,
+        delivered_count: 980,
+        opened_count: 500,
+        clicked_count: 50,
+        bounced_count: 20,
+        unsubscribed_count: 5,
+        open_rate: 0.51,
+        click_rate: 0.051,
+        imported_at: '2026-04-23T10:00:00Z',
+        publication_issues: { publication_id: PUB_ID },
+      },
+      error: null,
+    })
+
+    // Two subsequent fluent-chain resolutions for total + unique queries.
+    const rows = [
+      { id: '1', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.1', is_bot_ua: false },
+      { id: '2', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.1', is_bot_ua: false },
+      { id: '3', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'b@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.2', is_bot_ua: false },
+    ]
+    ;(mockChain.is as any)
+      .mockReturnValueOnce(Promise.resolve({ data: rows, error: null }))
+      .mockReturnValueOnce(Promise.resolve({ data: rows, error: null }))
+
+    const result = await getIssueEngagement({
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      excludeBots: true,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.totalClicks).toBe(3)
+    expect(result!.uniqueClickers).toBe(2)
+    expect(result!.delivery.deliveredCount).toBe(980)
   })
 })

--- a/src/lib/dal/__tests__/analytics.test.ts
+++ b/src/lib/dal/__tests__/analytics.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that use them
+// ---------------------------------------------------------------------------
+const mockSingle = vi.fn()
+const mockChain: Record<string, any> = {
+  select: vi.fn(function () { return mockChain }),
+  eq: vi.fn(function () { return mockChain }),
+  is: vi.fn(function () { return mockChain }),
+  in: vi.fn(function () { return mockChain }),
+  not: vi.fn(function () { return mockChain }),
+  single: mockSingle,
+  maybeSingle: vi.fn(),
+  order: vi.fn(function () { return mockChain }),
+  limit: vi.fn(function () { return mockChain }),
+}
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => mockChain),
+    rpc: vi.fn(() => mockChain),
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    correlationId: 'test-id',
+  })),
+}))
+
+vi.mock('@/lib/analytics/bot-policy', () => ({
+  loadExcludedIps: vi.fn(async () => ({
+    has: () => false,
+    matchesCidr: () => false,
+  })),
+  isClickCountable: vi.fn(() => true),
+  ExcludedIpSet: class {
+    has() { return false }
+    matchesCidr() { return false }
+  },
+}))
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { getDeliveryCounts } from '../analytics'
+
+const PUB_ID = 'pub-test-123'
+const ISSUE_ID = 'issue-test-456'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getDeliveryCounts', () => {
+  it('returns delivery counts when the row exists and ownership matches', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        issue_id: ISSUE_ID,
+        sent_count: 1000,
+        delivered_count: 980,
+        opened_count: 500,
+        clicked_count: 50,
+        bounced_count: 20,
+        unsubscribed_count: 5,
+        open_rate: 0.51,
+        click_rate: 0.051,
+        imported_at: '2026-04-23T10:00:00Z',
+        publication_issues: { publication_id: PUB_ID },
+      },
+      error: null,
+    })
+
+    const result = await getDeliveryCounts({ issueId: ISSUE_ID, publicationId: PUB_ID })
+
+    expect(result).not.toBeNull()
+    expect(result!.deliveredCount).toBe(980)
+    expect(result!.sentCount).toBe(1000)
+    expect(result!.espClickRate).toBe(0.051)
+    expect(result!.lastSyncedAt).toBe('2026-04-23T10:00:00Z')
+  })
+
+  it('returns null when ownership does not match (no row)', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: null })
+
+    const result = await getDeliveryCounts({ issueId: ISSUE_ID, publicationId: 'other-pub' })
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null on DB error', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+
+    const result = await getDeliveryCounts({ issueId: ISSUE_ID, publicationId: PUB_ID })
+
+    expect(result).toBeNull()
+  })
+})

--- a/src/lib/dal/__tests__/analytics.test.ts
+++ b/src/lib/dal/__tests__/analytics.test.ts
@@ -46,7 +46,12 @@ vi.mock('@/lib/analytics/bot-policy', () => ({
 }))
 
 import { supabaseAdmin } from '@/lib/supabase'
-import { getDeliveryCounts, getUniqueClickers, getIssueEngagement } from '../analytics'
+import {
+  getDeliveryCounts,
+  getUniqueClickers,
+  getIssueEngagement,
+  getModuleEngagement,
+} from '../analytics'
 
 const PUB_ID = 'pub-test-123'
 const ISSUE_ID = 'issue-test-456'
@@ -201,5 +206,92 @@ describe('getIssueEngagement', () => {
     expect(result!.totalClicks).toBe(3)
     expect(result!.uniqueClickers).toBe(2)
     expect(result!.delivery.deliveredCount).toBe(980)
+  })
+})
+
+describe('getModuleEngagement', () => {
+  it('returns module engagement with defaults to deliveredCount when moduleRecipients not provided', async () => {
+    // Delivery counts call
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        issue_id: ISSUE_ID,
+        sent_count: 1000,
+        delivered_count: 980,
+        opened_count: 500,
+        clicked_count: 50,
+        bounced_count: 20,
+        unsubscribed_count: 5,
+        open_rate: 0.51,
+        click_rate: 0.051,
+        imported_at: '2026-04-23T10:00:00Z',
+        publication_issues: { publication_id: PUB_ID },
+      },
+      error: null,
+    })
+
+    const rows = [
+      { id: '1', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 'Ads', ip_address: '1.1.1.1', is_bot_ua: false },
+      { id: '2', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'b@x.com', link_url: 'u', link_section: 'Ads', ip_address: '1.1.1.2', is_bot_ua: false },
+    ]
+    ;(mockChain.is as any).mockReturnValueOnce(Promise.resolve({ data: rows, error: null }))
+
+    const result = await getModuleEngagement({
+      moduleId: 'module-1',
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      linkSection: 'Ads',
+      excludeBots: true,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.uniqueClickers).toBe(2)
+    expect(result!.totalClicks).toBe(2)
+    expect(result!.moduleRecipients).toBe(980) // default = deliveredCount
+  })
+
+  it('uses explicit moduleRecipients when provided (segmented module)', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        issue_id: ISSUE_ID,
+        sent_count: 1000,
+        delivered_count: 980,
+        opened_count: 500,
+        clicked_count: 10,
+        bounced_count: 20,
+        unsubscribed_count: 5,
+        open_rate: 0.51,
+        click_rate: 0.01,
+        imported_at: '2026-04-23T10:00:00Z',
+        publication_issues: { publication_id: PUB_ID },
+      },
+      error: null,
+    })
+
+    ;(mockChain.is as any).mockReturnValueOnce(Promise.resolve({ data: [], error: null }))
+
+    const result = await getModuleEngagement({
+      moduleId: 'module-1',
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      linkSection: 'Ads',
+      moduleRecipients: 500, // segmented: only 500 of 980 saw this module
+      excludeBots: true,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.moduleRecipients).toBe(500)
+  })
+
+  it('returns null when delivery cannot be loaded', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: null })
+
+    const result = await getModuleEngagement({
+      moduleId: 'module-1',
+      issueId: ISSUE_ID,
+      publicationId: 'wrong-pub',
+      linkSection: 'Ads',
+    })
+
+    expect(result).toBeNull()
   })
 })

--- a/src/lib/dal/__tests__/analytics.test.ts
+++ b/src/lib/dal/__tests__/analytics.test.ts
@@ -182,14 +182,13 @@ describe('getIssueEngagement', () => {
       error: null,
     })
 
-    // Two subsequent fluent-chain resolutions for total + unique queries.
+    // Single fluent-chain resolution for link_clicks query.
     const rows = [
       { id: '1', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.1', is_bot_ua: false },
       { id: '2', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.1', is_bot_ua: false },
       { id: '3', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'b@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.2', is_bot_ua: false },
     ]
     ;(mockChain.is as any)
-      .mockReturnValueOnce(Promise.resolve({ data: rows, error: null }))
       .mockReturnValueOnce(Promise.resolve({ data: rows, error: null }))
 
     const result = await getIssueEngagement({

--- a/src/lib/dal/__tests__/analytics.test.ts
+++ b/src/lib/dal/__tests__/analytics.test.ts
@@ -46,7 +46,7 @@ vi.mock('@/lib/analytics/bot-policy', () => ({
 }))
 
 import { supabaseAdmin } from '@/lib/supabase'
-import { getDeliveryCounts } from '../analytics'
+import { getDeliveryCounts, getUniqueClickers } from '../analytics'
 
 const PUB_ID = 'pub-test-123'
 const ISSUE_ID = 'issue-test-456'
@@ -97,5 +97,54 @@ describe('getDeliveryCounts', () => {
     const result = await getDeliveryCounts({ issueId: ISSUE_ID, publicationId: PUB_ID })
 
     expect(result).toBeNull()
+  })
+})
+
+describe('getUniqueClickers', () => {
+  it('counts unique subscriber_email across countable clicks', async () => {
+    const rows = [
+      { id: '1', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.1', is_bot_ua: false },
+      { id: '2', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'b@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.2', is_bot_ua: false },
+      { id: '3', publication_id: PUB_ID, issue_id: ISSUE_ID, subscriber_email: 'a@x.com', link_url: 'u', link_section: 's', ip_address: '1.1.1.1', is_bot_ua: false },
+    ]
+    ;(mockChain.eq as any).mockImplementation(function () { return mockChain })
+    ;(mockChain.is as any).mockImplementation(function () { return mockChain })
+    ;(mockChain.is as any).mockReturnValueOnce(Promise.resolve({ data: rows, error: null }))
+
+    const count = await getUniqueClickers({
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      excludeBots: true,
+    })
+
+    expect(count).toBe(2)
+  })
+
+  it('returns 0 on DB error', async () => {
+    ;(mockChain.is as any).mockReturnValueOnce(
+      Promise.resolve({ data: null, error: { message: 'oops' } })
+    )
+
+    const count = await getUniqueClickers({
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      excludeBots: true,
+    })
+
+    expect(count).toBe(0)
+  })
+
+  it('returns 0 when no rows', async () => {
+    ;(mockChain.is as any).mockReturnValueOnce(
+      Promise.resolve({ data: [], error: null })
+    )
+
+    const count = await getUniqueClickers({
+      issueId: ISSUE_ID,
+      publicationId: PUB_ID,
+      excludeBots: true,
+    })
+
+    expect(count).toBe(0)
   })
 })

--- a/src/lib/dal/analytics.ts
+++ b/src/lib/dal/analytics.ts
@@ -132,6 +132,48 @@ function countUniqueEmails(rows: LinkClickRow[]): number {
 }
 
 /**
+ * Single-query loader returning the bot/IP-filtered link_clicks rows
+ * for an issue. Used by getIssueEngagement to avoid duplicate fetching
+ * when both totals and uniques are needed.
+ *
+ * Standalone callers (getTotalClicks, getUniqueClickers) keep their own
+ * fetch path so each can be called independently from API routes.
+ */
+async function loadCountableLinkClicks(args: {
+  issueId: string
+  publicationId: string
+  excludeBots: boolean
+}): Promise<LinkClickRow[]> {
+  const { issueId, publicationId, excludeBots } = args
+
+  try {
+    let query = supabaseAdmin
+      .from('link_clicks')
+      .select(LINK_CLICK_COLUMNS)
+      .eq('publication_id', publicationId)
+      .eq('issue_id', issueId)
+
+    if (excludeBots) query = query.is('is_bot_ua', false)
+
+    const { data, error } = await query
+    if (error || !data) {
+      if (error) log.error({ err: error, issueId, publicationId }, 'loadCountableLinkClicks failed')
+      return []
+    }
+
+    if (!excludeBots) return data as LinkClickRow[]
+
+    const excludedIps = await loadExcludedIps(publicationId)
+    return (data as LinkClickRow[]).filter((row) =>
+      isClickCountable(row, excludedIps)
+    )
+  } catch (err) {
+    log.error({ err, issueId, publicationId }, 'loadCountableLinkClicks threw')
+    return []
+  }
+}
+
+/**
  * Total raw click count for an issue (pre-dedup). Bot/IP filter applied
  * when excludeBots is true; no uniqueness reduction.
  */
@@ -172,6 +214,10 @@ async function getTotalClicks(args: {
 /**
  * Aggregate engagement for an issue: delivery counts + total clicks + unique clickers.
  * Returns null if delivery counts cannot be loaded (issue/publication mismatch or DB error).
+ *
+ * Uses a single link_clicks fetch to derive both total and unique counts;
+ * standalone getTotalClicks / getUniqueClickers can still be called from
+ * routes that need only one of those counts.
  */
 export async function getIssueEngagement(args: {
   issueId: string
@@ -183,16 +229,13 @@ export async function getIssueEngagement(args: {
   const delivery = await getDeliveryCounts({ issueId, publicationId })
   if (!delivery) return null
 
-  const [totalClicks, uniqueClickers] = await Promise.all([
-    getTotalClicks({ issueId, publicationId, excludeBots }),
-    getUniqueClickers({ issueId, publicationId, excludeBots }),
-  ])
+  const rows = await loadCountableLinkClicks({ issueId, publicationId, excludeBots })
 
   return {
     issueId,
     publicationId,
-    totalClicks,
-    uniqueClickers,
+    totalClicks: rows.length,
+    uniqueClickers: countUniqueEmails(rows),
     delivery,
   }
 }

--- a/src/lib/dal/analytics.ts
+++ b/src/lib/dal/analytics.ts
@@ -133,7 +133,9 @@ function countUniqueEmails(rows: LinkClickRow[]): number {
 
 /**
  * Single-query loader returning the bot/IP-filtered link_clicks rows
- * for an issue. Used by getIssueEngagement to avoid duplicate fetching
+ * for an issue (optionally narrowed to a single link_section for module-scoped reads).
+ *
+ * Used by getIssueEngagement / getModuleEngagement to avoid duplicate fetches
  * when both totals and uniques are needed.
  *
  * Standalone callers (getTotalClicks, getUniqueClickers) keep their own
@@ -142,9 +144,10 @@ function countUniqueEmails(rows: LinkClickRow[]): number {
 async function loadCountableLinkClicks(args: {
   issueId: string
   publicationId: string
+  linkSection?: string
   excludeBots: boolean
 }): Promise<LinkClickRow[]> {
-  const { issueId, publicationId, excludeBots } = args
+  const { issueId, publicationId, linkSection, excludeBots } = args
 
   try {
     let query = supabaseAdmin
@@ -153,11 +156,12 @@ async function loadCountableLinkClicks(args: {
       .eq('publication_id', publicationId)
       .eq('issue_id', issueId)
 
+    if (linkSection) query = query.eq('link_section', linkSection)
     if (excludeBots) query = query.is('is_bot_ua', false)
 
     const { data, error } = await query
     if (error || !data) {
-      if (error) log.error({ err: error, issueId, publicationId }, 'loadCountableLinkClicks failed')
+      if (error) log.error({ err: error, issueId, publicationId, linkSection }, 'loadCountableLinkClicks failed')
       return []
     }
 
@@ -168,7 +172,7 @@ async function loadCountableLinkClicks(args: {
       isClickCountable(row, excludedIps)
     )
   } catch (err) {
-    log.error({ err, issueId, publicationId }, 'loadCountableLinkClicks threw')
+    log.error({ err, issueId, publicationId, linkSection }, 'loadCountableLinkClicks threw')
     return []
   }
 }
@@ -237,5 +241,55 @@ export async function getIssueEngagement(args: {
     totalClicks: rows.length,
     uniqueClickers: countUniqueEmails(rows),
     delivery,
+  }
+}
+
+/**
+ * Aggregate engagement for a module within an issue.
+ *
+ * Module scope is defined by linkSection (e.g., 'Ads', 'AI Apps', 'Articles').
+ * Numbers are narrowed to clicks with that link_section.
+ *
+ * moduleRecipients defaults to delivery.deliveredCount for non-segmented modules.
+ * For segmented modules (an ad shown to a subset), callers pass the explicit
+ * recipient count from the per-issue module-assignment table.
+ *
+ * Uses a single link_clicks fetch (via loadCountableLinkClicks) to derive
+ * both total and unique counts for the module.
+ */
+export async function getModuleEngagement(args: {
+  moduleId: string
+  issueId: string
+  publicationId: string
+  linkSection: string
+  moduleRecipients?: number
+  excludeBots?: boolean
+}): Promise<ModuleEngagement | null> {
+  const {
+    moduleId,
+    issueId,
+    publicationId,
+    linkSection,
+    moduleRecipients,
+    excludeBots = true,
+  } = args
+
+  const delivery = await getDeliveryCounts({ issueId, publicationId })
+  if (!delivery) return null
+
+  const rows = await loadCountableLinkClicks({
+    issueId,
+    publicationId,
+    linkSection,
+    excludeBots,
+  })
+
+  return {
+    moduleId,
+    issueId,
+    publicationId,
+    totalClicks: rows.length,
+    uniqueClickers: countUniqueEmails(rows),
+    moduleRecipients: moduleRecipients ?? delivery.deliveredCount,
   }
 }

--- a/src/lib/dal/analytics.ts
+++ b/src/lib/dal/analytics.ts
@@ -99,7 +99,8 @@ export async function getUniqueClickers(args: {
 
     if (linkUrl) query = query.eq('link_url', linkUrl)
 
-    // SQL-level: exclude is_bot_ua = true rows when excludeBots is on.
+    // .is('is_bot_ua', false) matches IS FALSE only; NULL rows pass through
+    // intentionally — historical rows pre-dating the bot flag are not bots.
     if (excludeBots) query = query.is('is_bot_ua', false)
 
     const { data, error } = await query
@@ -157,6 +158,8 @@ async function loadCountableLinkClicks(args: {
       .eq('issue_id', issueId)
 
     if (linkSection) query = query.eq('link_section', linkSection)
+    // .is('is_bot_ua', false) matches IS FALSE only; NULL rows pass through
+    // intentionally — historical rows pre-dating the bot flag are not bots.
     if (excludeBots) query = query.is('is_bot_ua', false)
 
     const { data, error } = await query
@@ -195,6 +198,8 @@ async function getTotalClicks(args: {
       .eq('publication_id', publicationId)
       .eq('issue_id', issueId)
 
+    // .is('is_bot_ua', false) matches IS FALSE only; NULL rows pass through
+    // intentionally — historical rows pre-dating the bot flag are not bots.
     if (excludeBots) query = query.is('is_bot_ua', false)
 
     const { data, error } = await query

--- a/src/lib/dal/analytics.ts
+++ b/src/lib/dal/analytics.ts
@@ -1,0 +1,77 @@
+/**
+ * Data Access Layer — Analytics Domain
+ *
+ * All reads that feed the analytics library go through here.
+ * Every method requires publicationId for multi-tenant isolation.
+ * Explicit column lists — no select('*').
+ * Errors are logged, never thrown — callers receive null/empty on failure.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { createLogger } from '@/lib/logger'
+import { loadExcludedIps, isClickCountable } from '@/lib/analytics/bot-policy'
+import type {
+  DeliveryCounts,
+  IssueEngagement,
+  ModuleEngagement,
+  LinkClickRow,
+} from '@/lib/analytics/types'
+
+const log = createLogger({ module: 'dal:analytics' })
+
+// Explicit column lists
+const EMAIL_METRICS_COLUMNS = `
+  issue_id,
+  sent_count, delivered_count, opened_count, clicked_count,
+  bounced_count, unsubscribed_count,
+  open_rate, click_rate,
+  imported_at
+` as const
+
+const LINK_CLICK_COLUMNS = `
+  id, publication_id, issue_id, subscriber_email,
+  link_url, link_section, ip_address, is_bot_ua
+` as const
+
+// ==================== READ OPERATIONS ====================
+
+/**
+ * Fetch delivery counts for an issue, verifying publication ownership
+ * via a join on publication_issues.
+ */
+export async function getDeliveryCounts(args: {
+  issueId: string
+  publicationId: string
+}): Promise<DeliveryCounts | null> {
+  const { issueId, publicationId } = args
+
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('email_metrics')
+      .select(`${EMAIL_METRICS_COLUMNS}, publication_issues!inner(publication_id)`)
+      .eq('issue_id', issueId)
+      .eq('publication_issues.publication_id', publicationId)
+      .single()
+
+    if (error || !data) {
+      if (error) log.error({ err: error, issueId, publicationId }, 'getDeliveryCounts failed')
+      return null
+    }
+
+    return {
+      issueId: data.issue_id,
+      sentCount: data.sent_count ?? 0,
+      deliveredCount: data.delivered_count ?? 0,
+      openedCount: data.opened_count ?? 0,
+      clickedCount: data.clicked_count ?? 0,
+      bouncedCount: data.bounced_count ?? 0,
+      unsubscribedCount: data.unsubscribed_count ?? 0,
+      espOpenRate: data.open_rate,
+      espClickRate: data.click_rate,
+      lastSyncedAt: data.imported_at ?? null,
+    }
+  } catch (err) {
+    log.error({ err, issueId, publicationId }, 'getDeliveryCounts threw')
+    return null
+  }
+}

--- a/src/lib/dal/analytics.ts
+++ b/src/lib/dal/analytics.ts
@@ -75,3 +75,58 @@ export async function getDeliveryCounts(args: {
     return null
   }
 }
+
+/**
+ * Count unique clickers for an issue (optionally filtered to a single link).
+ * Applies bot and IP filtering in SQL where possible; CIDR matches applied in-app.
+ *
+ * "Unique clicker" = distinct subscriber_email for rows passing isClickCountable.
+ */
+export async function getUniqueClickers(args: {
+  issueId: string
+  publicationId: string
+  linkUrl?: string
+  excludeBots?: boolean
+}): Promise<number> {
+  const { issueId, publicationId, linkUrl, excludeBots = true } = args
+
+  try {
+    let query = supabaseAdmin
+      .from('link_clicks')
+      .select(LINK_CLICK_COLUMNS)
+      .eq('publication_id', publicationId)
+      .eq('issue_id', issueId)
+
+    if (linkUrl) query = query.eq('link_url', linkUrl)
+
+    // SQL-level: exclude is_bot_ua = true rows when excludeBots is on.
+    if (excludeBots) query = query.is('is_bot_ua', false)
+
+    const { data, error } = await query
+
+    if (error || !data) {
+      if (error) log.error({ err: error, issueId, publicationId }, 'getUniqueClickers failed')
+      return 0
+    }
+
+    if (!excludeBots) {
+      return countUniqueEmails(data as LinkClickRow[])
+    }
+
+    // Apply in-app IP + CIDR filter, then count uniques.
+    const excludedIps = await loadExcludedIps(publicationId)
+    const countable = (data as LinkClickRow[]).filter((row) =>
+      isClickCountable(row, excludedIps)
+    )
+    return countUniqueEmails(countable)
+  } catch (err) {
+    log.error({ err, issueId, publicationId }, 'getUniqueClickers threw')
+    return 0
+  }
+}
+
+function countUniqueEmails(rows: LinkClickRow[]): number {
+  const set = new Set<string>()
+  for (const row of rows) set.add(row.subscriber_email.toLowerCase())
+  return set.size
+}

--- a/src/lib/dal/analytics.ts
+++ b/src/lib/dal/analytics.ts
@@ -130,3 +130,69 @@ function countUniqueEmails(rows: LinkClickRow[]): number {
   for (const row of rows) set.add(row.subscriber_email.toLowerCase())
   return set.size
 }
+
+/**
+ * Total raw click count for an issue (pre-dedup). Bot/IP filter applied
+ * when excludeBots is true; no uniqueness reduction.
+ */
+async function getTotalClicks(args: {
+  issueId: string
+  publicationId: string
+  excludeBots: boolean
+}): Promise<number> {
+  const { issueId, publicationId, excludeBots } = args
+
+  try {
+    let query = supabaseAdmin
+      .from('link_clicks')
+      .select(LINK_CLICK_COLUMNS)
+      .eq('publication_id', publicationId)
+      .eq('issue_id', issueId)
+
+    if (excludeBots) query = query.is('is_bot_ua', false)
+
+    const { data, error } = await query
+    if (error || !data) {
+      if (error) log.error({ err: error, issueId, publicationId }, 'getTotalClicks failed')
+      return 0
+    }
+
+    if (!excludeBots) return data.length
+
+    const excludedIps = await loadExcludedIps(publicationId)
+    return (data as LinkClickRow[]).filter((row) =>
+      isClickCountable(row, excludedIps)
+    ).length
+  } catch (err) {
+    log.error({ err, issueId, publicationId }, 'getTotalClicks threw')
+    return 0
+  }
+}
+
+/**
+ * Aggregate engagement for an issue: delivery counts + total clicks + unique clickers.
+ * Returns null if delivery counts cannot be loaded (issue/publication mismatch or DB error).
+ */
+export async function getIssueEngagement(args: {
+  issueId: string
+  publicationId: string
+  excludeBots?: boolean
+}): Promise<IssueEngagement | null> {
+  const { issueId, publicationId, excludeBots = true } = args
+
+  const delivery = await getDeliveryCounts({ issueId, publicationId })
+  if (!delivery) return null
+
+  const [totalClicks, uniqueClickers] = await Promise.all([
+    getTotalClicks({ issueId, publicationId, excludeBots }),
+    getUniqueClickers({ issueId, publicationId, excludeBots }),
+  ])
+
+  return {
+    issueId,
+    publicationId,
+    totalClicks,
+    uniqueClickers,
+    delivery,
+  }
+}

--- a/src/lib/dal/index.ts
+++ b/src/lib/dal/index.ts
@@ -19,3 +19,11 @@ export {
   updateWelcomeSection,
   updateSubjectLine,
 } from './issues'
+
+// Analytics DAL
+export {
+  getDeliveryCounts,
+  getUniqueClickers,
+  getIssueEngagement,
+  getModuleEngagement,
+} from './analytics'


### PR DESCRIPTION
## Summary

Foundation PR for the analytics & metrics standardization initiative (spec: `docs/superpowers/specs/2026-04-23-analytics-metrics-design.md`). Pure addition — no consumers changed yet, zero risk to existing analytics pages.

- Adds `src/lib/analytics/` — typed metrics layer with pure compute functions (`computeIssueCTR`, `computeModuleCTR`, `computeIssueOpenRate`, `computeBounceRate`, `computeUnsubscribeRate`, `computePollResponseRate`, `computeFeedbackResponseRate`). No DB imports, trivially unit-testable.
- Adds `src/lib/dal/analytics.ts` — four publication-scoped DAL functions (`getDeliveryCounts`, `getUniqueClickers`, `getIssueEngagement`, `getModuleEngagement`) with explicit column lists, multi-tenant isolation via join on `publication_issues`, error-return-null semantics; no math.
- Centralizes bot/IP filter policy in `src/lib/analytics/bot-policy.ts` (`isClickCountable`, `ExcludedIpSet`, `loadExcludedIps`) — single source of truth for "does this click count?" with IPv4 CIDR matching.
- Publishes `docs/operations/metrics.md` — canonical KPI definitions (formula, source, uniqueness rule, owner) with governance rule that any future dashboard metric must add a glossary entry.
- 32 new unit/integration tests; full vitest suite 357/357 passing.

## Architecture

Split by concern enforces single-source-of-truth: pure formulas (no DB), DAL (no math), bot policy (one filter function called by all DAL reads). Follow-on PRs (2–6) cut over individual analytics routes to use this foundation.

## Test plan

- [ ] CI green: `npm run type-check`, `npm run lint`, `npm run test:run`, `npm run build`, `npm run check:bug-patterns`
- [ ] Spot-check `import { computeIssueCTR } from '@/lib/analytics'` — public API surface intentional and documented in glossary
- [ ] Spot-check `import { getIssueEngagement } from '@/lib/dal'` — DAL barrel resolves correctly
- [ ] No analytics page changes — existing dashboards behave identically (this PR adds nothing to user-visible flows)

## Deferred to follow-on PRs

- PR 2: `email_metrics.last_synced_at` migration + `<FreshnessBadge>` component
- PR 3: rewrite `/api/analytics/[campaign]`, `/api/link-tracking/analytics`, `/api/tools/analytics` to use DAL (fixes `SELECT *`, hardcoded PUBLICATION_ID, ISO-timestamp date logic)
- PR 4–5: shadow-read + cutover for `/api/ads/analytics`, `/api/ai-apps/analytics`, Issues click-rate computation
- PR 6: anomaly alerts (Track 5e) — `metric_alerts` table, detection cron, Slack integration
- "Poll Option Share" glossary entry: PR 3 will add it when `/api/polls/analytics` is rewritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot and IP filtering for click analytics to improve accuracy
  * Metric computation functions for CTR, open rates, bounce rates, and engagement tracking
  * Analytics data access layer for fetching delivery counts and engagement metrics

* **Documentation**
  * Added comprehensive KPI glossary documenting metric formulas and data lineage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->