### PR TITLE
feat(make-webhook): at-most-once dedup per (publication, subscriber)

### DIFF
--- a/db/migrations/20260429_make_webhook_fires.sql
+++ b/db/migrations/20260429_make_webhook_fires.sql
@@ -1,0 +1,19 @@
+-- Tracks which subscribers have already triggered the Make.com subscribe webhook
+-- per publication. Used as an at-most-once dedup gate so a subscriber who signs
+-- up via SparkLoop and later converts via AfterOffers (or vice-versa) only fires
+-- the webhook once. Cross-source, per-publication.
+
+CREATE TABLE IF NOT EXISTS make_webhook_fires (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  publication_id UUID NOT NULL REFERENCES publications(id) ON DELETE CASCADE,
+  subscriber_email TEXT NOT NULL,
+  source TEXT NOT NULL CHECK (source IN ('sparkloop', 'afteroffers')),
+  subscriber_id TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  CONSTRAINT make_webhook_fires_pub_email_unique UNIQUE (publication_id, subscriber_email)
+);
+
+CREATE INDEX IF NOT EXISTS idx_make_webhook_fires_pub
+  ON make_webhook_fires(publication_id);
+
+ALTER TABLE make_webhook_fires ENABLE ROW LEVEL SECURITY;

--- a/src/app/api/sparkloop/module-subscribe/route.ts
+++ b/src/app/api/sparkloop/module-subscribe/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { createHash } from 'crypto'
-import { createSparkLoopServiceForPublication, fireMakeWebhook } from '@/lib/sparkloop-client'
+import { createSparkLoopServiceForPublication, fireMakeWebhook, claimMakeWebhookFire } from '@/lib/sparkloop-client'
 import { supabaseAdmin } from '@/lib/supabase'
 import { checkUserAgent } from '@/lib/bot-detection'
 import { isIPExcluded, IPExclusion } from '@/lib/ip-utils'
@@ -270,13 +270,24 @@ export const GET = withApiHandler(
     }
 
     // Fire direct Make.com webhook (replaces the MailerLite-segment-triggered path).
+    // Dedup'd so the same subscriber doesn't trigger Make twice.
     if (subscriberUuid) {
       const webhookUrl = await getPublicationSetting(publicationId, 'sparkloop_webhook_url')
-      await fireMakeWebhook(
-        webhookUrl,
-        { subscriber_email: email, subscriber_id: subscriberUuid },
-        { publicationId }
-      )
+      if (webhookUrl) {
+        const claimed = await claimMakeWebhookFire({
+          publicationId,
+          subscriberEmail: email,
+          source: 'sparkloop',
+          subscriberId: subscriberUuid,
+        })
+        if (claimed) {
+          await fireMakeWebhook(
+            webhookUrl,
+            { subscriber_email: email, subscriber_id: subscriberUuid },
+            { publicationId }
+          )
+        }
+      }
     } else {
       console.log('[SparkLoop Module Subscribe] Skipping Make webhook: no subscriber_uuid available')
     }

--- a/src/app/api/sparkloop/recommend-subscribe/route.ts
+++ b/src/app/api/sparkloop/recommend-subscribe/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { withApiHandler } from '@/lib/api-handler'
 import { createHash } from 'crypto'
-import { createSparkLoopServiceForPublication, fireMakeWebhook } from '@/lib/sparkloop-client'
+import { createSparkLoopServiceForPublication, fireMakeWebhook, claimMakeWebhookFire } from '@/lib/sparkloop-client'
 import { supabaseAdmin } from '@/lib/supabase'
 import { checkUserAgent } from '@/lib/bot-detection'
 import { isIPExcluded, IPExclusion } from '@/lib/ip-utils'
@@ -256,13 +256,24 @@ export const POST = withApiHandler(
     }
 
     // Fire direct Make.com webhook (replaces the MailerLite-segment-triggered path).
+    // Dedup'd so the same subscriber doesn't trigger Make twice.
     if (subscriberUuid) {
       const webhookUrl = await getPublicationSetting(publicationId, 'sparkloop_webhook_url')
-      await fireMakeWebhook(
-        webhookUrl,
-        { subscriber_email: email, subscriber_id: subscriberUuid },
-        { publicationId }
-      )
+      if (webhookUrl) {
+        const claimed = await claimMakeWebhookFire({
+          publicationId,
+          subscriberEmail: email,
+          source: 'sparkloop',
+          subscriberId: subscriberUuid,
+        })
+        if (claimed) {
+          await fireMakeWebhook(
+            webhookUrl,
+            { subscriber_email: email, subscriber_id: subscriberUuid },
+            { publicationId }
+          )
+        }
+      }
     } else {
       console.log('[SparkLoop Recommend Subscribe] Skipping Make webhook: no subscriber_uuid available')
     }

--- a/src/app/api/sparkloop/subscribe/route.ts
+++ b/src/app/api/sparkloop/subscribe/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { withApiHandler } from '@/lib/api-handler'
 import { createHash } from 'crypto'
 import { cookies } from 'next/headers'
-import { createSparkLoopServiceForPublication, fireMakeWebhook } from '@/lib/sparkloop-client'
+import { createSparkLoopServiceForPublication, fireMakeWebhook, claimMakeWebhookFire } from '@/lib/sparkloop-client'
 import { supabaseAdmin } from '@/lib/supabase'
 import { MailerLiteService } from '@/lib/mailerlite'
 import { PUBLICATION_ID } from '@/lib/config'
@@ -236,14 +236,25 @@ export const POST = withApiHandler(
 
     // Fire direct Make.com webhook (replaces the MailerLite-segment-triggered path).
     // Fires on the same trigger condition as the field flip — user-action subscribe
-    // intent — and only when we have the SparkLoop subscriber_uuid.
+    // intent — and only when we have the SparkLoop subscriber_uuid. Dedup'd so the
+    // same subscriber doesn't trigger Make twice across SparkLoop/AfterOffers.
     if (subscriberUuid) {
       const webhookUrl = await getPublicationSetting(publicationId, 'sparkloop_webhook_url')
-      await fireMakeWebhook(
-        webhookUrl,
-        { subscriber_email: email, subscriber_id: subscriberUuid },
-        { publicationId }
-      )
+      if (webhookUrl) {
+        const claimed = await claimMakeWebhookFire({
+          publicationId,
+          subscriberEmail: email,
+          source: 'sparkloop',
+          subscriberId: subscriberUuid,
+        })
+        if (claimed) {
+          await fireMakeWebhook(
+            webhookUrl,
+            { subscriber_email: email, subscriber_id: subscriberUuid },
+            { publicationId }
+          )
+        }
+      }
     } else {
       console.log('[SparkLoop Subscribe] Skipping Make webhook: no subscriber_uuid available')
     }

--- a/src/app/api/webhooks/afteroffers/postback/route.ts
+++ b/src/app/api/webhooks/afteroffers/postback/route.ts
@@ -181,13 +181,23 @@ async function handlePostback(request: Request, logger: ReturnType<typeof import
     // produce a SparkLoop UUID.
     try {
       const { getPublicationSetting } = await import('@/lib/publication-settings')
-      const { fireMakeWebhook } = await import('@/lib/sparkloop-client')
+      const { fireMakeWebhook, claimMakeWebhookFire } = await import('@/lib/sparkloop-client')
       const webhookUrl = await getPublicationSetting(effectivePublicationId, 'sparkloop_webhook_url')
-      await fireMakeWebhook(
-        webhookUrl,
-        { subscriber_email: email, subscriber_id: clickId },
-        { publicationId: effectivePublicationId }
-      )
+      if (webhookUrl) {
+        const claimed = await claimMakeWebhookFire({
+          publicationId: effectivePublicationId,
+          subscriberEmail: email,
+          source: 'afteroffers',
+          subscriberId: clickId,
+        })
+        if (claimed) {
+          await fireMakeWebhook(
+            webhookUrl,
+            { subscriber_email: email, subscriber_id: clickId },
+            { publicationId: effectivePublicationId }
+          )
+        }
+      }
     } catch (whErr: unknown) {
       const errMsg = whErr instanceof Error ? whErr.message : 'Unknown error'
       logger.error({ error: errMsg, clickId, maskedEmail: maskEmail(email) }, 'Make webhook error (non-fatal)')

--- a/src/lib/sparkloop-client/index.ts
+++ b/src/lib/sparkloop-client/index.ts
@@ -6,5 +6,5 @@
  */
 
 export { SparkLoopService, createSparkLoopService, createSparkLoopServiceForPublication } from './sparkloop-client'
-export { fireMakeWebhook } from './make-webhook'
-export type { MakeWebhookPayload, FireMakeWebhookOptions } from './make-webhook'
+export { fireMakeWebhook, claimMakeWebhookFire } from './make-webhook'
+export type { MakeWebhookPayload, FireMakeWebhookOptions, ClaimMakeWebhookFireArgs } from './make-webhook'

--- a/src/lib/sparkloop-client/make-webhook.ts
+++ b/src/lib/sparkloop-client/make-webhook.ts
@@ -7,9 +7,66 @@
  * flip still happens for other downstream consumers.
  */
 
+import { supabaseAdmin } from '@/lib/supabase'
+
 export interface MakeWebhookPayload {
   subscriber_email: string
   subscriber_id: string
+}
+
+export interface ClaimMakeWebhookFireArgs {
+  publicationId: string
+  subscriberEmail: string
+  source: 'sparkloop' | 'afteroffers'
+  subscriberId: string
+}
+
+/**
+ * Atomically claim the right to fire the Make webhook for this subscriber.
+ *
+ * Inserts a row into `make_webhook_fires` keyed on (publication_id, subscriber_email).
+ * Returns true on a fresh insert (caller should fire), false if a row already
+ * exists (caller should skip). Email is lowercased before insert/check so
+ * case variants don't bypass the dedup.
+ *
+ * Cross-source, per-publication: a subscriber who triggered via SparkLoop will
+ * not re-trigger via AfterOffers (and vice-versa) for the same publication.
+ *
+ * Returns false on DB error too — failing closed (skip the fire) is safer than
+ * failing open (potential duplicate). The error is logged.
+ */
+export async function claimMakeWebhookFire(
+  args: ClaimMakeWebhookFireArgs
+): Promise<boolean> {
+  const email = args.subscriberEmail.trim().toLowerCase()
+  if (!email) return false
+
+  const { data, error } = await supabaseAdmin
+    .from('make_webhook_fires')
+    .insert({
+      publication_id: args.publicationId,
+      subscriber_email: email,
+      source: args.source,
+      subscriber_id: args.subscriberId,
+    })
+    .select('id')
+    .maybeSingle()
+
+  if (error) {
+    // 23505 = unique violation: already fired for this (publication, email).
+    if ((error as { code?: string }).code === '23505') {
+      console.log(
+        `[MakeWebhook] Skipped: already fired for ${email} pub=${args.publicationId} (existing claim)`
+      )
+      return false
+    }
+    console.error(
+      `[MakeWebhook] Claim insert failed (failing closed): ${error.message} pub=${args.publicationId}`
+    )
+    return false
+  }
+
+  return !!data
 }
 
 export interface FireMakeWebhookOptions {


### PR DESCRIPTION
## Summary

Prevent the same subscriber from triggering the Make.com webhook more than once per publication. Cross-source: a subscriber who signs up via SparkLoop will not re-trigger the webhook on a later AfterOffers conversion (and vice-versa) for the same publication.

## Stacked on #220

This PR's base is \`fix/afteroffers-tenant-aware-webhook\` (PR #220), not \`master\`. The dedup logic touches the AfterOffers postback handler that's introduced in PR #220. Once #220 merges to master, GitHub will auto-rebase this PR onto master and the diff will collapse to just the dedup commit.

**Merge order: #220 → this PR.**

## Implementation

- New migration \`db/migrations/20260429_make_webhook_fires.sql\` — table keyed on \`(publication_id, subscriber_email)\` with a unique constraint, plus \`source\` (\`'sparkloop' | 'afteroffers'\`) and \`subscriber_id\` columns for diagnostics.
- New helper \`claimMakeWebhookFire({ publicationId, subscriberEmail, source, subscriberId })\` in \`src/lib/sparkloop-client/make-webhook.ts\` does an atomic insert. Returns \`true\` on fresh claim (caller fires the webhook), \`false\` on Postgres unique violation \`23505\` (caller skips with a \`[MakeWebhook] Skipped: already fired …\` log line). DB errors also return \`false\` — fails closed to avoid duplicate triggers.
- Email is normalized to lowercase before insert/check so case variants can't bypass dedup.
- All four call sites (3 SparkLoop routes + AfterOffers postback) wrap their existing \`fireMakeWebhook\` call with \`claimMakeWebhookFire\` first.

## Migration step before deploy

Run \`npm run migrate:staging\` (then \`npm run migrate:prod\` after staging verification) to create the \`make_webhook_fires\` table before the new code runs in that environment. Without the table, \`claimMakeWebhookFire\` will log a DB error and fail closed → no webhooks fire until the table exists.

## Test plan

- [ ] \`npm run migrate:staging\` then build/type-check/lint clean.
- [ ] Configure a webhook URL on a test publication and a webhook.site target.
- [ ] Subscribe via SparkLoop popup with email \`A@example.com\` → confirm 1 POST to webhook.site, 1 row in \`make_webhook_fires\`.
- [ ] Subscribe again via the same SparkLoop route with the same email → confirm 0 new POSTs and \`[MakeWebhook] Skipped: already fired\` log line.
- [ ] Subscribe via SparkLoop module-subscribe with the same email → confirm 0 new POSTs (cross-route dedup).
- [ ] Trigger an AfterOffers conversion for the same email → confirm 0 new POSTs (cross-source dedup).
- [ ] Subscribe with a fresh email \`B@example.com\` → confirm 1 POST.
- [ ] Subscribe \`B@EXAMPLE.com\` (uppercase) → confirm 0 new POSTs (case-insensitive dedup).
- [ ] On a different publication, subscribe with \`A@example.com\` → confirm 1 POST (per-publication, not global).

🤖 Generated with [Claude Code](https://claude.com/claude-code)