### PR TITLE
test(newsletter-templates): add coverage for 2,316-line module (#58)

### DIFF
--- a/src/lib/newsletter-templates/__tests__/_fixtures.ts
+++ b/src/lib/newsletter-templates/__tests__/_fixtures.ts
@@ -1,0 +1,109 @@
+// src/lib/newsletter-templates/__tests__/_fixtures.ts
+import type { BusinessSettings, IssueSnapshot, SectionItem } from '../types'
+
+export function makeBusinessSettings(overrides: Partial<BusinessSettings> = {}): BusinessSettings {
+  return {
+    primaryColor: '#1877F2',
+    secondaryColor: '#10B981',
+    tertiaryColor: '#F59E0B',
+    quaternaryColor: '#8B5CF6',
+    headingFont: 'Georgia, serif',
+    bodyFont: 'Arial, sans-serif',
+    websiteUrl: 'https://test.example.com',
+    headerImageUrl: 'https://test.example.com/header.png',
+    newsletterName: 'Test Newsletter',
+    businessName: 'Test Business',
+    facebookEnabled: false,
+    facebookUrl: '',
+    twitterEnabled: false,
+    twitterUrl: '',
+    linkedinEnabled: false,
+    linkedinUrl: '',
+    instagramEnabled: false,
+    instagramUrl: '',
+    ...overrides,
+  }
+}
+
+export function makeIssue(overrides: Record<string, any> = {}) {
+  return {
+    id: 'issue-test-1',
+    publication_id: 'pub-test-1',
+    date: '2026-04-29',
+    mailerlite_issue_id: 'ml-1234',
+    status: 'draft',
+    welcome_summary: null,
+    subject_line: null,
+    poll_id: null,
+    module_articles: [],
+    ...overrides,
+  }
+}
+
+export function makeArticle(overrides: Record<string, any> = {}) {
+  return {
+    id: 'art-1',
+    headline: 'Test Headline',
+    content: 'Body content here.',
+    is_active: true,
+    rank: 1,
+    ai_image_url: null,
+    image_alt: null,
+    trade_image_url: null,
+    trade_image_alt: null,
+    article_module_id: 'mod-art-1',
+    rss_post: { source_url: 'https://source.example.com/article', image_url: null, image_alt: null },
+    ...overrides,
+  }
+}
+
+export function makeArticleModule(overrides: Record<string, any> = {}) {
+  return {
+    id: 'mod-art-1',
+    publication_id: 'pub-test-1',
+    name: 'Top Stories',
+    display_order: 10,
+    is_active: true,
+    show_name: true,
+    block_order: ['title', 'body'],
+    config: {},
+    ...overrides,
+  }
+}
+
+export function makeAdvertisement(overrides: Record<string, any> = {}) {
+  return {
+    id: 'ad-1',
+    title: 'Sponsor Title',
+    body: '<p>Sponsor body.</p>',
+    image_url: 'https://test.example.com/ad.png',
+    image_alt: 'Sponsor image',
+    button_text: 'Learn more',
+    button_url: 'https://sponsor.example.com',
+    cta_text: 'Click here →',
+    company_name: 'SponsorCo',
+    ...overrides,
+  }
+}
+
+export function makeSnapshot(overrides: Partial<IssueSnapshot> = {}): IssueSnapshot {
+  return {
+    issue: makeIssue(),
+    formattedDate: 'Wednesday, April 29, 2026',
+    businessSettings: makeBusinessSettings(),
+    sortedSections: [] as SectionItem[],
+    isReview: false,
+    preheaderText: '',
+    pollSelections: [],
+    promptSelections: [],
+    aiAppSelections: [],
+    textBoxSelections: [],
+    feedbackModule: null,
+    sparkloopRecSelections: [],
+    adSelections: [],
+    articlesByModule: {},
+    breakingNewsArticles: [],
+    beyondFeedArticles: [],
+    ...overrides,
+  }
+}

--- a/src/lib/newsletter-templates/__tests__/ads.test.ts
+++ b/src/lib/newsletter-templates/__tests__/ads.test.ts
@@ -1,0 +1,166 @@
+// src/lib/newsletter-templates/__tests__/ads.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { makeBusinessSettings, makeIssue, makeAdvertisement } from './_fixtures'
+
+// Mock Supabase + the ad-modules renderer (used by generateAdModulesSection)
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+    }),
+  },
+}))
+
+vi.mock('@/lib/ad-modules', () => ({
+  AdModuleRenderer: {
+    renderForArchive: vi.fn(() => '<div class="ad-mock">AD HTML</div>'),
+  },
+}))
+
+vi.mock('@/lib/html-normalizer', () => ({
+  normalizeEmailHtml: vi.fn((html: string) => html), // pass-through
+}))
+
+import {
+  generateAdvertorialHtml,
+  generateAdvertorialSection,
+  generateAdModulesSection,
+  generateDiningDealsSection,
+} from '../ads'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('generateAdvertorialHtml (pure renderer)', () => {
+  const baseStyle = {
+    primaryColor: '#1877F2',
+    headingFont: 'Georgia, serif',
+    bodyFont: 'Arial, sans-serif',
+  }
+
+  it('renders title and body', () => {
+    const html = generateAdvertorialHtml(
+      { title: 'Buy Our Thing', body: '<p>It is great</p>', button_url: 'https://x.test' },
+      baseStyle
+    )
+    expect(html).toContain('Buy Our Thing')
+    expect(html).toContain('<p>It is great</p>')
+  })
+
+  it('omits image row when image_url is missing', () => {
+    const html = generateAdvertorialHtml(
+      { title: 'No Image Ad', body: 'body', button_url: '#' },
+      baseStyle
+    )
+    expect(html).not.toContain('<img ')
+  })
+
+  it('renders image with sanitized alt when image_url present', () => {
+    // sanitizeAltText strips quotes entirely: Has "quotes" → Has quotes
+    const html = generateAdvertorialHtml(
+      {
+        title: 'Headline',
+        body: 'body',
+        button_url: 'https://x.test',
+        image_url: 'https://test.example.com/x.png',
+        image_alt: `Has "quotes"`,
+      },
+      baseStyle
+    )
+    expect(html).toContain('https://test.example.com/x.png')
+    expect(html).toContain("alt='Has quotes'")
+  })
+
+  it('escapes special chars in cta_text', () => {
+    const html = generateAdvertorialHtml(
+      {
+        title: 'T',
+        body: 'b',
+        button_url: 'https://x.test',
+        cta_text: '<script>alert(1)</script>',
+      },
+      baseStyle
+    )
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+
+  it('omits CTA row when button_url is "#" (no destination)', () => {
+    const html = generateAdvertorialHtml(
+      { title: 'T', body: 'b', button_url: '#', cta_text: 'Click me' },
+      baseStyle
+    )
+    // CTA only renders when buttonUrl !== '#'. The link wrapping the CTA shouldn't be there.
+    expect(html).not.toMatch(/<a[^>]*>Click me<\/a>/)
+  })
+
+  it('uses sectionName in header (defaults to "Advertorial")', () => {
+    const def = generateAdvertorialHtml(
+      { title: 't', body: 'b', button_url: '#' },
+      baseStyle
+    )
+    expect(def).toContain('>Advertorial<')
+
+    const named = generateAdvertorialHtml(
+      { title: 't', body: 'b', button_url: '#' },
+      { ...baseStyle, sectionName: 'Sponsored' }
+    )
+    expect(named).toContain('>Sponsored<')
+  })
+})
+
+describe('generateAdvertorialSection (DB-fallback path)', () => {
+  it('returns empty string when no ad selected', async () => {
+    // Default mock returns { data: null } from maybeSingle
+    const html = await generateAdvertorialSection(makeIssue(), false, 'Advertorial', makeBusinessSettings())
+    expect(html).toBe('')
+  })
+})
+
+describe('generateAdModulesSection', () => {
+  it('returns empty string when adSelections is empty array', async () => {
+    const html = await generateAdModulesSection(
+      makeIssue(),
+      'mod-ad-1',
+      makeBusinessSettings(),
+      [] // pre-fetched, empty
+    )
+    expect(html).toBe('')
+  })
+
+  it('filters pre-fetched selections by moduleId', async () => {
+    const adSelections = [
+      { ad_module: { id: 'mod-ad-1', name: 'Module A', display_order: 1, block_order: ['title', 'body'] }, advertisement: makeAdvertisement() },
+      { ad_module: { id: 'mod-ad-2', name: 'Module B', display_order: 2, block_order: ['title'] }, advertisement: makeAdvertisement({ title: 'Other Ad' }) },
+    ]
+    const html = await generateAdModulesSection(
+      makeIssue(),
+      'mod-ad-1',
+      makeBusinessSettings(),
+      adSelections
+    )
+    // Mock returns '<div class="ad-mock">AD HTML</div>' once per matching selection.
+    expect(html).toBe('<div class="ad-mock">AD HTML</div>')
+  })
+
+  it('passes a tracked URL (not raw) to the renderer', async () => {
+    const { AdModuleRenderer } = await import('@/lib/ad-modules')
+    const adSelections = [
+      { ad_module: { id: 'mod-ad-1', name: 'Module A', display_order: 1, block_order: ['title'] }, advertisement: makeAdvertisement({ button_url: 'https://sponsor.example.com' }) },
+    ]
+    await generateAdModulesSection(makeIssue(), 'mod-ad-1', makeBusinessSettings(), adSelections)
+    const callArg = vi.mocked(AdModuleRenderer.renderForArchive).mock.calls[0][1]
+    expect(callArg.button_url).toContain('/api/link-tracking/click?')
+  })
+})
+
+describe('generateDiningDealsSection (stub)', () => {
+  it('always returns empty string', async () => {
+    expect(await generateDiningDealsSection(makeIssue())).toBe('')
+  })
+})

--- a/src/lib/newsletter-templates/__tests__/articles.test.ts
+++ b/src/lib/newsletter-templates/__tests__/articles.test.ts
@@ -1,0 +1,146 @@
+// src/lib/newsletter-templates/__tests__/articles.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { makeBusinessSettings, makeIssue, makeArticle, makeArticleModule } from './_fixtures'
+
+// Mock Supabase before importing the SUT — articles.ts imports supabaseAdmin at top.
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null }),
+    }),
+  },
+}))
+
+import { generateArticleModuleSection } from '../articles'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('generateArticleModuleSection', () => {
+  it('returns empty string when moduleArticles is empty', async () => {
+    const html = await generateArticleModuleSection(
+      makeIssue(),
+      'mod-art-1',
+      false,
+      makeBusinessSettings(),
+      [], // empty articles
+      makeArticleModule()
+    )
+    expect(html).toBe('')
+  })
+
+  it('returns empty string when moduleConfig is missing and DB returns null', async () => {
+    const html = await generateArticleModuleSection(
+      makeIssue(),
+      'unknown-module-id',
+      false,
+      makeBusinessSettings()
+      // moduleArticles, moduleConfig both undefined → falls back to mocked DB → null
+    )
+    expect(html).toBe('')
+  })
+})
+
+describe('generateArticleModuleSection — content rendering', () => {
+  it('renders headline and body, wraps source URL with tracking', async () => {
+    const article = makeArticle({
+      headline: 'Major AI release',
+      content: 'Big news today.',
+      rss_post: { source_url: 'https://news.example.com/post-1', image_url: null, image_alt: null },
+    })
+    const html = await generateArticleModuleSection(
+      makeIssue(),
+      'mod-art-1',
+      false,
+      makeBusinessSettings(),
+      [article],
+      makeArticleModule({ block_order: ['title', 'body'] })
+    )
+    expect(html).toContain('Major AI release')
+    expect(html).toContain('Big news today.')
+    // Tracked URL prefix from wrapTrackingUrl
+    expect(html).toContain('/api/link-tracking/click?')
+    // Original URL is encoded as the `url` query param
+    expect(html).toContain(encodeURIComponent('https://news.example.com/post-1'))
+  })
+
+  it('uses bodyFont from settings, never hardcoded', async () => {
+    const article = makeArticle()
+    const html = await generateArticleModuleSection(
+      makeIssue(),
+      'mod-art-1',
+      false,
+      makeBusinessSettings({ bodyFont: 'CustomFont, sans-serif' }),
+      [article],
+      makeArticleModule()
+    )
+    expect(html).toContain('CustomFont, sans-serif')
+  })
+
+  it('renders trade_image when block_order includes trade_image and trade_image_url is set', async () => {
+    const article = makeArticle({
+      trade_image_url: 'https://test.example.com/trade.png',
+      trade_image_alt: 'Trade graphic',
+    })
+    const html = await generateArticleModuleSection(
+      makeIssue(),
+      'mod-art-1',
+      false,
+      makeBusinessSettings(),
+      [article],
+      makeArticleModule({ block_order: ['trade_image', 'title', 'body'] })
+    )
+    expect(html).toContain('https://test.example.com/trade.png')
+    expect(html).toContain('alt="Trade graphic"')
+  })
+
+  it('sanitizes alt text — strips quotes from headline-derived alt', async () => {
+    const article = makeArticle({
+      headline: `It's a "great" headline`,
+      ai_image_url: 'https://test.example.com/ai.png',
+      image_alt: null,
+    })
+    const html = await generateArticleModuleSection(
+      makeIssue(),
+      'mod-art-1',
+      false,
+      makeBusinessSettings(),
+      [article],
+      makeArticleModule({ block_order: ['ai_image', 'title'] })
+    )
+    // sanitizeAltText strips both ' and " — quoted form should NOT appear in alt attribute
+    expect(html).not.toContain(`alt="It's a "great" headline"`)
+    expect(html).toContain('alt="Its a great headline"')
+  })
+
+  it('hides module name header when show_name is false', async () => {
+    const article = makeArticle()
+    const html = await generateArticleModuleSection(
+      makeIssue(),
+      'mod-art-1',
+      false,
+      makeBusinessSettings(),
+      [article],
+      makeArticleModule({ name: 'Hidden Module', show_name: false })
+    )
+    expect(html).not.toContain('Hidden Module')
+  })
+
+  it('appends unsubscribe link when includeUnsubscribeLink=true', async () => {
+    const article = makeArticle()
+    const html = await generateArticleModuleSection(
+      makeIssue(),
+      'mod-art-1',
+      true, // includeUnsubscribeLink
+      makeBusinessSettings(),
+      [article],
+      makeArticleModule()
+    )
+    expect(html).toContain('{$unsubscribe}')
+    expect(html).toContain('unsubscribe')
+  })
+})

--- a/src/lib/newsletter-templates/__tests__/build-snapshot.test.ts
+++ b/src/lib/newsletter-templates/__tests__/build-snapshot.test.ts
@@ -19,6 +19,8 @@ vi.mock('@/lib/supabase', () => {
       limit: vi.fn(() => chain),
       single: vi.fn(() => Promise.resolve(result)),
       maybeSingle: vi.fn(() => Promise.resolve(result)),
+      // Make the chain itself awaitable for queries that don't end with .order()/.single().
+      // This is intentionally resolve-only — we don't need rejection paths in these tests.
       then: (resolve: any) => Promise.resolve(result).then(resolve),
     }
     return chain
@@ -65,6 +67,8 @@ import { buildIssueSnapshot } from '../build-snapshot'
 beforeEach(() => {
   // Reset all per-table data
   for (const k of Object.keys(tableData)) delete tableData[k]
+  // Reset selector mock call history (does NOT reset mock implementations)
+  vi.clearAllMocks()
 })
 
 describe('buildIssueSnapshot', () => {

--- a/src/lib/newsletter-templates/__tests__/build-snapshot.test.ts
+++ b/src/lib/newsletter-templates/__tests__/build-snapshot.test.ts
@@ -1,0 +1,150 @@
+// src/lib/newsletter-templates/__tests__/build-snapshot.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { makeIssue } from './_fixtures'
+
+// ---- Mock supabaseAdmin so each `from(table)` returns a query builder
+// whose final await resolves to whatever this file dictates per-table.
+const tableData: Record<string, any[]> = {}
+
+vi.mock('@/lib/supabase', () => {
+  const builder = (table: string) => {
+    const result = { data: tableData[table] ?? [], error: null }
+    const chain: any = {
+      select: vi.fn(() => chain),
+      eq: vi.fn(() => chain),
+      in: vi.fn(() => chain),
+      order: vi.fn(() => Promise.resolve(result)),
+      // Some callers use .limit(...).maybeSingle() — not used by build-snapshot itself,
+      // but provide for safety.
+      limit: vi.fn(() => chain),
+      single: vi.fn(() => Promise.resolve(result)),
+      maybeSingle: vi.fn(() => Promise.resolve(result)),
+      then: (resolve: any) => Promise.resolve(result).then(resolve),
+    }
+    return chain
+  }
+  return {
+    supabaseAdmin: { from: vi.fn((t: string) => builder(t)) },
+  }
+})
+
+// fetchBusinessSettings is called inside buildIssueSnapshot — short-circuit it.
+vi.mock('../helpers', async () => {
+  const actual = await vi.importActual<typeof import('../helpers')>('../helpers')
+  return {
+    ...actual,
+    fetchBusinessSettings: vi.fn().mockResolvedValue({
+      primaryColor: '#000', secondaryColor: '#000', tertiaryColor: '#000', quaternaryColor: '#000',
+      headingFont: 'A', bodyFont: 'A',
+      websiteUrl: 'https://test', headerImageUrl: '', newsletterName: 'N', businessName: 'B',
+      facebookEnabled: false, facebookUrl: '', twitterEnabled: false, twitterUrl: '',
+      linkedinEnabled: false, linkedinUrl: '', instagramEnabled: false, instagramUrl: '',
+    }),
+  }
+})
+
+// All dynamic selector imports — return empty by default.
+vi.mock('@/lib/poll-modules', () => ({
+  PollModuleSelector: { getIssuePollSelections: vi.fn().mockResolvedValue([]) },
+}))
+vi.mock('@/lib/ai-app-modules', () => ({
+  AppModuleSelector: { getIssueSelections: vi.fn().mockResolvedValue([]) },
+}))
+vi.mock('@/lib/text-box-modules', () => ({
+  TextBoxModuleSelector: { getIssueSelections: vi.fn().mockResolvedValue([]) },
+}))
+vi.mock('@/lib/feedback-modules', () => ({
+  FeedbackModuleSelector: { getFeedbackModuleWithBlocks: vi.fn().mockResolvedValue(null) },
+}))
+vi.mock('@/lib/sparkloop-rec-modules', () => ({
+  SparkLoopRecModuleSelector: { getIssueSelections: vi.fn().mockResolvedValue({ selections: [] }) },
+}))
+
+import { buildIssueSnapshot } from '../build-snapshot'
+
+beforeEach(() => {
+  // Reset all per-table data
+  for (const k of Object.keys(tableData)) delete tableData[k]
+})
+
+describe('buildIssueSnapshot', () => {
+  it('returns a fully-shaped snapshot with empty arrays by default', async () => {
+    const snapshot = await buildIssueSnapshot(makeIssue())
+    expect(snapshot.issue.id).toBe('issue-test-1')
+    expect(snapshot.formattedDate).toContain('April') // "Wednesday, April 29, 2026"
+    expect(snapshot.sortedSections).toEqual([])
+    expect(snapshot.pollSelections).toEqual([])
+    expect(snapshot.aiAppSelections).toEqual([])
+    expect(snapshot.textBoxSelections).toEqual([])
+    expect(snapshot.feedbackModule).toBeNull()
+    expect(snapshot.sparkloopRecSelections).toEqual([])
+    expect(snapshot.adSelections).toEqual([])
+    expect(snapshot.articlesByModule).toEqual({})
+    expect(snapshot.isReview).toBe(false)
+  })
+})
+
+describe('buildIssueSnapshot — sortedSections', () => {
+  it('merges all module types into one list sorted by display_order', async () => {
+    tableData['newsletter_sections'] = [{ id: 'sec-3', name: 'Top', display_order: 30, is_active: true, section_type: 'breaking_news' }]
+    tableData['ad_modules'] = [{ id: 'ad-1', name: 'AdMod', display_order: 10, is_active: true }]
+    tableData['poll_modules'] = [{ id: 'poll-1', name: 'PollMod', display_order: 20, is_active: true }]
+    tableData['prompt_modules'] = []
+    tableData['article_modules'] = []
+    tableData['text_box_modules'] = []
+    tableData['sparkloop_rec_modules'] = []
+    tableData['feedback_modules'] = []
+
+    const snap = await buildIssueSnapshot(makeIssue())
+    expect(snap.sortedSections.map(s => s.data.id)).toEqual(['ad-1', 'poll-1', 'sec-3'])
+    expect(snap.sortedSections.map(s => s.type)).toEqual(['ad_module', 'poll_module', 'section'])
+  })
+
+  it('filters out legacy primary_articles and secondary_articles section types', async () => {
+    tableData['newsletter_sections'] = [
+      { id: 'old1', name: 'P', display_order: 1, is_active: true, section_type: 'primary_articles' },
+      { id: 'old2', name: 'S', display_order: 2, is_active: true, section_type: 'secondary_articles' },
+      { id: 'keep', name: 'BN', display_order: 3, is_active: true, section_type: 'breaking_news' },
+    ]
+    tableData['ad_modules'] = []
+    tableData['poll_modules'] = []
+    tableData['prompt_modules'] = []
+    tableData['article_modules'] = []
+    tableData['text_box_modules'] = []
+    tableData['sparkloop_rec_modules'] = []
+    tableData['feedback_modules'] = []
+
+    const snap = await buildIssueSnapshot(makeIssue())
+    expect(snap.sortedSections.map(s => s.data.id)).toEqual(['keep'])
+  })
+})
+
+describe('buildIssueSnapshot — preheaderText', () => {
+  it('prefers welcome_summary over subject_line', async () => {
+    const snap = await buildIssueSnapshot(makeIssue({ welcome_summary: 'Welcome line', subject_line: 'Subject line' }))
+    expect(snap.preheaderText).toBe('Welcome line')
+  })
+
+  it('falls back to subject_line when welcome_summary is empty', async () => {
+    const snap = await buildIssueSnapshot(makeIssue({ welcome_summary: null, subject_line: 'Subject line' }))
+    expect(snap.preheaderText).toBe('Subject line')
+  })
+
+  it('truncates preheader to 120 chars', async () => {
+    const long = 'A'.repeat(200)
+    const snap = await buildIssueSnapshot(makeIssue({ welcome_summary: long }))
+    expect(snap.preheaderText).toHaveLength(120)
+  })
+
+  it('returns empty string when both fields are empty', async () => {
+    const snap = await buildIssueSnapshot(makeIssue({ welcome_summary: '', subject_line: '' }))
+    expect(snap.preheaderText).toBe('')
+  })
+})
+
+describe('buildIssueSnapshot — isReview flag', () => {
+  it('respects isReview option (default false)', async () => {
+    expect((await buildIssueSnapshot(makeIssue())).isReview).toBe(false)
+    expect((await buildIssueSnapshot(makeIssue(), { isReview: true })).isReview).toBe(true)
+  })
+})

--- a/src/lib/newsletter-templates/__tests__/full-newsletter.test.ts
+++ b/src/lib/newsletter-templates/__tests__/full-newsletter.test.ts
@@ -1,6 +1,6 @@
 // src/lib/newsletter-templates/__tests__/full-newsletter.test.ts
 import { describe, it, expect, vi } from 'vitest'
-import { makeSnapshot, makeBusinessSettings, makeIssue } from './_fixtures'
+import { makeSnapshot } from './_fixtures'
 
 vi.mock('@/lib/supabase', () => ({
   supabaseAdmin: {
@@ -21,11 +21,12 @@ import { renderNewsletterFromSnapshot } from '../full-newsletter'
 
 describe('renderNewsletterFromSnapshot', () => {
   it('composes a non-empty HTML document for an empty snapshot', async () => {
-    const html = await renderNewsletterFromSnapshot(makeSnapshot())
+    const snapshot = makeSnapshot()
+    const html = await renderNewsletterFromSnapshot(snapshot)
     expect(html).toContain('<!DOCTYPE html>')
     expect(html).toContain('</html>')
-    // Header date must appear
-    expect(html).toContain('Wednesday, April 29, 2026')
+    // Header date must appear — derive from fixture, not a hardcoded string
+    expect(html).toContain(snapshot.formattedDate)
   })
 
   it('omits the review banner when isReview is false', async () => {
@@ -41,10 +42,12 @@ describe('renderNewsletterFromSnapshot', () => {
 
   it('returns header + footer only when sortedSections is empty', async () => {
     const html = await renderNewsletterFromSnapshot(makeSnapshot())
-    // No section content between header and footer — just whitespace/structure.
-    // Both must exist.
+    // Both header and footer must exist.
     expect(html).toContain('View Online')   // header
     expect(html).toContain('Unsubscribe')   // footer
+    // And no module/section content in between (the empty fixture has no articles, ads, etc.)
+    expect(html).not.toContain('Top Stories')      // default article module name from fixture
+    expect(html).not.toContain('Sponsor Title')    // default ad title from fixture
   })
 
   it('rejects with prefixed error when an internal generator throws', async () => {

--- a/src/lib/newsletter-templates/__tests__/full-newsletter.test.ts
+++ b/src/lib/newsletter-templates/__tests__/full-newsletter.test.ts
@@ -1,0 +1,57 @@
+// src/lib/newsletter-templates/__tests__/full-newsletter.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { makeSnapshot, makeBusinessSettings, makeIssue } from './_fixtures'
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockResolvedValue({ data: [] }),
+    }),
+  },
+}))
+vi.mock('@/lib/publication-settings', () => ({
+  getBusinessSettings: vi.fn().mockResolvedValue({}),
+}))
+vi.mock('@/lib/bot-detection', () => ({ HONEYPOT_CONFIG: { SECTION_NAME: 'Honeypot' } }))
+vi.mock('@/lib/config', () => ({ STORAGE_PUBLIC_URL: 'https://test.storage' }))
+
+import { renderNewsletterFromSnapshot } from '../full-newsletter'
+
+describe('renderNewsletterFromSnapshot', () => {
+  it('composes a non-empty HTML document for an empty snapshot', async () => {
+    const html = await renderNewsletterFromSnapshot(makeSnapshot())
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain('</html>')
+    // Header date must appear
+    expect(html).toContain('Wednesday, April 29, 2026')
+  })
+
+  it('omits the review banner when isReview is false', async () => {
+    const html = await renderNewsletterFromSnapshot(makeSnapshot({ isReview: false }))
+    expect(html).not.toContain('Newsletter Review')
+  })
+
+  it('includes the review banner when isReview is true', async () => {
+    const html = await renderNewsletterFromSnapshot(makeSnapshot({ isReview: true }))
+    expect(html).toContain('Newsletter Review')
+    expect(html).toContain('preview of tomorrow')
+  })
+
+  it('returns header + footer only when sortedSections is empty', async () => {
+    const html = await renderNewsletterFromSnapshot(makeSnapshot())
+    // No section content between header and footer — just whitespace/structure.
+    // Both must exist.
+    expect(html).toContain('View Online')   // header
+    expect(html).toContain('Unsubscribe')   // footer
+  })
+
+  it('rejects with prefixed error when an internal generator throws', async () => {
+    const broken = makeSnapshot({
+      // Pass a snapshot where issue is missing required fields to trigger downstream error
+      issue: undefined as any,
+    })
+    await expect(renderNewsletterFromSnapshot(broken)).rejects.toThrow(/HTML generation failed/)
+  })
+})

--- a/src/lib/newsletter-templates/__tests__/helpers.test.ts
+++ b/src/lib/newsletter-templates/__tests__/helpers.test.ts
@@ -1,0 +1,106 @@
+// src/lib/newsletter-templates/__tests__/helpers.test.ts
+import { describe, it, expect } from 'vitest'
+import {
+  getLightBackground,
+  formatEventDate,
+  formatEventTime,
+  getEventEmoji,
+  getArticleEmoji,
+  getBreakingNewsEmoji,
+  getAIAppEmoji,
+} from '../helpers'
+
+describe('getLightBackground', () => {
+  it('blends a hex color with white at 90:10 (white-heavy)', () => {
+    // Pure black (#000000) blended 10% with 90% white → rgb(230, 230, 230)
+    expect(getLightBackground('#000000')).toBe('rgb(230, 230, 230)')
+  })
+
+  it('handles hex without leading #', () => {
+    expect(getLightBackground('FFFFFF')).toBe('rgb(255, 255, 255)')
+  })
+
+  it('produces a tinted (not full) version of a saturated color', () => {
+    // #FF0000 (red) → 10% red + 90% white → rgb(255, 230, 230)
+    expect(getLightBackground('#FF0000')).toBe('rgb(255, 230, 230)')
+  })
+})
+
+describe('formatEventDate', () => {
+  it('parses YYYY-MM-DD as a local date (no UTC drift)', () => {
+    // Critical: this MUST use local parsing, not new Date(str).
+    // 2026-01-01 should ALWAYS render as Jan 1 regardless of host timezone.
+    expect(formatEventDate('2026-01-01')).toBe('Thursday, January 1')
+  })
+
+  it('formats mid-year date', () => {
+    expect(formatEventDate('2026-07-04')).toBe('Saturday, July 4')
+  })
+})
+
+describe('formatEventTime', () => {
+  it('formats whole-hour times without minutes', () => {
+    const start = '2026-04-29T14:00:00'
+    const end = '2026-04-29T17:00:00'
+    expect(formatEventTime(start, end)).toBe('2PM - 5PM')
+  })
+
+  it('includes minutes when non-zero', () => {
+    const start = '2026-04-29T09:30:00'
+    const end = '2026-04-29T11:00:00'
+    expect(formatEventTime(start, end)).toBe('9:30AM - 11AM')
+  })
+
+  it('handles midnight (12AM) and noon (12PM)', () => {
+    expect(formatEventTime('2026-04-29T00:00:00', '2026-04-29T12:00:00')).toBe('12AM - 12PM')
+  })
+})
+
+describe('getEventEmoji', () => {
+  it('matches a category keyword', () => {
+    expect(getEventEmoji('Saturday Yoga in the Park', '')).toBe('🧘')
+  })
+
+  it('returns party emoji default when no keywords match', () => {
+    expect(getEventEmoji('Random Untagged Event', '')).toBe('🎉')
+  })
+
+  it('checks venue text in addition to title', () => {
+    // Empty title with amphitheater venue should match music
+    expect(getEventEmoji('Outdoor Show', 'Riverside Amphitheater')).toBe('🎶')
+  })
+})
+
+describe('getArticleEmoji', () => {
+  it('matches AI/automation as 🤖', () => {
+    expect(getArticleEmoji('New AI tool released', '')).toBe('🤖')
+  })
+
+  it('matches tax content as 💰', () => {
+    expect(getArticleEmoji('Year-end tax planning', '')).toBe('💰')
+  })
+
+  it('returns default 📈 when nothing matches', () => {
+    expect(getArticleEmoji('Generic announcement', 'No keywords here')).toBe('📈')
+  })
+})
+
+describe('getBreakingNewsEmoji', () => {
+  it('returns default 🔴 when nothing matches', () => {
+    expect(getBreakingNewsEmoji('Something happened', 'somewhere')).toBe('🔴')
+  })
+
+  it('matches fraud/scandal as ⚠️', () => {
+    expect(getBreakingNewsEmoji('Major fraud uncovered', '')).toBe('⚠️')
+  })
+})
+
+describe('getAIAppEmoji', () => {
+  it('matches accounting category', () => {
+    expect(getAIAppEmoji('AppName', 'Accounting', 'desc')).toBe('📊')
+  })
+
+  it('returns default 🔧 when nothing matches', () => {
+    expect(getAIAppEmoji('AppName', 'OtherCategory', 'desc')).toBe('🔧')
+  })
+})

--- a/src/lib/newsletter-templates/__tests__/layout.test.ts
+++ b/src/lib/newsletter-templates/__tests__/layout.test.ts
@@ -1,0 +1,164 @@
+// src/lib/newsletter-templates/__tests__/layout.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { makeBusinessSettings } from './_fixtures'
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockResolvedValue({ data: [] }),
+    }),
+  },
+}))
+
+vi.mock('@/lib/publication-settings', () => ({
+  getBusinessSettings: vi.fn(),
+}))
+
+vi.mock('@/lib/bot-detection', () => ({
+  HONEYPOT_CONFIG: { SECTION_NAME: 'Honeypot' },
+}))
+
+vi.mock('@/lib/config', () => ({
+  STORAGE_PUBLIC_URL: 'https://test.storage',
+}))
+
+import { generateNewsletterHeader, generateNewsletterFooter } from '../layout'
+
+describe('generateNewsletterHeader', () => {
+  it('includes the formatted date in the body', async () => {
+    const html = await generateNewsletterHeader(
+      'Wednesday, April 29, 2026',
+      '2026-04-29',
+      'ml-1',
+      'pub-1',
+      makeBusinessSettings()
+    )
+    expect(html).toContain('Wednesday, April 29, 2026')
+  })
+
+  it('renders headerImageUrl when present', async () => {
+    const html = await generateNewsletterHeader(
+      'date',
+      '2026-04-29',
+      'ml-1',
+      'pub-1',
+      makeBusinessSettings({ headerImageUrl: 'https://test.example.com/banner.png' })
+    )
+    expect(html).toContain('https://test.example.com/banner.png')
+  })
+
+  it('falls back to newsletterName text banner when headerImageUrl is empty', async () => {
+    const html = await generateNewsletterHeader(
+      'date',
+      '2026-04-29',
+      'ml-1',
+      'pub-1',
+      makeBusinessSettings({ headerImageUrl: '', newsletterName: 'Fallback Name' })
+    )
+    expect(html).not.toContain('<img alt="Fallback Name"')
+    expect(html).toContain('>Fallback Name<')
+  })
+
+  it('emits hidden preheader div when preheaderText provided', async () => {
+    const html = await generateNewsletterHeader(
+      'date',
+      '2026-04-29',
+      'ml-1',
+      'pub-1',
+      makeBusinessSettings(),
+      'Tomorrow: AI for accountants — what changed this week.'
+    )
+    expect(html).toContain('Tomorrow: AI for accountants')
+    expect(html).toContain('display:none')
+  })
+
+  it('omits preheader div when preheaderText is empty/undefined', async () => {
+    const html = await generateNewsletterHeader(
+      'date',
+      '2026-04-29',
+      'ml-1',
+      'pub-1',
+      makeBusinessSettings()
+    )
+    expect(html).not.toContain('display:none;font-size:1px')
+  })
+
+  it('wraps Sign Up link with tracking when issueDate provided', async () => {
+    const html = await generateNewsletterHeader(
+      'date',
+      '2026-04-29',
+      'ml-1',
+      'pub-1',
+      makeBusinessSettings({ websiteUrl: 'https://test.example.com' })
+    )
+    expect(html).toContain('/api/link-tracking/click?')
+  })
+})
+
+describe('generateNewsletterFooter', () => {
+  it('renders only enabled social icons', async () => {
+    const html = await generateNewsletterFooter(
+      '2026-04-29',
+      'ml-1',
+      'pub-1',
+      makeBusinessSettings({
+        facebookEnabled: true,
+        facebookUrl: 'https://fb.test/x',
+        twitterEnabled: false,
+        twitterUrl: 'https://tw.test/x',
+        linkedinEnabled: true,
+        linkedinUrl: 'https://li.test/x',
+      })
+    )
+    expect(html).toContain('alt="Facebook"')
+    expect(html).toContain('alt="LinkedIn"')
+    expect(html).not.toContain('alt="Twitter/X"')
+    expect(html).not.toContain('alt="Instagram"')
+  })
+
+  it('omits the social section entirely when no icons are enabled', async () => {
+    const html = await generateNewsletterFooter(
+      '2026-04-29',
+      'ml-1',
+      'pub-1',
+      makeBusinessSettings() // all *Enabled false by default
+    )
+    expect(html).not.toContain('alt="Facebook"')
+    expect(html).not.toContain('alt="Twitter/X"')
+  })
+
+  it('embeds honeypot link inside the address comma', async () => {
+    const html = await generateNewsletterFooter(
+      '2026-04-29',
+      'ml-1',
+      'pub-1',
+      makeBusinessSettings()
+    )
+    // Honeypot is wrapped in an <a> on the comma after "Saint Joseph".
+    // Look for the linked-comma pattern.
+    expect(html).toMatch(/Saint Joseph<a [^>]*>,<\/a>/)
+  })
+
+  it('includes unsubscribe link with email merge tag', async () => {
+    const html = await generateNewsletterFooter(
+      '2026-04-29',
+      'ml-1',
+      'pub-1',
+      makeBusinessSettings()
+    )
+    expect(html).toContain('Unsubscribe')
+    expect(html).toContain('{$email}')
+  })
+
+  it('includes current year in copyright', async () => {
+    const html = await generateNewsletterFooter(
+      '2026-04-29',
+      'ml-1',
+      'pub-1',
+      makeBusinessSettings()
+    )
+    expect(html).toContain(`©${new Date().getFullYear()}`)
+  })
+})

--- a/src/lib/newsletter-templates/__tests__/layout.test.ts
+++ b/src/lib/newsletter-templates/__tests__/layout.test.ts
@@ -71,7 +71,7 @@ describe('generateNewsletterHeader', () => {
       'Tomorrow: AI for accountants — what changed this week.'
     )
     expect(html).toContain('Tomorrow: AI for accountants')
-    expect(html).toContain('display:none')
+    expect(html).toContain('display:none;font-size:1px')
   })
 
   it('omits preheader div when preheaderText is empty/undefined', async () => {
@@ -153,12 +153,13 @@ describe('generateNewsletterFooter', () => {
   })
 
   it('includes current year in copyright', async () => {
+    const year = new Date().getFullYear()
     const html = await generateNewsletterFooter(
       '2026-04-29',
       'ml-1',
       'pub-1',
       makeBusinessSettings()
     )
-    expect(html).toContain(`©${new Date().getFullYear()}`)
+    expect(html).toContain(`©${year}`)
   })
 })

--- a/src/lib/newsletter-templates/__tests__/sections.test.ts
+++ b/src/lib/newsletter-templates/__tests__/sections.test.ts
@@ -1,0 +1,133 @@
+// src/lib/newsletter-templates/__tests__/sections.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { makeBusinessSettings, makeIssue } from './_fixtures'
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null }),
+    }),
+  },
+}))
+
+import {
+  generateWelcomeSection,
+  generatePollSection,
+  generateBreakingNewsSection,
+  generateBeyondTheFeedSection,
+  generateLocalEventsSection,
+  generateWordleSection,
+  generateMinnesotaGetawaysSection,
+  generateRoadWorkSection,
+} from '../sections'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('generateWelcomeSection', () => {
+  it('returns empty string when intro, tagline, and summary are all blank', async () => {
+    expect(await generateWelcomeSection(null, null, null, 'pub-1', makeBusinessSettings())).toBe('')
+    expect(await generateWelcomeSection('', '   ', '', 'pub-1', makeBusinessSettings())).toBe('')
+  })
+
+  it('always includes the personalized greeting merge tag', async () => {
+    const html = await generateWelcomeSection('Welcome back', null, null, 'pub-1', makeBusinessSettings())
+    expect(html).toContain(`{$name|default('Accounting Pro')}`)
+  })
+
+  it('uses bodyFont from business settings, never hardcoded', async () => {
+    const html = await generateWelcomeSection('Welcome', null, null, 'pub-1', makeBusinessSettings({ bodyFont: 'CustomFont, sans-serif' }))
+    expect(html).toContain('CustomFont, sans-serif')
+  })
+
+  it('renders all three parts when all three are provided', async () => {
+    const html = await generateWelcomeSection(
+      'Hello there',
+      'The bold tagline',
+      'A short summary.',
+      'pub-1',
+      makeBusinessSettings()
+    )
+    expect(html).toContain('The bold tagline')
+    expect(html).toContain('A short summary.')
+  })
+})
+
+describe('generateBreakingNewsSection', () => {
+  it('returns empty string when breakingNewsArticles is empty', async () => {
+    const html = await generateBreakingNewsSection(makeIssue(), makeBusinessSettings(), [])
+    expect(html).toBe('')
+  })
+
+  it('renders title with tracked URL using "Breaking News" as section name', async () => {
+    const selections = [{
+      post: { id: 'p1', ai_title: null, title: 'Headline One', ai_summary: null, description: 'Summary one', source_url: 'https://news.test/1' },
+    }]
+    const html = await generateBreakingNewsSection(makeIssue(), makeBusinessSettings(), selections)
+    expect(html).toContain('Headline One')
+    expect(html).toContain('Summary one')
+    expect(html).toContain('/api/link-tracking/click?')
+    // URLSearchParams encodes spaces as '+', so 'Breaking News' → 'Breaking+News'
+    expect(html).toContain('Breaking+News')
+  })
+
+  it('prefers ai_title and ai_summary over original when present', async () => {
+    const selections = [{
+      post: { id: 'p1', ai_title: 'AI Headline', title: 'Original Headline', ai_summary: 'AI summary', description: 'Original desc', source_url: 'https://x.test' },
+    }]
+    const html = await generateBreakingNewsSection(makeIssue(), makeBusinessSettings(), selections)
+    expect(html).toContain('AI Headline')
+    expect(html).toContain('AI summary')
+    expect(html).not.toContain('Original Headline')
+  })
+})
+
+describe('generateBeyondTheFeedSection', () => {
+  it('returns empty string when beyondFeedArticles is empty', async () => {
+    const html = await generateBeyondTheFeedSection(makeIssue(), makeBusinessSettings(), [])
+    expect(html).toBe('')
+  })
+
+  it('uses "Beyond the Feed" as the tracked section name', async () => {
+    const selections = [{
+      post: { id: 'p1', ai_title: 'A', title: 'A', ai_summary: 'B', description: 'B', source_url: 'https://x.test' },
+    }]
+    const html = await generateBeyondTheFeedSection(makeIssue(), makeBusinessSettings(), selections)
+    // URLSearchParams encodes spaces as '+', so 'Beyond the Feed' → 'Beyond+the+Feed'
+    expect(html).toContain('Beyond+the+Feed')
+  })
+})
+
+describe('generatePollSection', () => {
+  it('returns empty string when sent issue has no poll_id', async () => {
+    const html = await generatePollSection(
+      { id: 'i1', publication_id: 'p1', status: 'sent', poll_id: null },
+      makeBusinessSettings()
+    )
+    expect(html).toBe('')
+  })
+
+  it('returns empty string when DB returns no active poll for draft', async () => {
+    // Default mock single() returns { data: null }
+    const html = await generatePollSection(
+      { id: 'i1', publication_id: 'p1', status: 'draft' },
+      makeBusinessSettings()
+    )
+    expect(html).toBe('')
+  })
+})
+
+describe('stub sections (disabled features)', () => {
+  it('all return empty strings', async () => {
+    const issue = makeIssue()
+    expect(await generateLocalEventsSection(issue)).toBe('')
+    expect(await generateWordleSection(issue)).toBe('')
+    expect(await generateMinnesotaGetawaysSection(issue)).toBe('')
+    expect(await generateRoadWorkSection(issue)).toBe('')
+  })
+})

--- a/src/lib/newsletter-templates/__tests__/sections.test.ts
+++ b/src/lib/newsletter-templates/__tests__/sections.test.ts
@@ -14,6 +14,36 @@ vi.mock('@/lib/supabase', () => ({
   },
 }))
 
+vi.mock('@/lib/poll-modules', () => ({
+  PollModuleSelector: { getIssuePollSelections: vi.fn().mockResolvedValue([]) },
+  PollModuleRenderer: { renderPollModule: vi.fn().mockResolvedValue({ html: '<poll/>' }) },
+}))
+
+vi.mock('@/lib/ai-app-modules', () => ({
+  AppModuleSelector: { getIssueSelections: vi.fn().mockResolvedValue([]) },
+  AppModuleRenderer: { renderModule: vi.fn().mockResolvedValue({ html: '<ai/>', moduleName: 'm', appCount: 0 }) },
+}))
+
+vi.mock('@/lib/prompt-modules', () => ({
+  PromptModuleSelector: { getIssuePromptSelections: vi.fn().mockResolvedValue([]) },
+  PromptModuleRenderer: { renderPromptModule: vi.fn().mockResolvedValue({ html: '<prompt/>' }) },
+}))
+
+vi.mock('@/lib/text-box-modules', () => ({
+  TextBoxModuleSelector: { getIssueSelections: vi.fn().mockResolvedValue([]) },
+  TextBoxModuleRenderer: { renderModule: vi.fn().mockResolvedValue({ html: '<tb/>' }) },
+}))
+
+vi.mock('@/lib/feedback-modules', () => ({
+  FeedbackModuleSelector: { getFeedbackModuleWithBlocks: vi.fn().mockResolvedValue(null) },
+  FeedbackModuleRenderer: { renderFeedbackModule: vi.fn().mockResolvedValue({ html: '<fb/>' }) },
+}))
+
+vi.mock('@/lib/sparkloop-rec-modules', () => ({
+  SparkLoopRecModuleSelector: { getIssueSelections: vi.fn().mockResolvedValue({ selections: [] }) },
+  SparkLoopRecModuleRenderer: { renderSection: vi.fn(() => '<slr/>') },
+}))
+
 import {
   generateWelcomeSection,
   generatePollSection,
@@ -23,6 +53,12 @@ import {
   generateWordleSection,
   generateMinnesotaGetawaysSection,
   generateRoadWorkSection,
+  generatePollModulesSection,
+  generateAIAppsSection,
+  generatePromptModulesSection,
+  generateTextBoxModuleSection,
+  generateFeedbackModuleSection,
+  generateSparkLoopRecModuleSection,
 } from '../sections'
 
 beforeEach(() => {
@@ -135,5 +171,62 @@ describe('stub sections (disabled features)', () => {
     expect(await generateWordleSection(issue)).toBe('')
     expect(await generateMinnesotaGetawaysSection(issue)).toBe('')
     expect(await generateRoadWorkSection(issue)).toBe('')
+  })
+})
+
+describe('module-delegate sections — empty-state', () => {
+  it('generatePollModulesSection returns "" when no selection matches moduleId', async () => {
+    const html = await generatePollModulesSection(
+      { id: 'i1', publication_id: 'p1' },
+      'mod-poll-x',
+      makeBusinessSettings(),
+      [] // empty selections
+    )
+    expect(html).toBe('')
+  })
+
+  it('generateAIAppsSection returns "" when aiAppSelections is empty', async () => {
+    const html = await generateAIAppsSection(makeIssue(), makeBusinessSettings(), [])
+    expect(html).toBe('')
+  })
+
+  it('generatePromptModulesSection returns "" when promptSelections is empty', async () => {
+    const html = await generatePromptModulesSection(
+      { id: 'i1', publication_id: 'p1' },
+      'mod-prompt-x',
+      makeBusinessSettings(),
+      []
+    )
+    expect(html).toBe('')
+  })
+
+  it('generateTextBoxModuleSection returns "" when textBoxSelections is empty', async () => {
+    const html = await generateTextBoxModuleSection(
+      { id: 'i1', publication_id: 'p1' },
+      'mod-tb-x',
+      makeBusinessSettings(),
+      []
+    )
+    expect(html).toBe('')
+  })
+
+  it('generateFeedbackModuleSection returns "" when feedbackModule is null', async () => {
+    const html = await generateFeedbackModuleSection(
+      { id: 'i1', publication_id: 'p1' },
+      'mod-fb-x',
+      makeBusinessSettings(),
+      null
+    )
+    expect(html).toBe('')
+  })
+
+  it('generateSparkLoopRecModuleSection returns "" when selections empty', async () => {
+    const html = await generateSparkLoopRecModuleSection(
+      { id: 'i1', publication_id: 'p1' },
+      'mod-slr-x',
+      makeBusinessSettings(),
+      []
+    )
+    expect(html).toBe('')
   })
 })

--- a/src/lib/newsletter-templates/__tests__/sections.test.ts
+++ b/src/lib/newsletter-templates/__tests__/sections.test.ts
@@ -84,7 +84,7 @@ describe('generateWelcomeSection', () => {
   // NOTE: sections.ts:27-34 computes a `fullIntro` variable but never uses it —
   // the `intro` argument is silently dropped from rendered output. This test
   // characterizes that current (buggy) behavior so we'd notice if it changed.
-  // TODO: file follow-up issue to fix the dead code in generateWelcomeSection.
+  // TODO(#222): fix the dead code in generateWelcomeSection.
   it('renders greeting, tagline, and summary (intro arg currently unused — see source bug)', async () => {
     const html = await generateWelcomeSection(
       'Hello there',

--- a/src/lib/newsletter-templates/__tests__/sections.test.ts
+++ b/src/lib/newsletter-templates/__tests__/sections.test.ts
@@ -45,7 +45,11 @@ describe('generateWelcomeSection', () => {
     expect(html).toContain('CustomFont, sans-serif')
   })
 
-  it('renders all three parts when all three are provided', async () => {
+  // NOTE: sections.ts:27-34 computes a `fullIntro` variable but never uses it —
+  // the `intro` argument is silently dropped from rendered output. This test
+  // characterizes that current (buggy) behavior so we'd notice if it changed.
+  // TODO: file follow-up issue to fix the dead code in generateWelcomeSection.
+  it('renders greeting, tagline, and summary (intro arg currently unused — see source bug)', async () => {
     const html = await generateWelcomeSection(
       'Hello there',
       'The bold tagline',
@@ -55,6 +59,8 @@ describe('generateWelcomeSection', () => {
     )
     expect(html).toContain('The bold tagline')
     expect(html).toContain('A short summary.')
+    expect(html).toContain(`{$name|default('Accounting Pro')}`)
+    expect(html).not.toContain('Hello there')
   })
 })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
       SUPABASE_ANON_KEY: 'test-anon-key',
       SUPABASE_SERVICE_ROLE_KEY: 'test-service-role-key',
       OPENAI_API_KEY: 'test-openai-key',
+      // Pin timezone and locale so date/time tests are reproducible across CI environments.
+      TZ: 'UTC',
+      LANG: 'en_US.UTF-8',
     },
   },
 })


### PR DESCRIPTION
## Summary

Adds test coverage to `src/lib/newsletter-templates/` — the highest-risk untested module in the codebase per issue #58 (priority:p0). One-character changes here previously could break every subscriber's inbox with no automated catch.

**Test deltas**
- Before: 21 files, 369 tests
- After: 28 files, 448 tests (+79 tests across 8 new test files)

Closes #58.

## What's covered

| File | Tests | Focus |
|---|---|---|
| `helpers.test.ts` | 18 | Color math, date/time formatting, 4 emoji selectors (pure functions) |
| `articles.test.ts` | 8 | `generateArticleModuleSection` — empty states, tracked URLs, alt sanitization, block_order, show_name, unsubscribe link |
| `ads.test.ts` | 11 | `generateAdvertorialHtml` (pure renderer), `generateAdvertorialSection` empty path, `generateAdModulesSection` filtering + tracked URL passing, `generateDiningDealsSection` stub |
| `layout.test.ts` | 11 | Header (date, image fallback, preheader toggle, sign-up tracking), footer (selective social icons, honeypot in address comma, unsubscribe, copyright year) |
| `sections.test.ts` | 18 | Welcome (4), Breaking News (3), Beyond the Feed (2), Poll (2), stub sections (1), and 6 module-delegate empty-state branches (poll/AI/prompt/text-box/feedback/sparkloop) |
| `build-snapshot.test.ts` | 8 | `buildIssueSnapshot` shape, `display_order` merging, legacy section filtering, preheader truncation/precedence, `isReview` flag |
| `full-newsletter.test.ts` | 5 | `renderNewsletterFromSnapshot` composition, review banner toggle, header/footer presence, error wrapper |
| `_fixtures.ts` | — | Shared factories (`makeBusinessSettings`, `makeIssue`, `makeArticle`, `makeArticleModule`, `makeAdvertisement`, `makeSnapshot`) |

## Cross-cutting changes

- **`vitest.config.ts`**: pinned `TZ=UTC` and `LANG=en_US.UTF-8` for reproducible date/time tests across CI environments.
- **`.gitignore`**: added `.worktrees/` for git-worktree based development workflows.

## Bugs discovered

- **#222 — `generateWelcomeSection` silently drops `intro` argument.** Caught while writing characterization tests. The function computes a `fullIntro` variable at `sections.ts:27-34` but never uses it; the `intro` parameter is silently dropped from rendered HTML. The current (buggy) behavior is now pinned by a test in `sections.test.ts` with a `TODO(#222)` reference. **Not fixed in this PR** (out of scope — would deserve its own change).

## Plan-vs-implementation deviations (all improvements)

1. Tracking URL assertions corrected from `encodeURIComponent('Breaking News')` (`%20`) to `'Breaking+News'` (`+`). `wrapTrackingUrl` uses `URLSearchParams`, which form-encodes spaces. The plan was wrong; the tests were corrected.
2. Hardcoded date strings replaced with `snapshot.formattedDate` references where possible — less brittle.
3. Welcome section test extended with a negative assertion + TODO to characterize the discovered bug rather than silently passing.

## Not covered (out of scope)

- Live DB integration of `buildIssueSnapshot` (would need a test database).
- Visual regression of rendered HTML across email clients (would need email-rendering harnesses).
- Positive-path test for `articlesByModule` grouping in `build-snapshot.ts` (gap in plan; consider follow-up).

## Test plan

- [x] `npm run test:run` — 448/448 PASS
- [x] `npm run type-check` — PASS
- [ ] `npm run lint` — local run is blocked by a worktree-inside-parent ESLint plugin conflict (both `.eslintrc.json` files load `@next/next`). Will validate via CI on this PR.

## Discovered later

The repository's `git remote get-url origin` output exposes a personal access token in cleartext. Worth rotating that PAT and removing the credential from the local git config (`git remote set-url origin https://github.com/Venture-Formations/aiprodaily.git`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for newsletter template functionality, including tests for ad generation, article rendering, issue snapshots, full newsletter assembly, helper utilities, layout components, and section generators.

* **Chores**
  * Updated test environment variables and Git configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->