### PR TITLE
feat(sparkloop): fire Make webhook directly on subscribe

### DIFF
--- a/src/app/api/settings/sparkloop/route.ts
+++ b/src/app/api/settings/sparkloop/route.ts
@@ -18,10 +18,11 @@ export const GET = withApiHandler(
       return NextResponse.json({ error: 'publication_id required' }, { status: 400 })
     }
 
-    const [upscribeId, webhookSecret, afteroffersFormId] = await Promise.all([
+    const [upscribeId, webhookSecret, afteroffersFormId, makeWebhookUrl] = await Promise.all([
       getPublicationSetting(publicationId, 'sparkloop_upscribe_id'),
       getPublicationSetting(publicationId, 'sparkloop_webhook_secret'),
       getPublicationSetting(publicationId, 'afteroffers_form_id'),
+      getPublicationSetting(publicationId, 'sparkloop_webhook_url'),
     ])
 
     return NextResponse.json({
@@ -30,6 +31,7 @@ export const GET = withApiHandler(
       upscribeId: upscribeId || '',
       hasWebhookSecret: !!webhookSecret,
       afteroffersFormId: afteroffersFormId || '',
+      makeWebhookUrl: makeWebhookUrl || '',
     })
   }
 )
@@ -69,6 +71,19 @@ export const POST = withApiHandler(
       const { error } = await updatePublicationSetting(publicationId, 'afteroffers_form_id', body.afteroffersFormId)
       if (error) throw new Error(`Failed to save AfterOffers form ID: ${error}`)
       results.push('AfterOffers form ID updated')
+    }
+
+    if (body.makeWebhookUrl !== undefined) {
+      const trimmed = typeof body.makeWebhookUrl === 'string' ? body.makeWebhookUrl.trim() : ''
+      if (trimmed && !/^https:\/\//i.test(trimmed)) {
+        return NextResponse.json(
+          { error: 'Make webhook URL must start with https://' },
+          { status: 400 }
+        )
+      }
+      const { error } = await updatePublicationSetting(publicationId, 'sparkloop_webhook_url', trimmed)
+      if (error) throw new Error(`Failed to save Make webhook URL: ${error}`)
+      results.push('Make webhook URL updated')
     }
 
     return NextResponse.json({

--- a/src/app/api/sparkloop/module-subscribe/route.ts
+++ b/src/app/api/sparkloop/module-subscribe/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { createHash } from 'crypto'
-import { createSparkLoopServiceForPublication } from '@/lib/sparkloop-client'
+import { createSparkLoopServiceForPublication, fireMakeWebhook } from '@/lib/sparkloop-client'
 import { supabaseAdmin } from '@/lib/supabase'
 import { checkUserAgent } from '@/lib/bot-detection'
 import { isIPExcluded, IPExclusion } from '@/lib/ip-utils'
 import { PUBLICATION_ID } from '@/lib/config'
 import { MailerLiteService } from '@/lib/mailerlite'
-import { getEmailProviderSettings } from '@/lib/publication-settings'
+import { getEmailProviderSettings, getPublicationSetting } from '@/lib/publication-settings'
 import { updateBeehiivSubscriberField } from '@/lib/beehiiv'
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://aiprodaily.com'
 
@@ -267,6 +267,18 @@ export const GET = withApiHandler(
       }
     } catch (providerError) {
       console.error('[SparkLoop Module Subscribe] Email provider update error:', providerError)
+    }
+
+    // Fire direct Make.com webhook (replaces the MailerLite-segment-triggered path).
+    if (subscriberUuid) {
+      const webhookUrl = await getPublicationSetting(publicationId, 'sparkloop_webhook_url')
+      await fireMakeWebhook(
+        webhookUrl,
+        { subscriber_email: email, subscriber_id: subscriberUuid },
+        { publicationId }
+      )
+    } else {
+      console.log('[SparkLoop Module Subscribe] Skipping Make webhook: no subscriber_uuid available')
     }
 
     // Redirect to confirmation page

--- a/src/app/api/sparkloop/recommend-subscribe/route.ts
+++ b/src/app/api/sparkloop/recommend-subscribe/route.ts
@@ -2,13 +2,13 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { withApiHandler } from '@/lib/api-handler'
 import { createHash } from 'crypto'
-import { createSparkLoopServiceForPublication } from '@/lib/sparkloop-client'
+import { createSparkLoopServiceForPublication, fireMakeWebhook } from '@/lib/sparkloop-client'
 import { supabaseAdmin } from '@/lib/supabase'
 import { checkUserAgent } from '@/lib/bot-detection'
 import { isIPExcluded, IPExclusion } from '@/lib/ip-utils'
 import { PUBLICATION_ID } from '@/lib/config'
 import { MailerLiteService } from '@/lib/mailerlite'
-import { getEmailProviderSettings } from '@/lib/publication-settings'
+import { getEmailProviderSettings, getPublicationSetting } from '@/lib/publication-settings'
 import { updateBeehiivSubscriberField } from '@/lib/beehiiv'
 
 const inputSchema = z.object({
@@ -253,6 +253,18 @@ export const POST = withApiHandler(
       }
     } catch (providerError) {
       console.error('[SparkLoop Recommend Subscribe] Email provider update error:', providerError)
+    }
+
+    // Fire direct Make.com webhook (replaces the MailerLite-segment-triggered path).
+    if (subscriberUuid) {
+      const webhookUrl = await getPublicationSetting(publicationId, 'sparkloop_webhook_url')
+      await fireMakeWebhook(
+        webhookUrl,
+        { subscriber_email: email, subscriber_id: subscriberUuid },
+        { publicationId }
+      )
+    } else {
+      console.log('[SparkLoop Recommend Subscribe] Skipping Make webhook: no subscriber_uuid available')
     }
 
     return NextResponse.json({

--- a/src/app/api/sparkloop/subscribe/route.ts
+++ b/src/app/api/sparkloop/subscribe/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { createHash } from 'crypto'
 import { cookies } from 'next/headers'
-import { createSparkLoopServiceForPublication } from '@/lib/sparkloop-client'
+import { createSparkLoopServiceForPublication, fireMakeWebhook } from '@/lib/sparkloop-client'
 import { supabaseAdmin } from '@/lib/supabase'
 import { MailerLiteService } from '@/lib/mailerlite'
 import { PUBLICATION_ID } from '@/lib/config'
-import { getEmailProviderSettings } from '@/lib/publication-settings'
+import { getEmailProviderSettings, getPublicationSetting } from '@/lib/publication-settings'
 import { updateBeehiivSubscriberField } from '@/lib/beehiiv'
 import {
   attributeByVisitor,
@@ -232,6 +232,20 @@ export const POST = withApiHandler(
     } catch (providerError) {
       console.error('[SparkLoop Subscribe] Email provider update error:', providerError)
       // Don't fail the request for email provider errors
+    }
+
+    // Fire direct Make.com webhook (replaces the MailerLite-segment-triggered path).
+    // Fires on the same trigger condition as the field flip — user-action subscribe
+    // intent — and only when we have the SparkLoop subscriber_uuid.
+    if (subscriberUuid) {
+      const webhookUrl = await getPublicationSetting(publicationId, 'sparkloop_webhook_url')
+      await fireMakeWebhook(
+        webhookUrl,
+        { subscriber_email: email, subscriber_id: subscriberUuid },
+        { publicationId }
+      )
+    } else {
+      console.log('[SparkLoop Subscribe] Skipping Make webhook: no subscriber_uuid available')
     }
 
     // Record A/B sparkloop_signup conversion only on actual SparkLoop success.

--- a/src/components/settings/SparkLoopSettings.tsx
+++ b/src/components/settings/SparkLoopSettings.tsx
@@ -7,6 +7,7 @@ export default function SparkLoopSettings({ publicationId }: { publicationId: st
     upscribeId: '',
     webhookSecret: '',
     afteroffersFormId: '',
+    makeWebhookUrl: '',
   })
   const [hasApiKey, setHasApiKey] = useState(false)
   const [hasWebhookSecret, setHasWebhookSecret] = useState(false)
@@ -28,6 +29,7 @@ export default function SparkLoopSettings({ publicationId }: { publicationId: st
           upscribeId: data.upscribeId || '',
           webhookSecret: '', // Never pre-fill secrets
           afteroffersFormId: data.afteroffersFormId || '',
+          makeWebhookUrl: data.makeWebhookUrl || '',
         })
         setHasApiKey(data.hasApiKey || false)
         setHasWebhookSecret(data.hasWebhookSecret || false)
@@ -158,10 +160,27 @@ export default function SparkLoopSettings({ publicationId }: { publicationId: st
           </p>
         </div>
 
-        {/* Webhook URL (read-only) */}
+        {/* Make.com outbound webhook URL */}
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Webhook URL <span className="font-normal text-gray-400">(configure in SparkLoop)</span>
+            Make.com Subscribe Webhook URL <span className="font-normal text-gray-400">(optional)</span>
+          </label>
+          <input
+            type="url"
+            value={settings.makeWebhookUrl}
+            onChange={(e) => setSettings({ ...settings, makeWebhookUrl: e.target.value })}
+            placeholder="https://hook.eu2.make.com/..."
+            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500"
+          />
+          <p className="text-xs text-gray-400 mt-1">
+            Fires on every SparkLoop subscribe with <code className="font-mono">{'{ subscriber_email, subscriber_id }'}</code>. Leave blank to disable. Replaces the MailerLite-segment-triggered Make scenario.
+          </p>
+        </div>
+
+        {/* Inbound Webhook URL from SparkLoop (read-only) */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            SparkLoop Inbound Webhook URL <span className="font-normal text-gray-400">(configure in SparkLoop)</span>
           </label>
           <div className="flex items-center gap-2">
             <input

--- a/src/lib/sparkloop-client/index.ts
+++ b/src/lib/sparkloop-client/index.ts
@@ -6,3 +6,5 @@
  */
 
 export { SparkLoopService, createSparkLoopService, createSparkLoopServiceForPublication } from './sparkloop-client'
+export { fireMakeWebhook } from './make-webhook'
+export type { MakeWebhookPayload, FireMakeWebhookOptions } from './make-webhook'

--- a/src/lib/sparkloop-client/make-webhook.ts
+++ b/src/lib/sparkloop-client/make-webhook.ts
@@ -1,0 +1,94 @@
+/**
+ * Outbound Make.com webhook for SparkLoop subscribe events.
+ *
+ * Replaces the previous indirection where MailerLite's `sparkloop=true` segment
+ * trigger fired Make. We now POST directly from the subscribe routes so Make
+ * does not depend on email-provider automation. The MailerLite/Beehiiv field
+ * flip still happens for other downstream consumers.
+ */
+
+export interface MakeWebhookPayload {
+  subscriber_email: string
+  subscriber_id: string
+}
+
+export interface FireMakeWebhookOptions {
+  publicationId?: string
+  /** Override the default 5s timeout (ms). */
+  timeoutMs?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 5000
+
+/**
+ * POST a SparkLoop-subscribe payload to a configured Make.com webhook URL.
+ *
+ * Never throws. Returns true on a 2xx response, false otherwise (including
+ * skipped, timeout, network error, non-2xx status). Failures are logged with
+ * the `[MakeWebhook]` prefix and never block the calling request.
+ */
+export async function fireMakeWebhook(
+  url: string | null | undefined,
+  payload: MakeWebhookPayload,
+  opts: FireMakeWebhookOptions = {}
+): Promise<boolean> {
+  const pubTag = opts.publicationId ? ` pub=${opts.publicationId}` : ''
+
+  if (!url || !url.trim()) {
+    console.log(`[MakeWebhook] Skipped: no webhook URL configured${pubTag}`)
+    return false
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(url.trim())
+  } catch {
+    console.error(`[MakeWebhook] Skipped: invalid URL${pubTag}`)
+    return false
+  }
+
+  if (parsed.protocol !== 'https:') {
+    console.error(`[MakeWebhook] Skipped: URL must be https${pubTag}`)
+    return false
+  }
+
+  if (!payload.subscriber_email || !payload.subscriber_id) {
+    console.log(`[MakeWebhook] Skipped: missing subscriber_email or subscriber_id${pubTag}`)
+    return false
+  }
+
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const response = await fetch(parsed.toString(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        subscriber_email: payload.subscriber_email,
+        subscriber_id: payload.subscriber_id,
+      }),
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      console.error(
+        `[MakeWebhook] Non-2xx response: ${response.status} ${response.statusText}${pubTag}`
+      )
+      return false
+    }
+
+    console.log(`[MakeWebhook] Delivered for ${payload.subscriber_email}${pubTag}`)
+    return true
+  } catch (err) {
+    const isAbort = err instanceof Error && err.name === 'AbortError'
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error(
+      `[MakeWebhook] ${isAbort ? `Timeout after ${timeoutMs}ms` : 'Network error'}: ${msg}${pubTag}`
+    )
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}


### PR DESCRIPTION
## Summary

- Removes the dependency on the MailerLite segment-trigger to deliver SparkLoop subscribe events to Make.com.
- All three user-action subscribe routes (`subscribe`, `module-subscribe`, `recommend-subscribe`) now POST `{ subscriber_email, subscriber_id }` directly to a per-publication webhook URL right after the existing email-provider field flip. The `sparkloop=true` field flip is preserved for any other downstream consumers.
- New "Make.com Subscribe Webhook URL" field in the SparkLoop settings tab (per-publication, `https://`-only, blank disables).

## Implementation

- New utility `src/lib/sparkloop-client/make-webhook.ts` (`fireMakeWebhook`): https-only, 5s `AbortController` timeout, never throws, structured `[MakeWebhook]` logging.
- Wired into all three SparkLoop subscribe routes immediately after the field-flip block. Gated on a non-null SparkLoop `subscriberUuid`; bot/IP-blocked paths short-circuit before both the field flip and the webhook (unchanged behavior).
- `GET /api/settings/sparkloop` returns `makeWebhookUrl`; `POST` validates `https://` and persists to `sparkloop_webhook_url` setting key (no migration needed — existing key-value `newsletter_settings` table).

## Out of scope

- The MailerLite segment + segment-triggered Make scenario stay in place; users will switch their Make scenario over to the new webhook URL once verified, then optionally retire the segment automation.
- The `sparkloop=true` field flip itself is unchanged.

## Test plan

- [ ] On staging, set a `webhook.site` URL in the SparkLoop settings tab for a test publication.
- [ ] Trigger each of the three entry points and confirm a single POST to webhook.site per attempt with `{ subscriber_email, subscriber_id: "sub_..." }`:
  - [ ] Popup submit → `POST /api/sparkloop/subscribe`
  - [ ] Newsletter one-click link → `GET /api/sparkloop/module-subscribe?email=…&ref_code=…&issue_id=…`
  - [ ] Landing page subscribe → `POST /api/sparkloop/recommend-subscribe`
- [ ] Confirm `[MakeWebhook] Delivered` log line per request and that the MailerLite/Beehiiv field flip still happens.
- [ ] Failure path: point URL at `https://httpstat.us/500`, run a subscribe, confirm route still returns success and `[MakeWebhook]` logs the non-2xx.
- [ ] Disable: clear the URL via the UI, run a subscribe, confirm `[MakeWebhook] Skipped: no webhook URL configured` and no outbound POST.
- [ ] Tenant isolation: with publication A's URL set and B's blank, confirm a B subscribe does not call A's webhook.
- [ ] Inbound SparkLoop webhook flow unchanged (no Make webhook fires from inbound events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Make.com webhook URL configuration field in SparkLoop settings for outbound integrations.
  * Webhooks now automatically trigger on subscription-related events to enable custom downstream workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->