### PR TITLE
feat(subscribe/info): toggle each personalization question on/off

### DIFF
--- a/src/app/api/settings/website/route.ts
+++ b/src/app/api/settings/website/route.ts
@@ -16,8 +16,10 @@ const WEBSITE_SETTINGS_KEYS = [
   // Subscribe info page
   'subscribe_info_heading',
   'subscribe_info_subheading',
+  'subscribe_info_job_enabled',
   'subscribe_info_job_label',
   'subscribe_info_job_options',
+  'subscribe_info_clients_enabled',
   'subscribe_info_clients_label',
   'subscribe_info_clients_options',
   'subscribe_info_submit_text',

--- a/src/app/website/subscribe/info/page.tsx
+++ b/src/app/website/subscribe/info/page.tsx
@@ -16,12 +16,18 @@ export default async function SubscribeInfoPage() {
     'newsletter_name',
     'subscribe_info_heading',
     'subscribe_info_subheading',
+    'subscribe_info_job_enabled',
     'subscribe_info_job_label',
     'subscribe_info_job_options',
+    'subscribe_info_clients_enabled',
     'subscribe_info_clients_label',
     'subscribe_info_clients_options',
     'subscribe_info_submit_text',
   ])
+
+  // Default to enabled when the setting is missing (preserves existing behavior).
+  const jobEnabled = settings.subscribe_info_job_enabled !== 'false'
+  const clientsEnabled = settings.subscribe_info_clients_enabled !== 'false'
 
   const logoUrl = settings.logo_url || '/logo.png'
   const newsletterName = settings.newsletter_name || 'AI Accounting Daily'
@@ -81,8 +87,10 @@ export default async function SubscribeInfoPage() {
             {/* Personalization Form */}
             <div className="mt-6 sm:mt-10">
               <PersonalizationForm
+                jobEnabled={jobEnabled}
                 jobLabel={settings.subscribe_info_job_label || undefined}
                 jobOptions={jobOptions}
+                clientsEnabled={clientsEnabled}
                 clientsLabel={settings.subscribe_info_clients_label || undefined}
                 clientsOptions={clientsOptions}
                 submitText={settings.subscribe_info_submit_text || undefined}

--- a/src/app/website/subscribe/info/personalization-form.tsx
+++ b/src/app/website/subscribe/info/personalization-form.tsx
@@ -114,8 +114,8 @@ export function PersonalizationForm({
           original_email: emailChanged ? storedEmail : undefined,
           name: firstName.trim(),
           last_name: lastName.trim(),
-          job_type: jobType,
-          yearly_clients: yearlyClients,
+          ...(jobEnabled ? { job_type: jobType } : {}),
+          ...(clientsEnabled ? { yearly_clients: yearlyClients } : {}),
         })
       })
 

--- a/src/app/website/subscribe/info/personalization-form.tsx
+++ b/src/app/website/subscribe/info/personalization-form.tsx
@@ -20,16 +20,20 @@ const DEFAULT_CLIENTS_OPTIONS = [
 ]
 
 interface PersonalizationFormProps {
+  jobEnabled?: boolean
   jobLabel?: string
   jobOptions?: { value: string; label: string }[]
+  clientsEnabled?: boolean
   clientsLabel?: string
   clientsOptions?: { value: string; label: string }[]
   submitText?: string
 }
 
 export function PersonalizationForm({
+  jobEnabled = true,
   jobLabel = 'What best describes your role?',
   jobOptions = DEFAULT_JOB_OPTIONS,
+  clientsEnabled = true,
   clientsLabel = "How many clients' books/tax returns/financials do you handle yearly?",
   clientsOptions = DEFAULT_CLIENTS_OPTIONS,
   submitText = 'Complete Sign Up',
@@ -84,12 +88,12 @@ export function PersonalizationForm({
       return
     }
 
-    if (!jobType) {
+    if (jobEnabled && !jobType) {
       setError('Please select your job type')
       return
     }
 
-    if (!yearlyClients) {
+    if (clientsEnabled && !yearlyClients) {
       setError('Please select how many clients you handle')
       return
     }
@@ -186,48 +190,52 @@ export function PersonalizationForm({
         </div>
 
         {/* Job Type Dropdown */}
-        <div>
-          <label htmlFor="jobType" className="block text-sm font-medium text-slate-700 text-left mb-1">
-            {jobLabel} <span className="text-red-500">*</span>
-          </label>
-          <select
-            id="jobType"
-            required
-            value={jobType}
-            onChange={(e) => setJobType(e.target.value)}
-            disabled={isSubmitting || !email}
-            className="w-full rounded-lg border-0 bg-white px-4 py-3 text-slate-900 shadow-lg ring-1 ring-inset ring-slate-200 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm"
-          >
-            <option value="">Select your role...</option>
-            {jobOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </div>
+        {jobEnabled && (
+          <div>
+            <label htmlFor="jobType" className="block text-sm font-medium text-slate-700 text-left mb-1">
+              {jobLabel} <span className="text-red-500">*</span>
+            </label>
+            <select
+              id="jobType"
+              required
+              value={jobType}
+              onChange={(e) => setJobType(e.target.value)}
+              disabled={isSubmitting || !email}
+              className="w-full rounded-lg border-0 bg-white px-4 py-3 text-slate-900 shadow-lg ring-1 ring-inset ring-slate-200 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm"
+            >
+              <option value="">Select your role...</option>
+              {jobOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
         {/* Yearly Clients Dropdown */}
-        <div>
-          <label htmlFor="yearlyClients" className="block text-sm font-medium text-slate-700 text-left mb-1">
-            {clientsLabel} <span className="text-red-500">*</span>
-          </label>
-          <select
-            id="yearlyClients"
-            required
-            value={yearlyClients}
-            onChange={(e) => setYearlyClients(e.target.value)}
-            disabled={isSubmitting || !email}
-            className="w-full rounded-lg border-0 bg-white px-4 py-3 text-slate-900 shadow-lg ring-1 ring-inset ring-slate-200 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm"
-          >
-            <option value="">Select an option...</option>
-            {clientsOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </div>
+        {clientsEnabled && (
+          <div>
+            <label htmlFor="yearlyClients" className="block text-sm font-medium text-slate-700 text-left mb-1">
+              {clientsLabel} <span className="text-red-500">*</span>
+            </label>
+            <select
+              id="yearlyClients"
+              required
+              value={yearlyClients}
+              onChange={(e) => setYearlyClients(e.target.value)}
+              disabled={isSubmitting || !email}
+              className="w-full rounded-lg border-0 bg-white px-4 py-3 text-slate-900 shadow-lg ring-1 ring-inset ring-slate-200 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm"
+            >
+              <option value="">Select an option...</option>
+              {clientsOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
         {/* Submit Button */}
         <button

--- a/src/components/settings/WebsiteSettings.tsx
+++ b/src/components/settings/WebsiteSettings.tsx
@@ -97,14 +97,14 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
         <SettingsTextarea label="Heading" value={settings.subscribe_info_heading} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_info_heading: v }))} placeholder={"One Last Step!\n**Personalize Your Experience**"} rows={2} hint="Use Enter for line breaks. Wrap text in **double asterisks** for gradient underline style." />
         <SettingsTextarea label="Subheadline" value={settings.subscribe_info_subheading} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_info_subheading: v }))} placeholder="Help us tailor your newsletter to your needs. This only takes 30 seconds!" rows={2} />
 
-        <div className={`border rounded-md p-3 space-y-3 ${settings.subscribe_info_job_enabled ? '' : 'bg-gray-50 opacity-75'}`}>
+        <div className={`border rounded-md p-3 space-y-3 ${settings.subscribe_info_job_enabled ? '' : 'bg-gray-50'}`}>
           <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-gray-700">Question 1</span>
-            <button type="button" onClick={() => setSettings(prev => ({ ...prev, subscribe_info_job_enabled: !prev.subscribe_info_job_enabled }))} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${settings.subscribe_info_job_enabled ? 'bg-blue-600' : 'bg-gray-200'}`}>
+            <span id="question-1-label" className="text-sm font-medium text-gray-700">Question 1</span>
+            <button type="button" aria-labelledby="question-1-label" aria-pressed={settings.subscribe_info_job_enabled} onClick={() => setSettings(prev => ({ ...prev, subscribe_info_job_enabled: !prev.subscribe_info_job_enabled }))} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${settings.subscribe_info_job_enabled ? 'bg-blue-600' : 'bg-gray-300'}`}>
               <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${settings.subscribe_info_job_enabled ? 'translate-x-6' : 'translate-x-1'}`} />
             </button>
           </div>
-          {settings.subscribe_info_job_enabled && (
+          {settings.subscribe_info_job_enabled ? (
             <>
               <SettingsInput label="Question 1 Label" value={settings.subscribe_info_job_label} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_info_job_label: v }))} placeholder="What best describes your role?" />
               <OptionsEditor
@@ -113,17 +113,19 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
                 onChange={(opts) => setSettings(prev => ({ ...prev, subscribe_info_job_options: opts }))}
               />
             </>
+          ) : (
+            <p className="text-xs text-gray-500">Hidden from subscribers. Toggle on to edit.</p>
           )}
         </div>
 
-        <div className={`border rounded-md p-3 space-y-3 ${settings.subscribe_info_clients_enabled ? '' : 'bg-gray-50 opacity-75'}`}>
+        <div className={`border rounded-md p-3 space-y-3 ${settings.subscribe_info_clients_enabled ? '' : 'bg-gray-50'}`}>
           <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-gray-700">Question 2</span>
-            <button type="button" onClick={() => setSettings(prev => ({ ...prev, subscribe_info_clients_enabled: !prev.subscribe_info_clients_enabled }))} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${settings.subscribe_info_clients_enabled ? 'bg-blue-600' : 'bg-gray-200'}`}>
+            <span id="question-2-label" className="text-sm font-medium text-gray-700">Question 2</span>
+            <button type="button" aria-labelledby="question-2-label" aria-pressed={settings.subscribe_info_clients_enabled} onClick={() => setSettings(prev => ({ ...prev, subscribe_info_clients_enabled: !prev.subscribe_info_clients_enabled }))} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${settings.subscribe_info_clients_enabled ? 'bg-blue-600' : 'bg-gray-300'}`}>
               <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${settings.subscribe_info_clients_enabled ? 'translate-x-6' : 'translate-x-1'}`} />
             </button>
           </div>
-          {settings.subscribe_info_clients_enabled && (
+          {settings.subscribe_info_clients_enabled ? (
             <>
               <SettingsInput label="Question 2 Label" value={settings.subscribe_info_clients_label} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_info_clients_label: v }))} placeholder="How many clients' books/tax returns/financials do you handle yearly?" />
               <OptionsEditor
@@ -132,6 +134,8 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
                 onChange={(opts) => setSettings(prev => ({ ...prev, subscribe_info_clients_options: opts }))}
               />
             </>
+          ) : (
+            <p className="text-xs text-gray-500">Hidden from subscribers. Toggle on to edit.</p>
           )}
         </div>
 

--- a/src/components/settings/WebsiteSettings.tsx
+++ b/src/components/settings/WebsiteSettings.tsx
@@ -99,7 +99,7 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
 
         <div className={`border rounded-md p-3 space-y-3 ${settings.subscribe_info_job_enabled ? '' : 'bg-gray-50 opacity-75'}`}>
           <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-gray-700">Question 1 (Job/Role)</span>
+            <span className="text-sm font-medium text-gray-700">Question 1</span>
             <button type="button" onClick={() => setSettings(prev => ({ ...prev, subscribe_info_job_enabled: !prev.subscribe_info_job_enabled }))} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${settings.subscribe_info_job_enabled ? 'bg-blue-600' : 'bg-gray-200'}`}>
               <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${settings.subscribe_info_job_enabled ? 'translate-x-6' : 'translate-x-1'}`} />
             </button>
@@ -118,7 +118,7 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
 
         <div className={`border rounded-md p-3 space-y-3 ${settings.subscribe_info_clients_enabled ? '' : 'bg-gray-50 opacity-75'}`}>
           <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-gray-700">Question 2 (Clients)</span>
+            <span className="text-sm font-medium text-gray-700">Question 2</span>
             <button type="button" onClick={() => setSettings(prev => ({ ...prev, subscribe_info_clients_enabled: !prev.subscribe_info_clients_enabled }))} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${settings.subscribe_info_clients_enabled ? 'bg-blue-600' : 'bg-gray-200'}`}>
               <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${settings.subscribe_info_clients_enabled ? 'translate-x-6' : 'translate-x-1'}`} />
             </button>

--- a/src/components/settings/WebsiteSettings.tsx
+++ b/src/components/settings/WebsiteSettings.tsx
@@ -96,21 +96,44 @@ export default function WebsiteSettings({ publicationId }: { publicationId: stri
         </div>
         <SettingsTextarea label="Heading" value={settings.subscribe_info_heading} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_info_heading: v }))} placeholder={"One Last Step!\n**Personalize Your Experience**"} rows={2} hint="Use Enter for line breaks. Wrap text in **double asterisks** for gradient underline style." />
         <SettingsTextarea label="Subheadline" value={settings.subscribe_info_subheading} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_info_subheading: v }))} placeholder="Help us tailor your newsletter to your needs. This only takes 30 seconds!" rows={2} />
-        <SettingsInput label="Question 1 Label" value={settings.subscribe_info_job_label} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_info_job_label: v }))} placeholder="What best describes your role?" />
 
-        <OptionsEditor
-          label="Question 1 Options"
-          options={settings.subscribe_info_job_options}
-          onChange={(opts) => setSettings(prev => ({ ...prev, subscribe_info_job_options: opts }))}
-        />
+        <div className={`border rounded-md p-3 space-y-3 ${settings.subscribe_info_job_enabled ? '' : 'bg-gray-50 opacity-75'}`}>
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-gray-700">Question 1 (Job/Role)</span>
+            <button type="button" onClick={() => setSettings(prev => ({ ...prev, subscribe_info_job_enabled: !prev.subscribe_info_job_enabled }))} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${settings.subscribe_info_job_enabled ? 'bg-blue-600' : 'bg-gray-200'}`}>
+              <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${settings.subscribe_info_job_enabled ? 'translate-x-6' : 'translate-x-1'}`} />
+            </button>
+          </div>
+          {settings.subscribe_info_job_enabled && (
+            <>
+              <SettingsInput label="Question 1 Label" value={settings.subscribe_info_job_label} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_info_job_label: v }))} placeholder="What best describes your role?" />
+              <OptionsEditor
+                label="Question 1 Options"
+                options={settings.subscribe_info_job_options}
+                onChange={(opts) => setSettings(prev => ({ ...prev, subscribe_info_job_options: opts }))}
+              />
+            </>
+          )}
+        </div>
 
-        <SettingsInput label="Question 2 Label" value={settings.subscribe_info_clients_label} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_info_clients_label: v }))} placeholder="How many clients' books/tax returns/financials do you handle yearly?" />
-
-        <OptionsEditor
-          label="Question 2 Options"
-          options={settings.subscribe_info_clients_options}
-          onChange={(opts) => setSettings(prev => ({ ...prev, subscribe_info_clients_options: opts }))}
-        />
+        <div className={`border rounded-md p-3 space-y-3 ${settings.subscribe_info_clients_enabled ? '' : 'bg-gray-50 opacity-75'}`}>
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-gray-700">Question 2 (Clients)</span>
+            <button type="button" onClick={() => setSettings(prev => ({ ...prev, subscribe_info_clients_enabled: !prev.subscribe_info_clients_enabled }))} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${settings.subscribe_info_clients_enabled ? 'bg-blue-600' : 'bg-gray-200'}`}>
+              <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${settings.subscribe_info_clients_enabled ? 'translate-x-6' : 'translate-x-1'}`} />
+            </button>
+          </div>
+          {settings.subscribe_info_clients_enabled && (
+            <>
+              <SettingsInput label="Question 2 Label" value={settings.subscribe_info_clients_label} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_info_clients_label: v }))} placeholder="How many clients' books/tax returns/financials do you handle yearly?" />
+              <OptionsEditor
+                label="Question 2 Options"
+                options={settings.subscribe_info_clients_options}
+                onChange={(opts) => setSettings(prev => ({ ...prev, subscribe_info_clients_options: opts }))}
+              />
+            </>
+          )}
+        </div>
 
         <SettingsInput label="Submit Button Text" value={settings.subscribe_info_submit_text} onChange={(v) => setSettings(prev => ({ ...prev, subscribe_info_submit_text: v }))} placeholder="Complete Sign Up" />
       </div>

--- a/src/components/settings/useWebsiteSettings.ts
+++ b/src/components/settings/useWebsiteSettings.ts
@@ -29,8 +29,10 @@ export interface WebsiteSettingsState {
   subscribe_tagline: string
   subscribe_info_heading: string
   subscribe_info_subheading: string
+  subscribe_info_job_enabled: boolean
   subscribe_info_job_label: string
   subscribe_info_job_options: { value: string; label: string }[]
+  subscribe_info_clients_enabled: boolean
   subscribe_info_clients_label: string
   subscribe_info_clients_options: { value: string; label: string }[]
   subscribe_info_submit_text: string
@@ -48,8 +50,10 @@ export function useWebsiteSettings(publicationId: string) {
     subscribe_tagline: '',
     subscribe_info_heading: '',
     subscribe_info_subheading: '',
+    subscribe_info_job_enabled: true,
     subscribe_info_job_label: '',
     subscribe_info_job_options: DEFAULT_JOB_OPTIONS,
+    subscribe_info_clients_enabled: true,
     subscribe_info_clients_label: '',
     subscribe_info_clients_options: DEFAULT_CLIENTS_OPTIONS,
     subscribe_info_submit_text: '',


### PR DESCRIPTION
## Summary
- Adds per-question on/off toggles to **Settings → Website → Subscribe Info Page** so the public Subscribe Info Page can render 0, 1, or 2 questions.
- Each question (Q1 = role/job_type, Q2 = clients/yearly_clients) is independently toggleable. Disabled questions are hidden on the public form and skipped in client-side validation; saved labels/options are preserved for re-enable.
- Backwards-compatible: existing publications default to both questions enabled (the new keys are absent and treated as enabled).

## Changes
- `src/components/settings/WebsiteSettings.tsx` — toggle UI per question with \`aria-labelledby\` + \`aria-pressed\`; disabled card shows "Hidden from subscribers" hint.
- `src/components/settings/useWebsiteSettings.ts` — new \`subscribe_info_job_enabled\` and \`subscribe_info_clients_enabled\` boolean state (default \`true\`).
- `src/app/api/settings/website/route.ts` — registers the two new keys; existing boolean serialization handles round-trip.
- `src/app/website/subscribe/info/page.tsx` — fetches enabled flags (defaults to enabled when missing) and forwards to the form.
- `src/app/website/subscribe/info/personalization-form.tsx` — conditionally renders dropdowns, skips validation when disabled, omits the field from the personalize POST body when disabled.

## Notes from pre-push gate review
Out-of-scope findings flagged as follow-ups (not in this PR):
- Settings POST loop swallows upsert errors (pre-existing pattern, all 16 keys).
- POST endpoint lacks publication-membership ownership check (pre-existing, separate from this feature).
- Server-side enforcement of toggles on \`/api/subscribe/personalize\` (currently relies on client-side; downstream \`if (job_type)\` guard is benign but worth hardening).
- \`OptionsEditor\` overwrites \`value\` with edited \`label\` text (pre-existing).
- Debug \`console.log\` calls in \`publication-settings.ts\` (unrelated).

## Test plan
- [ ] Settings page: toggle each question off/on, save, reload — verify state persists.
- [ ] Settings page: toggle off, save, reload — saved labels/options come back when re-enabled.
- [ ] Public \`/subscribe/info\`: with both on, both questions render and are required.
- [ ] Public \`/subscribe/info\`: with Q1 off only, just Q2 renders; submit succeeds without job_type.
- [ ] Public \`/subscribe/info\`: with Q2 off only, just Q1 renders; submit succeeds without yearly_clients.
- [ ] Public \`/subscribe/info\`: with both off, only email + first/last name + submit show; submit succeeds.
- [ ] New publication (no settings rows): both questions render by default.
- [ ] Screen reader announces toggles as "Question 1, pressed/not pressed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional enable/disable controls for Job Type and Yearly Clients fields in subscription forms. Website administrators can now toggle these fields on or off in settings to customize subscriber data collection. When disabled, the fields are hidden from subscribers with a notification indicating they are currently unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->