### PR TITLE
Promote staging: sparkloop isolation, A/B testing, analytics foundation

### DIFF
--- a/src/app/api/sparkloop/admin/daterange/route.ts
+++ b/src/app/api/sparkloop/admin/daterange/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from 'next/server'
 import { createHash } from 'crypto'
 import { withApiHandler } from '@/lib/api-handler'
 import { supabaseAdmin } from '@/lib/supabase'
-import { PUBLICATION_ID } from '@/lib/config'
 import { buildDateRangeBoundaries, toLocalDateStr, type SupportedTz } from '@/lib/date-utils'
 
 function hashEmail(email: string): string {
@@ -18,9 +17,8 @@ const PAGE_SIZE = 1000
 export const maxDuration = 60
 
 export const GET = withApiHandler(
-  { authTier: 'admin', logContext: 'sparkloop/admin/daterange' },
-  async ({ request, logger }) => {
-    const publicationId = new URL(request.url).searchParams.get('publicationId') || PUBLICATION_ID
+  { authTier: 'admin', logContext: 'sparkloop/admin/daterange', requirePublicationId: true },
+  async ({ request, publicationId, logger }) => {
     const { searchParams } = new URL(request.url)
     const start = searchParams.get('start')
     const end = searchParams.get('end')

--- a/src/app/api/sparkloop/admin/route.ts
+++ b/src/app/api/sparkloop/admin/route.ts
@@ -2,14 +2,7 @@ import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { supabaseAdmin } from '@/lib/supabase'
 import { getPublicationSettings, updatePublicationSetting } from '@/lib/publication-settings'
-import { SparkLoopService, createSparkLoopServiceForPublication } from '@/lib/sparkloop-client'
-import { PUBLICATION_ID } from '@/lib/config'
-
-// Resolve publicationId from query params, falling back to default
-function resolvePublicationId(request: Request): string {
-  const { searchParams } = new URL(request.url)
-  return searchParams.get('publicationId') || PUBLICATION_ID
-}
+import { SparkLoopService } from '@/lib/sparkloop-client'
 
 // Hardcoded fallbacks if no publication_settings exist
 const FALLBACK_DEFAULT_CR = 22
@@ -23,9 +16,9 @@ const FALLBACK_DEFAULT_RCR = 25
 export const maxDuration = 60
 
 export const GET = withApiHandler(
-  { authTier: 'admin', logContext: 'sparkloop/admin' },
-  async ({ request, logger }) => {
-    const publicationId = resolvePublicationId(request)
+  { authTier: 'admin', logContext: 'sparkloop/admin', requirePublicationId: true },
+  async ({ request, publicationId, logger }) => {
+    if (!publicationId) throw new Error('publication_id required') // narrowed by withApiHandler
     const { searchParams } = new URL(request.url)
     const filter = searchParams.get('filter') || 'all' // all, active, excluded
 
@@ -462,9 +455,9 @@ export const GET = withApiHandler(
  * Update recommendation (exclude/reactivate/pause/unpause)
  */
 export const PATCH = withApiHandler(
-  { authTier: 'admin', logContext: 'sparkloop/admin' },
-  async ({ request, logger }) => {
-    const publicationId = resolvePublicationId(request)
+  { authTier: 'admin', logContext: 'sparkloop/admin', requirePublicationId: true },
+  async ({ request, publicationId, logger }) => {
+    if (!publicationId) throw new Error('publication_id required')
     const body = await request.json()
     const { id, excluded, excluded_reason, action } = body
 
@@ -546,6 +539,7 @@ export const PATCH = withApiHandler(
       .from('sparkloop_recommendations')
       .update(updateData)
       .eq('id', id)
+      .eq('publication_id', publicationId)
       .select()
       .single()
 
@@ -569,9 +563,9 @@ export const PATCH = withApiHandler(
  * Bulk update recommendations
  */
 export const POST = withApiHandler(
-  { authTier: 'admin', logContext: 'sparkloop/admin' },
-  async ({ request, logger }) => {
-    const publicationId = resolvePublicationId(request)
+  { authTier: 'admin', logContext: 'sparkloop/admin', requirePublicationId: true },
+  async ({ request, publicationId, logger }) => {
+    if (!publicationId) throw new Error('publication_id required')
     const body = await request.json()
     const { action, ids, excluded_reason } = body
 
@@ -615,6 +609,7 @@ export const POST = withApiHandler(
       .from('sparkloop_recommendations')
       .update(updateData)
       .in('id', ids)
+      .eq('publication_id', publicationId)
       .select()
 
     if (error) {

--- a/src/app/api/sparkloop/admin/route.ts
+++ b/src/app/api/sparkloop/admin/route.ts
@@ -76,7 +76,6 @@ export const GET = withApiHandler(
     // the first one recorded after (first_send_date + S), so we only count confirms/rejects
     // that correspond to subs we actually sent.
     const today = new Date()
-    const todayStr = today.toISOString().split('T')[0]
 
     // 1. Count matured sends per ref_code, grouped by screening_period
     const screeningGroups = new Map<number, string[]>()
@@ -94,8 +93,9 @@ export const GET = withApiHandler(
         cutoff.setDate(cutoff.getDate() - s)
         // Use end-of-day so all sends on the cutoff date are included.
         // Without this, Supabase treats a bare date string as midnight,
-        // excluding sends after 00:00 UTC on that day.
-        const cutoffStr = cutoff.toISOString().split('T')[0] + 'T23:59:59.999Z'
+        // excluding sends after 00:00 UTC on that day. UTC is intentional —
+        // the boundary matches subscribed_at (timestamptz, stored UTC).
+        const cutoffStr = cutoff.toISOString().split('T')[0] + 'T23:59:59.999Z' // bug-check-ignore: date-iso
 
         // Paginate to avoid Supabase's 1000-row limit
         let offset = 0

--- a/src/app/api/sparkloop/admin/submissions/route.ts
+++ b/src/app/api/sparkloop/admin/submissions/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { supabaseAdmin } from '@/lib/supabase'
-import { PUBLICATION_ID } from '@/lib/config'
 import { buildDateRangeBoundaries, type SupportedTz } from '@/lib/date-utils'
 
 /**
@@ -13,9 +12,8 @@ import { buildDateRangeBoundaries, type SupportedTz } from '@/lib/date-utils'
  * Query params: ref_code, start (YYYY-MM-DD), end (YYYY-MM-DD)
  */
 export const GET = withApiHandler(
-  { authTier: 'admin', logContext: 'sparkloop/admin/submissions' },
-  async ({ request, logger }) => {
-    const publicationId = new URL(request.url).searchParams.get('publicationId') || PUBLICATION_ID
+  { authTier: 'admin', logContext: 'sparkloop/admin/submissions', requirePublicationId: true },
+  async ({ request, publicationId, logger }) => {
     const { searchParams } = new URL(request.url)
     const refCode = searchParams.get('ref_code')
     const start = searchParams.get('start')

--- a/src/app/api/sparkloop/offer-stats/route.ts
+++ b/src/app/api/sparkloop/offer-stats/route.ts
@@ -40,7 +40,10 @@ export const GET = withApiHandler(
     let todayImpressions = 0
     let todayClaims = 0
 
-    const todayStr = new Date().toISOString().split('T')[0]
+    // UTC date — both sides of the comparison below extract the date in UTC
+    // (event.created_at is timestamptz stored as UTC), so consistency matters
+    // more than user-local "today" here.
+    const todayStr = new Date().toISOString().split('T')[0] // bug-check-ignore: date-iso
 
     for (const event of events) {
       const day = event.created_at.split('T')[0]

--- a/src/app/api/sparkloop/offer-stats/route.ts
+++ b/src/app/api/sparkloop/offer-stats/route.ts
@@ -4,7 +4,7 @@ import { supabaseAdmin } from '@/lib/supabase'
 const PAGE_SIZE = 1000
 
 export const GET = withApiHandler(
-  { authTier: 'public', logContext: 'sparkloop-offer-stats', requirePublicationId: true },
+  { authTier: 'admin', logContext: 'sparkloop-offer-stats', requirePublicationId: true },
   async ({ request, publicationId, logger }) => {
     const days = parseInt(request.nextUrl.searchParams.get('days') || '30', 10)
 

--- a/src/app/api/sparkloop/offer-stats/route.ts
+++ b/src/app/api/sparkloop/offer-stats/route.ts
@@ -1,13 +1,11 @@
 import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { supabaseAdmin } from '@/lib/supabase'
-import { PUBLICATION_ID } from '@/lib/config'
 const PAGE_SIZE = 1000
 
 export const GET = withApiHandler(
-  { authTier: 'public', logContext: 'sparkloop-offer-stats' },
-  async ({ request, logger }) => {
-    const publicationId = new URL(request.url).searchParams.get('publicationId') || PUBLICATION_ID
+  { authTier: 'public', logContext: 'sparkloop-offer-stats', requirePublicationId: true },
+  async ({ request, publicationId, logger }) => {
     const days = parseInt(request.nextUrl.searchParams.get('days') || '30', 10)
 
     const since = new Date()

--- a/src/app/api/sparkloop/stats/route.ts
+++ b/src/app/api/sparkloop/stats/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { supabaseAdmin } from '@/lib/supabase'
 import { getPublicationSettings } from '@/lib/publication-settings'
-import { PUBLICATION_ID } from '@/lib/config'
 import { toLocalDateStr as toDateStr, buildDateRangeBoundaries, getTodayStr, getDaysAgoStr, type SupportedTz } from '@/lib/date-utils'
 const FALLBACK_DEFAULT_RCR = 25
 
@@ -31,9 +30,9 @@ interface DailyStats {
 export const maxDuration = 60
 
 export const GET = withApiHandler(
-  { authTier: 'admin', logContext: 'sparkloop/stats' },
-  async ({ request, logger }) => {
-    const publicationId = new URL(request.url).searchParams.get('publicationId') || PUBLICATION_ID
+  { authTier: 'admin', logContext: 'sparkloop/stats', requirePublicationId: true },
+  async ({ request, publicationId, logger }) => {
+    if (!publicationId) throw new Error('publication_id required')
     const { searchParams } = new URL(request.url)
     const days = Math.max(1, Math.min(365, parseInt(searchParams.get('days') || '30') || 30))
     const startDate = searchParams.get('start')

--- a/src/app/api/sparkloop/stats/route.ts
+++ b/src/app/api/sparkloop/stats/route.ts
@@ -88,7 +88,8 @@ export const GET = withApiHandler(
       Array.from(screeningGroups.entries()).map(async ([s, refCodes]) => {
         const cutoff = new Date(today)
         cutoff.setDate(cutoff.getDate() - s)
-        const cutoffStr = cutoff.toISOString().split('T')[0] + 'T23:59:59.999Z'
+        // UTC end-of-day — boundary matches subscribed_at (timestamptz, UTC).
+        const cutoffStr = cutoff.toISOString().split('T')[0] + 'T23:59:59.999Z' // bug-check-ignore: date-iso
 
         let offset = 0
         const counts = new Map<string, number>()
@@ -166,7 +167,8 @@ export const GET = withApiHandler(
 
       const baselineDate = new Date(firstSend)
       baselineDate.setDate(baselineDate.getDate() + s)
-      const baselineDateStr = baselineDate.toISOString().split('T')[0]
+      // Compared against snap.snapshot_date (UTC YYYY-MM-DD column), so UTC is intentional.
+      const baselineDateStr = baselineDate.toISOString().split('T')[0] // bug-check-ignore: date-iso
 
       let baselineSnap: SnapRow | null = null
       for (let i = 1; i < snaps.length; i++) {

--- a/src/app/api/sparkloop/sync/route.ts
+++ b/src/app/api/sparkloop/sync/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { createSparkLoopServiceForPublication } from '@/lib/sparkloop-client'
-import { PUBLICATION_ID } from '@/lib/config'
 
 /**
  * POST /api/sparkloop/sync
@@ -11,15 +10,13 @@ import { PUBLICATION_ID } from '@/lib/config'
  * Can be called manually or via cron job
  */
 export const POST = withApiHandler(
-  { authTier: 'system', logContext: 'sparkloop/sync' },
-  async ({ request }) => {
-    const { searchParams } = new URL(request.url)
-    const publicationId = searchParams.get('publicationId') || PUBLICATION_ID
-    const service = await createSparkLoopServiceForPublication(publicationId)
+  { authTier: 'system', logContext: 'sparkloop/sync', requirePublicationId: true },
+  async ({ publicationId }) => {
+    const service = await createSparkLoopServiceForPublication(publicationId!)
     if (!service) {
       return NextResponse.json({ error: 'SparkLoop not configured for this publication' }, { status: 400 })
     }
-    const result = await service.syncRecommendationsToDatabase(publicationId)
+    const result = await service.syncRecommendationsToDatabase(publicationId!)
 
     return NextResponse.json({
       success: true,
@@ -35,15 +32,13 @@ export const POST = withApiHandler(
  * Get sync status and last sync time
  */
 export const GET = withApiHandler(
-  { authTier: 'system', logContext: 'sparkloop/sync' },
-  async ({ request }) => {
-    const { searchParams } = new URL(request.url)
-    const publicationId = searchParams.get('publicationId') || PUBLICATION_ID
-    const service = await createSparkLoopServiceForPublication(publicationId)
+  { authTier: 'system', logContext: 'sparkloop/sync', requirePublicationId: true },
+  async ({ publicationId }) => {
+    const service = await createSparkLoopServiceForPublication(publicationId!)
     if (!service) {
       return NextResponse.json({ error: 'SparkLoop not configured for this publication' }, { status: 400 })
     }
-    const stored = await service.getStoredRecommendations(publicationId)
+    const stored = await service.getStoredRecommendations(publicationId!)
 
     // Find oldest sync time
     const lastSyncTimes = stored

--- a/src/app/dashboard/[slug]/sparkloop/components/OffersTab.tsx
+++ b/src/app/dashboard/[slug]/sparkloop/components/OffersTab.tsx
@@ -49,12 +49,18 @@ export default function OffersTab({ publicationId }: OffersTabProps) {
   const [timeframe, setTimeframe] = useState<'7' | '30'>('30')
 
   useEffect(() => {
-    if (!publicationId) return
+    if (!publicationId) {
+      setLoading(false)
+      return
+    }
     fetchStats()
   }, [timeframe, publicationId])
 
   async function fetchStats() {
-    if (!publicationId) return
+    if (!publicationId) {
+      setLoading(false)
+      return
+    }
     setLoading(true)
     try {
       const res = await fetch(`/api/sparkloop/offer-stats?days=${timeframe}&publication_id=${publicationId}`)

--- a/src/app/dashboard/[slug]/sparkloop/components/OffersTab.tsx
+++ b/src/app/dashboard/[slug]/sparkloop/components/OffersTab.tsx
@@ -37,7 +37,11 @@ interface RecentEvent {
   ip: string | null
 }
 
-export default function OffersTab() {
+interface OffersTabProps {
+  publicationId: string | null
+}
+
+export default function OffersTab({ publicationId }: OffersTabProps) {
   const [summary, setSummary] = useState<Summary | null>(null)
   const [dailyStats, setDailyStats] = useState<DailyStats[]>([])
   const [recentEvents, setRecentEvents] = useState<RecentEvent[]>([])
@@ -45,13 +49,15 @@ export default function OffersTab() {
   const [timeframe, setTimeframe] = useState<'7' | '30'>('30')
 
   useEffect(() => {
+    if (!publicationId) return
     fetchStats()
-  }, [timeframe])
+  }, [timeframe, publicationId])
 
   async function fetchStats() {
+    if (!publicationId) return
     setLoading(true)
     try {
-      const res = await fetch(`/api/sparkloop/offer-stats?days=${timeframe}`)
+      const res = await fetch(`/api/sparkloop/offer-stats?days=${timeframe}&publication_id=${publicationId}`)
       const data = await res.json()
       if (data.success) {
         setSummary(data.summary)

--- a/src/app/dashboard/[slug]/sparkloop/components/PublicationsTab.tsx
+++ b/src/app/dashboard/[slug]/sparkloop/components/PublicationsTab.tsx
@@ -11,9 +11,10 @@ import {
 
 interface Props {
   recommendations: Recommendation[]
+  publicationId: string | null
 }
 
-export default function PublicationsTab({ recommendations }: Props) {
+export default function PublicationsTab({ recommendations, publicationId }: Props) {
   const {
     selectedRec, searchText, setSearchText, dropdownOpen, setDropdownOpen,
     dropdownRef, startDate, setStartDate, endDate, setEndDate,
@@ -21,7 +22,7 @@ export default function PublicationsTab({ recommendations }: Props) {
     sortAsc, setSortAsc, timezone, setTimezone, tz,
     filteredRecs, filteredReferrals,
     setQuickRange, clearSelection, clearDates, selectRec,
-  } = usePublicationsTab(recommendations)
+  } = usePublicationsTab(recommendations, publicationId)
 
   return (
     <div className="space-y-6">

--- a/src/app/dashboard/[slug]/sparkloop/components/detailed-tab/DetailedTab.tsx
+++ b/src/app/dashboard/[slug]/sparkloop/components/detailed-tab/DetailedTab.tsx
@@ -11,8 +11,8 @@ import { DefaultsEditor } from './DefaultsEditor'
 import { GlobalStatsBar } from './GlobalStatsBar'
 import type { DetailedTabProps } from './types'
 
-export default function DetailedTab({ recommendations, globalStats, defaults, loading, onRefresh }: DetailedTabProps) {
-  const state = useDetailedTabState({ recommendations, onRefresh })
+export default function DetailedTab({ recommendations, globalStats, defaults, loading, onRefresh, publicationId }: DetailedTabProps) {
+  const state = useDetailedTabState({ recommendations, onRefresh, publicationId })
 
   return (
     <div className="py-4">

--- a/src/app/dashboard/[slug]/sparkloop/components/detailed-tab/types.ts
+++ b/src/app/dashboard/[slug]/sparkloop/components/detailed-tab/types.ts
@@ -27,6 +27,7 @@ export interface DetailedTabProps {
   defaults: Defaults
   loading: boolean
   onRefresh: () => void
+  publicationId: string | null
 }
 
 export interface DateRangeMetrics {

--- a/src/app/dashboard/[slug]/sparkloop/components/detailed-tab/useDetailedTabState.ts
+++ b/src/app/dashboard/[slug]/sparkloop/components/detailed-tab/useDetailedTabState.ts
@@ -7,9 +7,10 @@ import type { Column, Recommendation, DateRangeMetrics, RangeStats, StatusFilter
 interface UseDetailedTabStateOptions {
   recommendations: Recommendation[]
   onRefresh: () => void
+  publicationId: string | null
 }
 
-export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedTabStateOptions) {
+export function useDetailedTabState({ recommendations, onRefresh, publicationId }: UseDetailedTabStateOptions) {
   const [columns, setColumns] = useState<Column[]>(DEFAULT_COLUMNS)
   const [sortColumn, setSortColumn] = useState<string | null>('calculated_score')
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc')
@@ -57,11 +58,12 @@ export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedT
 
     // Validate: start <= end
     if (dateStart > dateEnd) return
+    if (!publicationId) return
 
     const fetchDateRange = async () => {
       setDateRangeLoading(true)
       try {
-        const res = await fetch(`/api/sparkloop/admin/daterange?start=${dateStart}&end=${dateEnd}&tz=${timezone}`)
+        const res = await fetch(`/api/sparkloop/admin/daterange?start=${dateStart}&end=${dateEnd}&tz=${timezone}&publication_id=${publicationId}`)
         const data = await res.json()
         if (data.success) {
           setDateRangeMetrics(data.metrics)
@@ -73,7 +75,7 @@ export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedT
       setDateRangeLoading(false)
     }
     fetchDateRange()
-  }, [dateStart, dateEnd, timezone])
+  }, [dateStart, dateEnd, timezone, publicationId])
 
   const clearDateRange = useCallback(() => {
     setDateStart('')
@@ -216,11 +218,16 @@ export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedT
     return result
   }, [effectiveRecommendations, searchQuery, statusFilter, sortColumn, sortDirection])
 
+  const adminUrl = publicationId
+    ? `/api/sparkloop/admin?publication_id=${publicationId}`
+    : '/api/sparkloop/admin'
+
   // --- Action handlers ---
   async function handlePause(rec: Recommendation) {
+    if (!publicationId) return
     setActionLoading(rec.id)
     try {
-      const res = await fetch('/api/sparkloop/admin', {
+      const res = await fetch(adminUrl, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: rec.id, action: 'pause' }),
@@ -238,9 +245,10 @@ export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedT
   }
 
   async function handleExclude(rec: Recommendation) {
+    if (!publicationId) return
     setActionLoading(rec.id)
     try {
-      const res = await fetch('/api/sparkloop/admin', {
+      const res = await fetch(adminUrl, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: rec.id, excluded: true, excluded_reason: 'manual' }),
@@ -258,13 +266,14 @@ export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedT
   }
 
   async function handleReactivate(rec: Recommendation) {
+    if (!publicationId) return
     setActionLoading(rec.id)
     try {
       // If excluded, un-exclude. If paused, unpause.
       const body = rec.excluded
         ? { id: rec.id, excluded: false }
         : { id: rec.id, action: 'unpause' }
-      const res = await fetch('/api/sparkloop/admin', {
+      const res = await fetch(adminUrl, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -282,14 +291,14 @@ export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedT
   }
 
   async function bulkAction(action: 'exclude' | 'reactivate' | 'pause') {
-    if (selectedIds.size === 0) return
+    if (selectedIds.size === 0 || !publicationId) return
 
     const reason = action === 'exclude' ? prompt('Exclusion reason (e.g., budget_used_up):') : null
     if (action === 'exclude' && reason === null) return
 
     setActionLoading('bulk')
     try {
-      const res = await fetch('/api/sparkloop/admin', {
+      const res = await fetch(adminUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -314,8 +323,9 @@ export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedT
   }
 
   async function handleToggleModuleEligible(rec: Recommendation) {
+    if (!publicationId) return
     try {
-      const res = await fetch('/api/sparkloop/admin', {
+      const res = await fetch(adminUrl, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: rec.id, action: 'toggle_module_eligible', eligible_for_module: !rec.eligible_for_module }),
@@ -356,7 +366,7 @@ export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedT
   }
 
   async function saveOverrides() {
-    if (!overrideRec) return
+    if (!overrideRec || !publicationId) return
     setOverrideSaving(true)
     try {
       const body: Record<string, unknown> = {
@@ -368,7 +378,7 @@ export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedT
       body.override_rcr = overrideRcrValue.trim() === '' ? null : parseFloat(overrideRcrValue)
       body.override_slip = overrideSlipValue.trim() === '' ? null : parseFloat(overrideSlipValue)
 
-      const res = await fetch('/api/sparkloop/admin', {
+      const res = await fetch(adminUrl, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -387,6 +397,7 @@ export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedT
   }
 
   async function saveDefault(field: 'cr' | 'rcr' | 'mcb') {
+    if (!publicationId) return
     const value = field === 'cr' ? defaultCrInput : field === 'rcr' ? defaultRcrInput : defaultMcbInput
     const parsed = field === 'mcb' ? parseInt(value) : parseFloat(value)
     if (field === 'mcb') {
@@ -407,7 +418,7 @@ export function useDetailedTabState({ recommendations, onRefresh }: UseDetailedT
       if (field === 'rcr') body.default_rcr = parsed
       if (field === 'mcb') body.min_conversions_budget = parsed
 
-      const res = await fetch('/api/sparkloop/admin', {
+      const res = await fetch(adminUrl, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),

--- a/src/app/dashboard/[slug]/sparkloop/components/detailed-tab/useDetailedTabState.ts
+++ b/src/app/dashboard/[slug]/sparkloop/components/detailed-tab/useDetailedTabState.ts
@@ -58,7 +58,12 @@ export function useDetailedTabState({ recommendations, onRefresh, publicationId 
 
     // Validate: start <= end
     if (dateStart > dateEnd) return
-    if (!publicationId) return
+    if (!publicationId) {
+      // Clear stale metrics if the publication context drops out
+      setDateRangeMetrics(null)
+      setRangeStats(null)
+      return
+    }
 
     const fetchDateRange = async () => {
       setDateRangeLoading(true)

--- a/src/app/dashboard/[slug]/sparkloop/components/usePublicationsTab.ts
+++ b/src/app/dashboard/[slug]/sparkloop/components/usePublicationsTab.ts
@@ -23,7 +23,7 @@ export interface Summary {
   page: SourceSummary
 }
 
-export function usePublicationsTab(recommendations: Recommendation[]) {
+export function usePublicationsTab(recommendations: Recommendation[], publicationId: string | null) {
   const [selectedRec, setSelectedRec] = useState<Recommendation | null>(null)
   const [searchText, setSearchText] = useState('')
   const [dropdownOpen, setDropdownOpen] = useState(false)
@@ -62,13 +62,13 @@ export function usePublicationsTab(recommendations: Recommendation[]) {
   }
 
   useEffect(() => {
-    if (selectedRec && startDate && endDate) {
+    if (selectedRec && startDate && endDate && publicationId) {
       fetchSubmissions()
     }
-  }, [selectedRec, startDate, endDate, timezone])
+  }, [selectedRec, startDate, endDate, timezone, publicationId])
 
   async function fetchSubmissions() {
-    if (!selectedRec || !startDate || !endDate) return
+    if (!selectedRec || !startDate || !endDate || !publicationId) return
     setLoading(true)
     try {
       const params = new URLSearchParams({
@@ -76,6 +76,7 @@ export function usePublicationsTab(recommendations: Recommendation[]) {
         start: startDate,
         end: endDate,
         tz: timezone,
+        publication_id: publicationId,
       })
       const res = await fetch(`/api/sparkloop/admin/submissions?${params}`)
       const data = await res.json()

--- a/src/app/dashboard/[slug]/sparkloop/components/useSparkLoopData.ts
+++ b/src/app/dashboard/[slug]/sparkloop/components/useSparkLoopData.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useParams } from 'next/navigation'
 import type { Recommendation } from '../types'
 
 interface Counts {
@@ -63,6 +64,7 @@ export interface EstimatedValue {
 }
 
 export interface SparkLoopData {
+  publicationId: string | null
   recommendations: Recommendation[]
   counts: Counts
   globalStats: GlobalStats | null
@@ -100,6 +102,10 @@ function filterEligibleRecs(recommendations: Recommendation[]): Recommendation[]
 }
 
 export function useSparkLoopData(): SparkLoopData {
+  const params = useParams()
+  const slug = (params?.slug as string | undefined) ?? null
+
+  const [publicationId, setPublicationId] = useState<string | null>(null)
   const [recommendations, setRecommendations] = useState<Recommendation[]>([])
   const [counts, setCounts] = useState<Counts>({ total: 0, active: 0, excluded: 0, paused: 0, archived: 0 })
   const [globalStats, setGlobalStats] = useState<GlobalStats | null>(null)
@@ -112,11 +118,41 @@ export function useSparkLoopData(): SparkLoopData {
   const [timeframe, setTimeframe] = useState<'7' | '30' | '90'>('30')
   const [error, setError] = useState<string | null>(null)
 
+  // Resolve slug -> publication_id once on mount / slug change
+  useEffect(() => {
+    if (!slug) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch('/api/newsletters')
+        if (!res.ok) throw new Error('Failed to fetch publications')
+        const data = await res.json()
+        const found = data.newsletters?.find((n: { slug: string; id: string }) => n.slug === slug)
+        if (cancelled) return
+        if (found) {
+          setPublicationId(found.id)
+        } else {
+          setError(`Publication not found for slug: ${slug}`)
+          setLoading(false)
+          setChartLoading(false)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(`Failed to resolve publication: ${err instanceof Error ? err.message : 'Network error'}`)
+          setLoading(false)
+          setChartLoading(false)
+        }
+      }
+    })()
+    return () => { cancelled = true }
+  }, [slug])
+
   const fetchRecommendations = useCallback(async () => {
+    if (!publicationId) return
     setLoading(true)
     setError(null)
     try {
-      const res = await fetch('/api/sparkloop/admin?filter=all')
+      const res = await fetch(`/api/sparkloop/admin?filter=all&publication_id=${publicationId}`)
       const data = await res.json()
       if (data.success) {
         setRecommendations(data.recommendations)
@@ -133,27 +169,29 @@ export function useSparkLoopData(): SparkLoopData {
       console.error('Failed to fetch recommendations:', err)
     }
     setLoading(false)
-  }, [])
+  }, [publicationId])
 
   const fetchChartStats = useCallback(async () => {
+    if (!publicationId) return
     setChartLoading(true)
     try {
-      const res = await fetch(`/api/sparkloop/stats?days=${timeframe}`)
+      const res = await fetch(`/api/sparkloop/stats?days=${timeframe}&publication_id=${publicationId}`)
       const data = await res.json()
       if (data.success) setChartStats(data)
     } catch (err) {
       console.error('Failed to fetch chart stats:', err)
     }
     setChartLoading(false)
-  }, [timeframe])
+  }, [timeframe, publicationId])
 
   useEffect(() => { fetchRecommendations() }, [fetchRecommendations])
   useEffect(() => { fetchChartStats() }, [fetchChartStats])
 
   const syncFromSparkLoop = useCallback(async () => {
+    if (!publicationId) return
     setSyncing(true)
     try {
-      const res = await fetch('/api/sparkloop/sync', { method: 'POST' })
+      const res = await fetch(`/api/sparkloop/sync?publication_id=${publicationId}`, { method: 'POST' })
       const data = await res.json()
       if (data.success) {
         alert(`Synced ${data.synced} recommendations (${data.created} new, ${data.updated} updated)`)
@@ -167,7 +205,7 @@ export function useSparkLoopData(): SparkLoopData {
       alert('Sync failed')
     }
     setSyncing(false)
-  }, [fetchRecommendations, fetchChartStats])
+  }, [publicationId, fetchRecommendations, fetchChartStats])
 
   const popupPreview = useMemo(() => filterEligibleRecs(recommendations).slice(0, 5), [recommendations])
   const recsPagePreview = useMemo(() => filterEligibleRecs(recommendations).slice(5, 8), [recommendations])
@@ -189,6 +227,7 @@ export function useSparkLoopData(): SparkLoopData {
   }, [popupPreview, recsPagePreview])
 
   return {
+    publicationId,
     recommendations, counts, globalStats, defaults,
     loading, syncing, error,
     chartStats, chartLoading, timeframe, setTimeframe,

--- a/src/app/dashboard/[slug]/sparkloop/page.tsx
+++ b/src/app/dashboard/[slug]/sparkloop/page.tsx
@@ -10,6 +10,7 @@ import { useSparkLoopData } from './components/useSparkLoopData'
 
 export default function SparkLoopAdminPage() {
   const {
+    publicationId,
     recommendations, counts, globalStats, defaults,
     loading, syncing, error,
     chartStats, chartLoading, timeframe, setTimeframe,
@@ -72,9 +73,9 @@ export default function SparkLoopAdminPage() {
         </div>
 
         {activeTab === 'offers' ? (
-          <OffersTab />
+          <OffersTab publicationId={publicationId} />
         ) : activeTab === 'publications' ? (
-          <PublicationsTab recommendations={recommendations} />
+          <PublicationsTab recommendations={recommendations} publicationId={publicationId} />
         ) : activeTab === 'overview' ? (
           <OverviewTab
             chartStats={chartStats}
@@ -94,6 +95,7 @@ export default function SparkLoopAdminPage() {
             defaults={defaults}
             loading={loading}
             onRefresh={fetchRecommendations}
+            publicationId={publicationId}
           />
         )}
       </div>

--- a/src/app/website/subscribe/offers/offers-content.tsx
+++ b/src/app/website/subscribe/offers/offers-content.tsx
@@ -81,7 +81,15 @@ export function OffersContent({ logoUrl, newsletterName, afteroffersFormId }: Of
   // instead of producing a scrollbar inside the iframe.
   useEffect(() => {
     function handleMessage(event: MessageEvent) {
-      if (!event.origin.endsWith('afteroffers.com')) return
+      // Validate hostname strictly so a domain like attacker-afteroffers.com
+      // (or attacker.com/afteroffers.com path) can't impersonate the iframe.
+      let hostname: string
+      try {
+        hostname = new URL(event.origin).hostname.toLowerCase()
+      } catch {
+        return
+      }
+      if (hostname !== 'afteroffers.com' && !hostname.endsWith('.afteroffers.com')) return
 
       const data = event.data
       let height: number | undefined

--- a/src/app/website/subscribe/offers/offers-content.tsx
+++ b/src/app/website/subscribe/offers/offers-content.tsx
@@ -25,6 +25,10 @@ export function OffersContent({ logoUrl, newsletterName, afteroffersFormId }: Of
   const email = searchParams.get('email') || ''
   const urlClickId = searchParams.get('click_id') || ''
   const [clickId, setClickId] = useState('')
+  // Default tall enough that AfterOffers content rarely clips even if the
+  // iframe never reports its real height via postMessage. The listener below
+  // will shrink/expand this once a real height arrives.
+  const [iframeHeight, setIframeHeight] = useState(1800)
 
   // Store email in sessionStorage so info page can retrieve it as fallback
   useEffect(() => {
@@ -73,6 +77,35 @@ export function OffersContent({ logoUrl, newsletterName, afteroffersFormId }: Of
     setClickId(id)
   }, [urlClickId])
 
+  // Listen for height messages from the AfterOffers iframe so the page scrolls
+  // instead of producing a scrollbar inside the iframe.
+  useEffect(() => {
+    function handleMessage(event: MessageEvent) {
+      if (!event.origin.endsWith('afteroffers.com')) return
+
+      const data = event.data
+      let height: number | undefined
+
+      if (typeof data === 'number') {
+        height = data
+      } else if (typeof data === 'string') {
+        const match = data.match(/(\d+(?:\.\d+)?)/)
+        if (match) height = Number(match[1])
+      } else if (data && typeof data === 'object') {
+        const candidate = data.height ?? data.iframeHeight ?? data.contentHeight ?? data.scrollHeight
+        if (typeof candidate === 'number') height = candidate
+        else if (typeof candidate === 'string' && !Number.isNaN(Number(candidate))) height = Number(candidate)
+      }
+
+      if (height && Number.isFinite(height) && height > 0) {
+        setIframeHeight(Math.ceil(height))
+      }
+    }
+
+    window.addEventListener('message', handleMessage)
+    return () => window.removeEventListener('message', handleMessage)
+  }, [])
+
   // Build the AfterOffers URL with email and click_id
   const params = new URLSearchParams()
   if (email) {
@@ -109,11 +142,12 @@ export function OffersContent({ logoUrl, newsletterName, afteroffersFormId }: Of
             <div className="rounded-xl overflow-hidden shadow-lg border border-slate-200">
               <iframe
                 src={afterOffersUrl}
-                height="600"
                 width="100%"
                 frameBorder="0"
+                scrolling="no"
                 sandbox="allow-forms allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox allow-same-origin"
-                className="w-full"
+                className="w-full block"
+                style={{ height: `${iframeHeight}px` }}
               />
             </div>
           )}

--- a/src/app/website/subscribe/offers/offers-content.tsx
+++ b/src/app/website/subscribe/offers/offers-content.tsx
@@ -106,7 +106,9 @@ export function OffersContent({ logoUrl, newsletterName, afteroffersFormId }: Of
       }
 
       if (height && Number.isFinite(height) && height > 0) {
-        setIframeHeight(Math.ceil(height))
+        // Cap to a sane upper bound so a misbehaving message can't blow out the layout.
+        const safeHeight = Math.min(Math.ceil(height), 10000)
+        setIframeHeight(safeHeight)
       }
     }
 

--- a/src/lib/publication-settings.ts
+++ b/src/lib/publication-settings.ts
@@ -242,10 +242,14 @@ export async function resolvePublicationFromRequest(): Promise<{
 /**
  * Get SparkLoop credentials for a publication.
  *
- * IMPORTANT: Queries publication_settings directly — does NOT fall through
- * to app_settings. This prevents cross-tenant credential leakage where one
- * publication's SparkLoop API key could be returned for another tenant.
- * Falls back to environment variables only.
+ * The API key is a single shared account-level secret and is sourced from env.
+ * The upscribe ID is a per-tenant identifier that scopes API calls to a
+ * specific publication's recommendations and aggregates — it MUST come from
+ * publication_settings with no env fallback. Falling back to a global
+ * SPARKLOOP_UPSCRIBE_ID would silently impersonate whichever tenant owns that
+ * upscribe (e.g. a misconfigured tenant inheriting another tenant's snapshots).
+ * The webhook secret is currently treated like the API key — account-level —
+ * since multiple publications share one webhook endpoint.
  */
 export async function getSparkLoopCredentials(publicationId: string): Promise<{
   apiKey: string
@@ -261,9 +265,8 @@ export async function getSparkLoopCredentials(publicationId: string): Promise<{
   const map = Object.fromEntries((data ?? []).map(r => [r.key, r.value]))
 
   return {
-    // SparkLoop API key is a single shared account-level secret — always sourced from env.
     apiKey: process.env.SPARKLOOP_API_KEY || '',
-    upscribeId: map['sparkloop_upscribe_id'] || process.env.SPARKLOOP_UPSCRIBE_ID || '',
+    upscribeId: map['sparkloop_upscribe_id'] || '',
     webhookSecret: map['sparkloop_webhook_secret'] || process.env.SPARKLOOP_WEBHOOK_SECRET || '',
   }
 }


### PR DESCRIPTION
## Summary

Promotes the staging branch to master. Highlights, grouped by area:

**SparkLoop multi-tenant hardening**
- Scope `/dashboard/[slug]/sparkloop` data to the active publication via slug → `publication_id` resolution; six routes now `requirePublicationId: true` and drop the global `PUBLICATION_ID` fallback.
- Add `publication_id` filter on PATCH/POST update queries (defense-in-depth).
- Remove the `SPARKLOOP_UPSCRIBE_ID` env fallback in `getSparkLoopCredentials` — it caused publications without their own upscribe to silently impersonate whichever tenant owned the env-var upscribe.
- Bump `/api/sparkloop/offer-stats` from `authTier: 'public'` to `'admin'` — the route returned `subscriber_email` and `ip_address`, which shouldn't be reachable behind only a publication_id guess.
- Earlier in the branch: API key rotation handling, subscribe outage robustness, `publication_id` propagation through subscribe / recommend / module-subscribe client flows.

**Subscribe pages & A/B testing**
- New `/subscribe` A/B testing system (cron scheduler, dashboard CRUD, stats endpoint).
- Subscribe pages are now the source of truth for `/subscribe` content; default seed migration; live-edit preview; optional per-page phone collection.
- Allow staging A/B testing without DNS changes.

**Analytics foundation (PR1)**
- Shared types, pure metric formulas with unit tests, bot + IP filter policy.
- Analytics DAL skeleton: `getDeliveryCounts`, `getUniqueClickers`, `getIssueEngagement`, `getModuleEngagement` (section-scoped aggregation), barrel exports.
- Design spec and PR1 implementation plan documents.

**Website / SSR**
- AfterOffers iframe sizes to its content via postMessage — no internal scrollbars. Origin validated via strict hostname parse (`afteroffers.com` or `*.afteroffers.com`); height clamped to 10,000px as defense-in-depth.
- AdSense, Meta Pixel, and CMP scripts render in initial SSR HTML.
- Publication-specific archive cover image; `resolveArchiveCoverImage` helper.

**RSS / scoring**
- New "Sent" variant of the RSS Output module feed.
- `transaction_type` passed into scoring placeholders; `rated_before` / `rated_after` filters on rescore-module-posts.

**CI / review fixes (latest commits)**
- Bug-pattern (`date-iso`) check: dropped one unused `todayStr` local; suppressed four intentional UTC-extraction sites with inline `// bug-check-ignore: date-iso` and explanations (UTC end-of-day boundaries against `timestamptz` columns and a `YYYY-MM-DD` snapshot column).
- CodeQL incomplete-URL-sanitization: replaced `event.origin.endsWith('afteroffers.com')` with strict `new URL(...).hostname` check.
- Cleared stale date-range metrics in `useDetailedTabState` when `publicationId` drops to null.
- Cleared `loading` state in `OffersTab` on the publicationId early-return so a failed slug-resolution doesn't spinner forever.

**Findings deliberately not fixed in this PR (rationale)**
- `webhookSecret` env fallback in `publication-settings.ts`: production `trader-leak` has no per-tenant secret row and relies on the env fallback today; removing it would break their webhook validation. Worth doing once the per-tenant secret is configured — separate decision.
- `stats/route.ts` and `admin/route.ts` runtime `if (!publicationId) throw` guards: these aren't redundant runtime defenses (`withApiHandler` already 400s on missing `publication_id`); they exist for **TypeScript narrowing** at non-Supabase call sites like `getPublicationSettings(publicationId, ...)` which expects `string`. Removing them would force `publicationId!` at multiple sites with no functional change. Routes that only use `publicationId` in `.eq()` filters (e.g. `daterange`, `submissions`, `offer-stats`) correctly do not need the guard.

## Test plan
- [ ] Load `/dashboard/<slug>/sparkloop` for at least two publications and confirm Detailed and Overview tabs show distinct metrics per tenant.
- [ ] Confirm a publication missing `sparkloop_upscribe_id` is skipped by the sync cron (warn log, no rows written).
- [ ] Run `/subscribe` with an active A/B test and verify variant assignment is sticky across navigation.
- [ ] `npm run test:run` — analytics + DAL unit tests pass.
- [ ] Visit `/website/subscribe/offers`; AfterOffers iframe expands to content height (no inner scrollbar) and tops out at 10,000px.
- [ ] View page source on `/website` and confirm AdSense / Meta Pixel script tags are present in the initial HTML.
- [ ] RSS Output module "Sent" feed returns only sent issues' articles.
- [ ] Hit `/api/sparkloop/offer-stats` without an admin session → expect 401/403 (was 200 before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)