### PR TITLE
fix(beehiiv): use real per-subscriber stats field names

### DIFF
--- a/src/lib/__tests__/beehiiv.test.ts
+++ b/src/lib/__tests__/beehiiv.test.ts
@@ -10,7 +10,42 @@ describe('getBeehiivSubscriberStats', () => {
     vi.clearAllMocks()
   })
 
-  it('returns parsed stats for an active subscriber with opens', async () => {
+  it('returns parsed stats using actual Beehiiv field names (total_unique_opened, total_received)', async () => {
+    // Mirrors a real production response shape (verified against Beehiiv API 2026-04-30).
+    mockedAxios.get = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        data: {
+          id: 'sub_abc123',
+          status: 'active',
+          stats: {
+            total_sent: 6,
+            total_received: 6,
+            total_unique_opened: 5,
+            total_clicked: 3,
+            total_unique_clicked: 2,
+            open_rate: 83.33,
+            click_rate: 40.0,
+          },
+        },
+      },
+    })
+
+    const result = await getBeehiivSubscriberStats('user@example.com', 'pub_xyz', 'key123')
+
+    expect(result.found).toBe(true)
+    expect(result.status).toBe('active')
+    expect(result.uniqueOpens).toBe(5)
+    expect(result.emailsReceived).toBe(6)
+    expect(result.subscriptionId).toBe('sub_abc123')
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://api.beehiiv.com/v2/publications/pub_xyz/subscriptions/by_email/user%40example.com?expand=stats',
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer key123' }) }),
+    )
+  })
+
+  it('falls back to legacy unique_opens / emails_received field names', async () => {
+    // Defensive: if Beehiiv ever returns the older field names we used to assume.
     mockedAxios.get = vi.fn().mockResolvedValue({
       status: 200,
       data: {
@@ -27,15 +62,8 @@ describe('getBeehiivSubscriberStats', () => {
 
     const result = await getBeehiivSubscriberStats('user@example.com', 'pub_xyz', 'key123')
 
-    expect(result.found).toBe(true)
-    expect(result.status).toBe('active')
     expect(result.uniqueOpens).toBe(4)
     expect(result.emailsReceived).toBe(10)
-    expect(result.subscriptionId).toBe('sub_abc123')
-    expect(mockedAxios.get).toHaveBeenCalledWith(
-      'https://api.beehiiv.com/v2/publications/pub_xyz/subscriptions/by_email/user%40example.com?expand=stats',
-      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer key123' }) }),
-    )
   })
 
   it('returns found=false on 404', async () => {

--- a/src/lib/beehiiv.ts
+++ b/src/lib/beehiiv.ts
@@ -90,17 +90,30 @@ export async function getBeehiivSubscriberStats(
       return { found: false }
     }
     const stats = data.stats || {}
+    // Beehiiv's per-subscriber stats endpoint uses total_unique_opened / total_received.
+    // Older field names (unique_opens, opens, emails_received) are kept as fallbacks for
+    // resilience to API variation, but production responses use the total_* names.
     const uniqueOpens =
-      typeof stats.unique_opens === 'number'
+      typeof stats.total_unique_opened === 'number'
+        ? stats.total_unique_opened
+        : typeof stats.unique_opens === 'number'
         ? stats.unique_opens
         : typeof stats.opens === 'number'
         ? stats.opens
+        : 0
+    const emailsReceived =
+      typeof stats.total_received === 'number'
+        ? stats.total_received
+        : typeof stats.total_sent === 'number'
+        ? stats.total_sent
+        : typeof stats.emails_received === 'number'
+        ? stats.emails_received
         : 0
     return {
       found: true,
       status: typeof data.status === 'string' ? data.status : undefined,
       uniqueOpens,
-      emailsReceived: typeof stats.emails_received === 'number' ? stats.emails_received : 0,
+      emailsReceived,
       subscriptionId: typeof data.id === 'string' ? data.id : undefined,
     }
   } catch (error: any) {


### PR DESCRIPTION
## Summary

Hotfix for the Beehiiv first-open Make webhook gate (PR #225). Discovered via end-to-end production test that the cron always saw 0 opens regardless of actual subscriber engagement.

## Root cause

Beehiiv's per-subscriber stats endpoint (`/subscriptions/by_email/{email}?expand=stats`) returns `total_unique_opened` and `total_received`. Our `getBeehiivSubscriberStats` was looking for `unique_opens` / `opens` / `emails_received` — which are the field names from the per-POST stats endpoint (different schema). Bad assumption from spec-phase research.

Without this fix, the gate would NEVER transition pending rows to fired, no matter how many emails the subscriber opened. They'd just sit pending until the 7-day soft expiry hit.

## Verification

Direct API call to Beehiiv for a real Trader Leak subscriber returned:
```
"stats": {
  "total_sent": 6, "total_received": 6,
  "total_unique_opened": 5,
  "total_clicked": 3, "total_unique_clicked": 2,
  "open_rate": 83.33, "click_rate": 40.0
}
```

Our parser now prefers `total_unique_opened` / `total_received`, with the legacy field names kept as fallbacks for resilience. Test updated to mirror the verified real response shape; a second test asserts the legacy fallback still works.

## Test plan

- [x] 17/17 unit tests passing locally (added 1 new test for real shape, kept 1 for fallback)
- [x] Type-check clean
- [x] Pre-push hooks passed
- [ ] Post-merge: trigger cron once, verify the existing pending Trader Leak row transitions to `fired` and Make.com receives the payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)