### PR TITLE
fix(afteroffers): tenant-aware postback + Make webhook on conversion

### DIFF
--- a/src/app/api/afteroffers/map-click/route.ts
+++ b/src/app/api/afteroffers/map-click/route.ts
@@ -7,18 +7,23 @@ import { PUBLICATION_ID } from '@/lib/config'
 const inputSchema = z.object({
   email: z.string().email(),
   click_id: z.string().min(1),
+  publication_id: z.string().uuid().optional(),
 })
 
 export const POST = withApiHandler(
   { authTier: 'public', inputSchema, logContext: 'afteroffers/map-click' },
   async ({ input, logger }) => {
-    const { email, click_id } = input
+    const { email, click_id, publication_id } = input
+
+    // Fall back to env default when the client didn't send publication_id (older
+    // cached bundles, or contexts where the publication isn't known to the form).
+    const effectivePublicationId = publication_id || PUBLICATION_ID
 
     const { error } = await supabaseAdmin
       .from('afteroffers_click_mappings')
       .upsert(
         {
-          publication_id: PUBLICATION_ID,
+          publication_id: effectivePublicationId,
           click_id,
           email,
         },

--- a/src/app/api/webhooks/afteroffers/postback/route.ts
+++ b/src/app/api/webhooks/afteroffers/postback/route.ts
@@ -159,6 +159,23 @@ async function handlePostback(request: Request, logger: ReturnType<typeof import
       const errMsg = mlError instanceof Error ? mlError.message : 'Unknown error'
       logger.error({ error: errMsg, clickId, maskedEmail: maskEmail(email) }, 'Email provider afteroffers_conversion update error (non-fatal)')
     }
+
+    // Fire direct Make.com webhook (same setting as SparkLoop subscribes).
+    // Uses the AfterOffers click_id as subscriber_id since AfterOffers does not
+    // produce a SparkLoop UUID.
+    try {
+      const { getPublicationSetting } = await import('@/lib/publication-settings')
+      const { fireMakeWebhook } = await import('@/lib/sparkloop-client')
+      const webhookUrl = await getPublicationSetting(PUBLICATION_ID, 'sparkloop_webhook_url')
+      await fireMakeWebhook(
+        webhookUrl,
+        { subscriber_email: email, subscriber_id: clickId },
+        { publicationId: PUBLICATION_ID }
+      )
+    } catch (whErr: unknown) {
+      const errMsg = whErr instanceof Error ? whErr.message : 'Unknown error'
+      logger.error({ error: errMsg, clickId, maskedEmail: maskEmail(email) }, 'Make webhook error (non-fatal)')
+    }
   }
 
   return NextResponse.json({ success: true })

--- a/src/app/api/webhooks/afteroffers/postback/route.ts
+++ b/src/app/api/webhooks/afteroffers/postback/route.ts
@@ -43,19 +43,35 @@ async function handlePostback(request: Request, logger: ReturnType<typeof import
     )
   }
 
-  // If email missing, look up from click mapping table
-  if (!email && clickId) {
-    const { data: mapping } = await supabaseAdmin
-      .from('afteroffers_click_mappings')
-      .select('email')
-      .eq('publication_id', PUBLICATION_ID)
-      .eq('click_id', clickId)
-      .maybeSingle()
+  // Resolve the click mapping by click_id alone — the row carries the correct
+  // publication_id, which is the trust anchor for downstream tenant-scoped writes.
+  // If two rows match (theoretical UUID collision across publications), take the
+  // most recent one and warn.
+  let mappingPublicationId: string | undefined
+  const { data: mappings } = await supabaseAdmin
+    .from('afteroffers_click_mappings')
+    .select('publication_id, email, created_at')
+    .eq('click_id', clickId)
+    .order('created_at', { ascending: false })
+    .limit(2)
 
-    if (mapping?.email) {
-      email = mapping.email
+  if (mappings && mappings.length > 0) {
+    mappingPublicationId = mappings[0].publication_id as string
+    if (!email && mappings[0].email) {
+      email = mappings[0].email as string
       logger.info({ clickId }, 'Resolved email from click mapping')
     }
+    if (mappings.length > 1) {
+      logger.warn({ clickId }, 'Multiple click mappings matched — using most recent')
+    }
+  }
+
+  const effectivePublicationId = mappingPublicationId || PUBLICATION_ID
+  if (!mappingPublicationId) {
+    logger.warn(
+      { clickId, fallbackPublicationId: PUBLICATION_ID },
+      'No click mapping found — falling back to env default publication_id'
+    )
   }
 
   const eventType = eventParam && eventParam.trim() !== '' ? eventParam.trim().toLowerCase() : 'conversion'
@@ -92,7 +108,7 @@ async function handlePostback(request: Request, logger: ReturnType<typeof import
     .from('afteroffers_events')
     .upsert(
       {
-        publication_id: PUBLICATION_ID,
+        publication_id: effectivePublicationId,
         click_id: clickId,
         email,
         revenue,
@@ -122,7 +138,7 @@ async function handlePostback(request: Request, logger: ReturnType<typeof import
   if (email && eventType === 'conversion') {
     try {
       const { getEmailProviderSettings } = await import('@/lib/publication-settings')
-      const providerSettings = await getEmailProviderSettings(PUBLICATION_ID)
+      const providerSettings = await getEmailProviderSettings(effectivePublicationId)
 
       if (providerSettings.provider === 'beehiiv') {
         const { updateBeehiivSubscriberField } = await import('@/lib/beehiiv')
@@ -166,11 +182,11 @@ async function handlePostback(request: Request, logger: ReturnType<typeof import
     try {
       const { getPublicationSetting } = await import('@/lib/publication-settings')
       const { fireMakeWebhook } = await import('@/lib/sparkloop-client')
-      const webhookUrl = await getPublicationSetting(PUBLICATION_ID, 'sparkloop_webhook_url')
+      const webhookUrl = await getPublicationSetting(effectivePublicationId, 'sparkloop_webhook_url')
       await fireMakeWebhook(
         webhookUrl,
         { subscriber_email: email, subscriber_id: clickId },
-        { publicationId: PUBLICATION_ID }
+        { publicationId: effectivePublicationId }
       )
     } catch (whErr: unknown) {
       const errMsg = whErr instanceof Error ? whErr.message : 'Unknown error'

--- a/src/app/website/subscribe/subscribe-form.tsx
+++ b/src/app/website/subscribe/subscribe-form.tsx
@@ -104,15 +104,20 @@ export function SubscribeForm({
       // Ignore storage errors
     }
 
-    // Fire-and-forget: map click_id to email for postback attribution
+    // Fire-and-forget: map click_id to email for postback attribution.
+    // Pass publicationId so the postback handler can resolve the correct tenant.
     fetch('/api/afteroffers/map-click', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: subscribedEmail, click_id: clickId }),
+      body: JSON.stringify({
+        email: subscribedEmail,
+        click_id: clickId,
+        ...(publicationId ? { publication_id: publicationId } : {}),
+      }),
     }).catch(() => { /* non-critical */ })
 
     window.location.href = `/subscribe/offers?email=${encodeURIComponent(subscribedEmail)}&click_id=${encodeURIComponent(clickId)}`
-  }, [subscribedEmail])
+  }, [subscribedEmail, publicationId])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/src/components/settings/SparkLoopSettings.tsx
+++ b/src/components/settings/SparkLoopSettings.tsx
@@ -173,7 +173,7 @@ export default function SparkLoopSettings({ publicationId }: { publicationId: st
             className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500"
           />
           <p className="text-xs text-gray-400 mt-1">
-            Fires on every SparkLoop subscribe with <code className="font-mono">{'{ subscriber_email, subscriber_id }'}</code>. Leave blank to disable. Replaces the MailerLite-segment-triggered Make scenario.
+            Fires on every SparkLoop subscribe and every AfterOffers conversion with <code className="font-mono">{'{ subscriber_email, subscriber_id }'}</code>. <code className="font-mono">subscriber_id</code> is the SparkLoop UUID (<code className="font-mono">sub_…</code>) for SparkLoop events and the AfterOffers <code className="font-mono">click_id</code> for AfterOffers events. Leave blank to disable. Replaces the MailerLite-segment-triggered Make scenario.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

Two AfterOffers fixes that landed on staging after PR #218 was merged. Splitting them into a fresh PR per request.

1. **Make webhook on AfterOffers conversion** — extends the direct Make.com webhook from #218 to AfterOffers conversion postbacks. Same payload shape (`{ subscriber_email, subscriber_id }`), same publication-level webhook URL setting (`sparkloop_webhook_url`). `subscriber_id` is the AfterOffers `click_id` since AfterOffers does not produce a SparkLoop UUID.

2. **Tenant-aware postback handler (closes #219)** — replaces the `PUBLICATION_ID` env-default hardcode in the AfterOffers click-mapping write and postback read paths. The `afteroffers_click_mappings` row now carries the correct `publication_id` (passed through from `subscribe-form.tsx`'s existing prop), and the postback resolves it from the row to drive every downstream tenant-scoped operation.

## Files

- `src/app/website/subscribe/subscribe-form.tsx` — pass `publication_id` to `/api/afteroffers/map-click` (prop already in scope).
- `src/app/api/afteroffers/map-click/route.ts` — accept optional `publication_id` (Zod), fall back to env default for cached older bundles.
- `src/app/api/webhooks/afteroffers/postback/route.ts` — look up the click_mapping by `click_id` alone, read `publication_id` off the row, thread it through the events upsert, email-provider field flip, and Make webhook URL lookup. Orphan postbacks (no mapping) and the rare multi-mapping match log warnings and fall back to the env default.

## Backward compatibility

- Single-publication deployments behave identically to today.
- Older browser bundles still POST to `map-click` without `publication_id` and continue to work via the env-default fallback.
- Postbacks for `click_id`s with no stored mapping fall back to the env default and emit `logger.warn` so we can quantify orphan rate.

## Test plan

- [ ] Local/staging build, type-check, lint clean.
- [ ] Subscribe via form on default publication's domain → conversion postback → verify mapping, event row, field flip, and `[MakeWebhook] Delivered` all use the env-default publication_id.
- [ ] On a non-default publication's domain (or with a forced `publication_id` body param), repeat → verify all four operations land on that publication, not the default.
- [ ] Orphan postback (`click_id` with no mapping) → verify `logger.warn` line, fallback to env default, no crash.
- [ ] Make webhook fires per AfterOffers conversion in addition to per SparkLoop subscribe (verify two distinct payload shapes for `subscriber_id`: `sub_…` for SparkLoop, `click_id` for AfterOffers).

Closes #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)