### PR TITLE
fix(offers): shrink AfterOffers iframe default to 800px with scrolling

### DIFF
--- a/src/app/website/subscribe/offers/offers-content.tsx
+++ b/src/app/website/subscribe/offers/offers-content.tsx
@@ -25,10 +25,11 @@ export function OffersContent({ logoUrl, newsletterName, afteroffersFormId }: Of
   const email = searchParams.get('email') || ''
   const urlClickId = searchParams.get('click_id') || ''
   const [clickId, setClickId] = useState('')
-  // Default tall enough that AfterOffers content rarely clips even if the
-  // iframe never reports its real height via postMessage. The listener below
-  // will shrink/expand this once a real height arrives.
-  const [iframeHeight, setIframeHeight] = useState(1800)
+  // Sized to fit the typical AfterOffers form (~5 offers + email + button).
+  // The listener below expands this if AfterOffers reports a taller content
+  // height via postMessage. In practice AfterOffers rarely posts a height,
+  // so this default is what most users will see.
+  const [iframeHeight, setIframeHeight] = useState(800)
 
   // Store email in sessionStorage so info page can retrieve it as fallback
   useEffect(() => {
@@ -154,7 +155,7 @@ export function OffersContent({ logoUrl, newsletterName, afteroffersFormId }: Of
                 src={afterOffersUrl}
                 width="100%"
                 frameBorder="0"
-                scrolling="no"
+                scrolling="auto"
                 sandbox="allow-forms allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox allow-same-origin"
                 className="w-full block"
                 style={{ height: `${iframeHeight}px` }}


### PR DESCRIPTION
## Summary
- The previous 1800px default left a large empty area below the AfterOffers form because AfterOffers does not post a content height back to the parent (verified via window message listener — only reCAPTCHA messages arrive).
- Drop the default to 800px to match the typical 5-offer form, and switch the iframe back to `scrolling="auto"` so unusually tall content stays reachable via an internal scrollbar instead of clipping.
- Listener that resizes on `postMessage` from `*.afteroffers.com` is left in place as a no-op safety net in case AfterOffers ever begins reporting heights.

## Test plan
- [ ] Load `/subscribe/offers` on a publication that uses AfterOffers and confirm there is no large empty area below the form.
- [ ] If the iframe content is unusually tall, confirm an internal scrollbar appears so the SEND & CONTINUE button is reachable.
- [ ] Verify normal flow: choose offers → submit → continue to next subscribe step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)