### PR TITLE
test(ad-scheduler): add unit test coverage (closes #59)

### DIFF
--- a/src/lib/__tests__/ad-scheduler.test.ts
+++ b/src/lib/__tests__/ad-scheduler.test.ts
@@ -87,6 +87,11 @@ function pushRecordAdUsageMocks(opts: {
 }
 
 beforeEach(() => {
+  // Suppress production code's console.log/error so CI logs aren't drowned
+  // in [AdScheduler] noise — production emits 23 log lines per happy path.
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+
   responseQueue.length = 0
   fromCalls.length = 0
   insertCalls.length = 0
@@ -182,6 +187,17 @@ describe('AdScheduler.assignAdToIssue', () => {
     expect(insertCalls).toHaveLength(0)
   })
 
+  it('locks behavior: existence check filters on issue_id only, so a different adId is silently skipped', async () => {
+    // Documents the current invariant: one ad per issue. If the production
+    // code ever starts filtering on (issue_id, advertisement_id), this test
+    // will fail and force a deliberate decision.
+    responseQueue.push({ data: { id: 'existing-1' }, error: null })
+
+    await AdScheduler.assignAdToIssue('issue-1', 'ad-2', '2026-01-01')
+
+    expect(insertCalls).toHaveLength(0)
+  })
+
   it('inserts assignment without used_at when not yet assigned', async () => {
     responseQueue.push({ data: null, error: null })
     responseQueue.push({ data: null, error: null })
@@ -227,8 +243,8 @@ describe('AdScheduler.recordAdUsage', () => {
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
 
-    // updateCalls[0] is the assignment update; used_at must be an ISO timestamp.
-    expect(updateCalls[0].used_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    const assignmentUpdate = updateCalls.find(c => 'used_at' in c)
+    expect(assignmentUpdate?.used_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
   })
 
   it('inserts a new assignment when none exists', async () => {
@@ -260,8 +276,8 @@ describe('AdScheduler.recordAdUsage', () => {
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
 
-    // updateCalls[1] is the advertisement update.
-    expect(updateCalls[1].times_used).toBe(6)
+    const adUpdate = updateCalls.find(c => 'times_used' in c)
+    expect(adUpdate?.times_used).toBe(6)
   })
 
   it('treats null times_used as 0 when incrementing', async () => {
@@ -274,7 +290,8 @@ describe('AdScheduler.recordAdUsage', () => {
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
 
-    expect(updateCalls[1].times_used).toBe(1)
+    const adUpdate = updateCalls.find(c => 'times_used' in c)
+    expect(adUpdate?.times_used).toBe(1)
   })
 
   it('sets last_used_date to the issue date', async () => {
@@ -287,7 +304,8 @@ describe('AdScheduler.recordAdUsage', () => {
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-03-15', 'pub-1')
 
-    expect(updateCalls[1].last_used_date).toBe('2026-03-15')
+    const adUpdate = updateCalls.find(c => 'last_used_date' in c)
+    expect(adUpdate?.last_used_date).toBe('2026-03-15')
   })
 
   it('advances next position to currentPosition + 1', async () => {

--- a/src/lib/__tests__/ad-scheduler.test.ts
+++ b/src/lib/__tests__/ad-scheduler.test.ts
@@ -1,20 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// ---------------------------------------------------------------------------
-// Mocks - declared before importing the module under test so vi.mock hoisting
+// Mocks declared before importing the module under test so vi.mock hoisting
 // resolves them correctly.
-// ---------------------------------------------------------------------------
 
 type SupaResponse = { data: any; error: any }
 
-// Queue of responses; each call to supabaseAdmin.from() shifts one off the queue.
 const responseQueue: SupaResponse[] = []
-// Tracks every from(table) call so tests can assert against query shape.
 const fromCalls: string[] = []
-// Tracks payloads passed to .insert() and .update() in call order.
 const insertCalls: any[] = []
 const updateCalls: any[] = []
-// Tracks values passed to .eq() chains so tests can verify filters.
 const eqCalls: Array<[string, any]> = []
 
 function makeChain(response: SupaResponse): any {
@@ -36,7 +30,7 @@ function makeChain(response: SupaResponse): any {
   })
   chain.maybeSingle = vi.fn(() => Promise.resolve(response))
   chain.single = vi.fn(() => Promise.resolve(response))
-  // Make chain awaitable for queries that resolve directly (e.g. .order(),
+  // Make chain awaitable for queries that resolve directly (.order(),
   // .insert(), .update().eq()).
   chain.then = (resolve: any, reject: any) =>
     Promise.resolve(response).then(resolve, reject)
@@ -77,6 +71,21 @@ function makeAd(overrides: Record<string, any> = {}) {
   }
 }
 
+// Pushes the 5 supabase responses recordAdUsage's happy path consumes, in order:
+// fetch used ad → lookup existing assignment → write assignment → update ad
+// → fetch active ads for next-position calc.
+function pushRecordAdUsageMocks(opts: {
+  usedAd: { display_order: number; times_used: number | null }
+  existingAssignment?: { id: string } | null
+  activeAds: Array<{ display_order: number }>
+}) {
+  responseQueue.push({ data: opts.usedAd, error: null })
+  responseQueue.push({ data: opts.existingAssignment ?? null, error: null })
+  responseQueue.push({ data: null, error: null })
+  responseQueue.push({ data: null, error: null })
+  responseQueue.push({ data: opts.activeAds, error: null })
+}
+
 beforeEach(() => {
   responseQueue.length = 0
   fromCalls.length = 0
@@ -86,9 +95,6 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-// ---------------------------------------------------------------------------
-// selectAdForissue
-// ---------------------------------------------------------------------------
 describe('AdScheduler.selectAdForissue', () => {
   const ctx = { issueDate: '2026-01-01', issueId: 'issue-1', newsletterId: 'pub-1' }
 
@@ -123,7 +129,7 @@ describe('AdScheduler.selectAdForissue', () => {
   })
 
   it('skips gaps and returns the next available position', async () => {
-    // Queue is positions [1, 3, 5]; next_ad_position points to missing 2.
+    // Positions [1, 3, 5]; next_ad_position points to missing 2.
     const ad1 = makeAd({ id: 'ad-1', display_order: 1 })
     const ad3 = makeAd({ id: 'ad-3', display_order: 3 })
     const ad5 = makeAd({ id: 'ad-5', display_order: 5 })
@@ -167,12 +173,8 @@ describe('AdScheduler.selectAdForissue', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// assignAdToIssue
-// ---------------------------------------------------------------------------
 describe('AdScheduler.assignAdToIssue', () => {
   it('skips insert when ad is already assigned to the issue', async () => {
-    // Existing assignment lookup returns a row.
     responseQueue.push({ data: { id: 'existing-1' }, error: null })
 
     await AdScheduler.assignAdToIssue('issue-1', 'ad-1', '2026-01-01')
@@ -181,7 +183,6 @@ describe('AdScheduler.assignAdToIssue', () => {
   })
 
   it('inserts assignment without used_at when not yet assigned', async () => {
-    // Existing lookup returns null, then insert succeeds.
     responseQueue.push({ data: null, error: null })
     responseQueue.push({ data: null, error: null })
 
@@ -193,7 +194,7 @@ describe('AdScheduler.assignAdToIssue', () => {
       advertisement_id: 'ad-1',
       issue_date: '2026-01-01',
     })
-    // Critical: used_at must NOT be set here — that happens at send-final.
+    // used_at must NOT be set here — it's set later at send-final.
     expect(insertCalls[0]).not.toHaveProperty('used_at')
   })
 
@@ -207,9 +208,6 @@ describe('AdScheduler.assignAdToIssue', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// recordAdUsage
-// ---------------------------------------------------------------------------
 describe('AdScheduler.recordAdUsage', () => {
   it('throws when fetching the used ad fails', async () => {
     responseQueue.push({ data: null, error: { message: 'not found' } })
@@ -220,45 +218,26 @@ describe('AdScheduler.recordAdUsage', () => {
   })
 
   it('updates an existing assignment with used_at timestamp', async () => {
-    // 1. Fetch used ad
-    responseQueue.push({
-      data: { display_order: 1, times_used: 0 },
-      error: null,
+    pushRecordAdUsageMocks({
+      usedAd: { display_order: 1, times_used: 0 },
+      existingAssignment: { id: 'asgn-1' },
+      activeAds: [{ display_order: 1 }, { display_order: 2 }],
     })
-    // 2. Existing assignment exists
-    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
-    // 3. Update assignment with used_at
-    responseQueue.push({ data: null, error: null })
-    // 4. Update advertisement times_used
-    responseQueue.push({ data: null, error: null })
-    // 5. Fetch active ads for next-position calc
-    responseQueue.push({
-      data: [{ display_order: 1 }, { display_order: 2 }],
-      error: null,
-    })
-
     mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
 
-    // First update call is the assignment update — must include used_at.
+    // updateCalls[0] is the assignment update.
     expect(updateCalls[0]).toHaveProperty('used_at')
     expect(typeof updateCalls[0].used_at).toBe('string')
   })
 
   it('inserts a new assignment when none exists', async () => {
-    responseQueue.push({
-      data: { display_order: 1, times_used: 0 },
-      error: null,
+    pushRecordAdUsageMocks({
+      usedAd: { display_order: 1, times_used: 0 },
+      existingAssignment: null,
+      activeAds: [{ display_order: 1 }, { display_order: 2 }],
     })
-    responseQueue.push({ data: null, error: null }) // no existing assignment
-    responseQueue.push({ data: null, error: null }) // insert succeeds
-    responseQueue.push({ data: null, error: null }) // ad update succeeds
-    responseQueue.push({
-      data: [{ display_order: 1 }, { display_order: 2 }],
-      error: null,
-    })
-
     mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
@@ -273,39 +252,25 @@ describe('AdScheduler.recordAdUsage', () => {
   })
 
   it('increments times_used by 1', async () => {
-    responseQueue.push({
-      data: { display_order: 2, times_used: 5 },
-      error: null,
+    pushRecordAdUsageMocks({
+      usedAd: { display_order: 2, times_used: 5 },
+      existingAssignment: { id: 'asgn-1' },
+      activeAds: [{ display_order: 1 }, { display_order: 2 }, { display_order: 3 }],
     })
-    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
-    responseQueue.push({ data: null, error: null }) // assignment update
-    responseQueue.push({ data: null, error: null }) // ad update
-    responseQueue.push({
-      data: [{ display_order: 1 }, { display_order: 2 }, { display_order: 3 }],
-      error: null,
-    })
-
     mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
 
-    // Second update call is the advertisement update.
+    // updateCalls[1] is the advertisement update.
     expect(updateCalls[1].times_used).toBe(6)
   })
 
   it('treats null times_used as 0 when incrementing', async () => {
-    responseQueue.push({
-      data: { display_order: 1, times_used: null },
-      error: null,
+    pushRecordAdUsageMocks({
+      usedAd: { display_order: 1, times_used: null },
+      existingAssignment: { id: 'asgn-1' },
+      activeAds: [{ display_order: 1 }, { display_order: 2 }],
     })
-    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
-    responseQueue.push({ data: null, error: null })
-    responseQueue.push({ data: null, error: null })
-    responseQueue.push({
-      data: [{ display_order: 1 }, { display_order: 2 }],
-      error: null,
-    })
-
     mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
@@ -314,18 +279,11 @@ describe('AdScheduler.recordAdUsage', () => {
   })
 
   it('sets last_used_date to the issue date', async () => {
-    responseQueue.push({
-      data: { display_order: 1, times_used: 0 },
-      error: null,
+    pushRecordAdUsageMocks({
+      usedAd: { display_order: 1, times_used: 0 },
+      existingAssignment: { id: 'asgn-1' },
+      activeAds: [{ display_order: 1 }, { display_order: 2 }],
     })
-    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
-    responseQueue.push({ data: null, error: null })
-    responseQueue.push({ data: null, error: null })
-    responseQueue.push({
-      data: [{ display_order: 1 }, { display_order: 2 }],
-      error: null,
-    })
-
     mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-03-15', 'pub-1')
@@ -334,22 +292,11 @@ describe('AdScheduler.recordAdUsage', () => {
   })
 
   it('advances next position to currentPosition + 1', async () => {
-    responseQueue.push({
-      data: { display_order: 2, times_used: 0 },
-      error: null,
+    pushRecordAdUsageMocks({
+      usedAd: { display_order: 2, times_used: 0 },
+      existingAssignment: { id: 'asgn-1' },
+      activeAds: [{ display_order: 1 }, { display_order: 2 }, { display_order: 3 }],
     })
-    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
-    responseQueue.push({ data: null, error: null })
-    responseQueue.push({ data: null, error: null })
-    responseQueue.push({
-      data: [
-        { display_order: 1 },
-        { display_order: 2 },
-        { display_order: 3 },
-      ],
-      error: null,
-    })
-
     mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
@@ -359,22 +306,11 @@ describe('AdScheduler.recordAdUsage', () => {
 
   it('loops next position back to 1 when past the max position', async () => {
     // Used ad is at the last position (3); next should wrap to 1.
-    responseQueue.push({
-      data: { display_order: 3, times_used: 0 },
-      error: null,
+    pushRecordAdUsageMocks({
+      usedAd: { display_order: 3, times_used: 0 },
+      existingAssignment: { id: 'asgn-1' },
+      activeAds: [{ display_order: 1 }, { display_order: 2 }, { display_order: 3 }],
     })
-    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
-    responseQueue.push({ data: null, error: null })
-    responseQueue.push({ data: null, error: null })
-    responseQueue.push({
-      data: [
-        { display_order: 1 },
-        { display_order: 2 },
-        { display_order: 3 },
-      ],
-      error: null,
-    })
-
     mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
@@ -383,18 +319,11 @@ describe('AdScheduler.recordAdUsage', () => {
   })
 
   it('throws when updateNextAdPosition reports failure', async () => {
-    responseQueue.push({
-      data: { display_order: 1, times_used: 0 },
-      error: null,
+    pushRecordAdUsageMocks({
+      usedAd: { display_order: 1, times_used: 0 },
+      existingAssignment: { id: 'asgn-1' },
+      activeAds: [{ display_order: 1 }, { display_order: 2 }],
     })
-    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
-    responseQueue.push({ data: null, error: null })
-    responseQueue.push({ data: null, error: null })
-    responseQueue.push({
-      data: [{ display_order: 1 }, { display_order: 2 }],
-      error: null,
-    })
-
     mockedUpdateNextAdPosition.mockResolvedValue({
       success: false,
       error: 'settings write failed',

--- a/src/lib/__tests__/ad-scheduler.test.ts
+++ b/src/lib/__tests__/ad-scheduler.test.ts
@@ -1,0 +1,407 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mocks - declared before importing the module under test so vi.mock hoisting
+// resolves them correctly.
+// ---------------------------------------------------------------------------
+
+type SupaResponse = { data: any; error: any }
+
+// Queue of responses; each call to supabaseAdmin.from() shifts one off the queue.
+const responseQueue: SupaResponse[] = []
+// Tracks every from(table) call so tests can assert against query shape.
+const fromCalls: string[] = []
+// Tracks payloads passed to .insert() and .update() in call order.
+const insertCalls: any[] = []
+const updateCalls: any[] = []
+// Tracks values passed to .eq() chains so tests can verify filters.
+const eqCalls: Array<[string, any]> = []
+
+function makeChain(response: SupaResponse): any {
+  const chain: any = {}
+  chain.select = vi.fn(() => chain)
+  chain.eq = vi.fn((col: string, val: any) => {
+    eqCalls.push([col, val])
+    return chain
+  })
+  chain.not = vi.fn(() => chain)
+  chain.order = vi.fn(() => chain)
+  chain.insert = vi.fn((payload: any) => {
+    insertCalls.push(payload)
+    return chain
+  })
+  chain.update = vi.fn((payload: any) => {
+    updateCalls.push(payload)
+    return chain
+  })
+  chain.maybeSingle = vi.fn(() => Promise.resolve(response))
+  chain.single = vi.fn(() => Promise.resolve(response))
+  // Make chain awaitable for queries that resolve directly (e.g. .order(),
+  // .insert(), .update().eq()).
+  chain.then = (resolve: any, reject: any) =>
+    Promise.resolve(response).then(resolve, reject)
+  return chain
+}
+
+vi.mock('../supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn((table: string) => {
+      fromCalls.push(table)
+      const response = responseQueue.shift() ?? { data: null, error: null }
+      return makeChain(response)
+    }),
+  },
+}))
+
+vi.mock('../publication-settings', () => ({
+  getAdSettings: vi.fn(),
+  updateNextAdPosition: vi.fn(),
+}))
+
+import { AdScheduler } from '../ad-scheduler'
+import { getAdSettings, updateNextAdPosition } from '../publication-settings'
+
+const mockedGetAdSettings = vi.mocked(getAdSettings)
+const mockedUpdateNextAdPosition = vi.mocked(updateNextAdPosition)
+
+function makeAd(overrides: Record<string, any> = {}) {
+  return {
+    id: overrides.id ?? 'ad-default',
+    title: overrides.title ?? 'Default Ad',
+    display_order: 1,
+    status: 'active',
+    publication_id: 'pub-1',
+    times_used: 0,
+    last_used_date: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  responseQueue.length = 0
+  fromCalls.length = 0
+  insertCalls.length = 0
+  updateCalls.length = 0
+  eqCalls.length = 0
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// selectAdForissue
+// ---------------------------------------------------------------------------
+describe('AdScheduler.selectAdForissue', () => {
+  const ctx = { issueDate: '2026-01-01', issueId: 'issue-1', newsletterId: 'pub-1' }
+
+  it('returns null when no active ads exist', async () => {
+    mockedGetAdSettings.mockResolvedValue({ next_ad_position: 1 })
+    responseQueue.push({ data: [], error: null })
+
+    const result = await AdScheduler.selectAdForissue(ctx)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when supabase returns an error', async () => {
+    mockedGetAdSettings.mockResolvedValue({ next_ad_position: 1 })
+    responseQueue.push({ data: null, error: { message: 'boom' } })
+
+    const result = await AdScheduler.selectAdForissue(ctx)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns the ad at the exact next_ad_position', async () => {
+    const ad1 = makeAd({ id: 'ad-1', display_order: 1 })
+    const ad2 = makeAd({ id: 'ad-2', display_order: 2 })
+    const ad3 = makeAd({ id: 'ad-3', display_order: 3 })
+    mockedGetAdSettings.mockResolvedValue({ next_ad_position: 2 })
+    responseQueue.push({ data: [ad1, ad2, ad3], error: null })
+
+    const result = await AdScheduler.selectAdForissue(ctx)
+
+    expect(result?.id).toBe('ad-2')
+  })
+
+  it('skips gaps and returns the next available position', async () => {
+    // Queue is positions [1, 3, 5]; next_ad_position points to missing 2.
+    const ad1 = makeAd({ id: 'ad-1', display_order: 1 })
+    const ad3 = makeAd({ id: 'ad-3', display_order: 3 })
+    const ad5 = makeAd({ id: 'ad-5', display_order: 5 })
+    mockedGetAdSettings.mockResolvedValue({ next_ad_position: 2 })
+    responseQueue.push({ data: [ad1, ad3, ad5], error: null })
+
+    const result = await AdScheduler.selectAdForissue(ctx)
+
+    expect(result?.id).toBe('ad-3')
+  })
+
+  it('loops back to the first ad when next_ad_position is past the end', async () => {
+    const ad1 = makeAd({ id: 'ad-1', display_order: 1 })
+    const ad2 = makeAd({ id: 'ad-2', display_order: 2 })
+    mockedGetAdSettings.mockResolvedValue({ next_ad_position: 99 })
+    responseQueue.push({ data: [ad1, ad2], error: null })
+
+    const result = await AdScheduler.selectAdForissue(ctx)
+
+    expect(result?.id).toBe('ad-1')
+  })
+
+  it('filters by publication_id and active status', async () => {
+    const ad1 = makeAd({ id: 'ad-1', display_order: 1 })
+    mockedGetAdSettings.mockResolvedValue({ next_ad_position: 1 })
+    responseQueue.push({ data: [ad1], error: null })
+
+    await AdScheduler.selectAdForissue(ctx)
+
+    expect(fromCalls).toContain('advertisements')
+    expect(eqCalls).toContainEqual(['publication_id', 'pub-1'])
+    expect(eqCalls).toContainEqual(['status', 'active'])
+  })
+
+  it('returns null when getAdSettings throws', async () => {
+    mockedGetAdSettings.mockRejectedValue(new Error('settings unavailable'))
+
+    const result = await AdScheduler.selectAdForissue(ctx)
+
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// assignAdToIssue
+// ---------------------------------------------------------------------------
+describe('AdScheduler.assignAdToIssue', () => {
+  it('skips insert when ad is already assigned to the issue', async () => {
+    // Existing assignment lookup returns a row.
+    responseQueue.push({ data: { id: 'existing-1' }, error: null })
+
+    await AdScheduler.assignAdToIssue('issue-1', 'ad-1', '2026-01-01')
+
+    expect(insertCalls).toHaveLength(0)
+  })
+
+  it('inserts assignment without used_at when not yet assigned', async () => {
+    // Existing lookup returns null, then insert succeeds.
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({ data: null, error: null })
+
+    await AdScheduler.assignAdToIssue('issue-1', 'ad-1', '2026-01-01')
+
+    expect(insertCalls).toHaveLength(1)
+    expect(insertCalls[0]).toEqual({
+      issue_id: 'issue-1',
+      advertisement_id: 'ad-1',
+      issue_date: '2026-01-01',
+    })
+    // Critical: used_at must NOT be set here — that happens at send-final.
+    expect(insertCalls[0]).not.toHaveProperty('used_at')
+  })
+
+  it('throws when insert fails', async () => {
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({ data: null, error: { message: 'insert failed' } })
+
+    await expect(
+      AdScheduler.assignAdToIssue('issue-1', 'ad-1', '2026-01-01')
+    ).rejects.toBeTruthy()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// recordAdUsage
+// ---------------------------------------------------------------------------
+describe('AdScheduler.recordAdUsage', () => {
+  it('throws when fetching the used ad fails', async () => {
+    responseQueue.push({ data: null, error: { message: 'not found' } })
+
+    await expect(
+      AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
+    ).rejects.toBeTruthy()
+  })
+
+  it('updates an existing assignment with used_at timestamp', async () => {
+    // 1. Fetch used ad
+    responseQueue.push({
+      data: { display_order: 1, times_used: 0 },
+      error: null,
+    })
+    // 2. Existing assignment exists
+    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
+    // 3. Update assignment with used_at
+    responseQueue.push({ data: null, error: null })
+    // 4. Update advertisement times_used
+    responseQueue.push({ data: null, error: null })
+    // 5. Fetch active ads for next-position calc
+    responseQueue.push({
+      data: [{ display_order: 1 }, { display_order: 2 }],
+      error: null,
+    })
+
+    mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
+
+    await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
+
+    // First update call is the assignment update — must include used_at.
+    expect(updateCalls[0]).toHaveProperty('used_at')
+    expect(typeof updateCalls[0].used_at).toBe('string')
+  })
+
+  it('inserts a new assignment when none exists', async () => {
+    responseQueue.push({
+      data: { display_order: 1, times_used: 0 },
+      error: null,
+    })
+    responseQueue.push({ data: null, error: null }) // no existing assignment
+    responseQueue.push({ data: null, error: null }) // insert succeeds
+    responseQueue.push({ data: null, error: null }) // ad update succeeds
+    responseQueue.push({
+      data: [{ display_order: 1 }, { display_order: 2 }],
+      error: null,
+    })
+
+    mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
+
+    await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
+
+    expect(insertCalls).toHaveLength(1)
+    expect(insertCalls[0]).toMatchObject({
+      issue_id: 'issue-1',
+      advertisement_id: 'ad-1',
+      issue_date: '2026-01-01',
+    })
+    expect(insertCalls[0]).toHaveProperty('used_at')
+  })
+
+  it('increments times_used by 1', async () => {
+    responseQueue.push({
+      data: { display_order: 2, times_used: 5 },
+      error: null,
+    })
+    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
+    responseQueue.push({ data: null, error: null }) // assignment update
+    responseQueue.push({ data: null, error: null }) // ad update
+    responseQueue.push({
+      data: [{ display_order: 1 }, { display_order: 2 }, { display_order: 3 }],
+      error: null,
+    })
+
+    mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
+
+    await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
+
+    // Second update call is the advertisement update.
+    expect(updateCalls[1].times_used).toBe(6)
+  })
+
+  it('treats null times_used as 0 when incrementing', async () => {
+    responseQueue.push({
+      data: { display_order: 1, times_used: null },
+      error: null,
+    })
+    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({
+      data: [{ display_order: 1 }, { display_order: 2 }],
+      error: null,
+    })
+
+    mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
+
+    await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
+
+    expect(updateCalls[1].times_used).toBe(1)
+  })
+
+  it('sets last_used_date to the issue date', async () => {
+    responseQueue.push({
+      data: { display_order: 1, times_used: 0 },
+      error: null,
+    })
+    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({
+      data: [{ display_order: 1 }, { display_order: 2 }],
+      error: null,
+    })
+
+    mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
+
+    await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-03-15', 'pub-1')
+
+    expect(updateCalls[1].last_used_date).toBe('2026-03-15')
+  })
+
+  it('advances next position to currentPosition + 1', async () => {
+    responseQueue.push({
+      data: { display_order: 2, times_used: 0 },
+      error: null,
+    })
+    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({
+      data: [
+        { display_order: 1 },
+        { display_order: 2 },
+        { display_order: 3 },
+      ],
+      error: null,
+    })
+
+    mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
+
+    await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
+
+    expect(mockedUpdateNextAdPosition).toHaveBeenCalledWith('pub-1', 3)
+  })
+
+  it('loops next position back to 1 when past the max position', async () => {
+    // Used ad is at the last position (3); next should wrap to 1.
+    responseQueue.push({
+      data: { display_order: 3, times_used: 0 },
+      error: null,
+    })
+    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({
+      data: [
+        { display_order: 1 },
+        { display_order: 2 },
+        { display_order: 3 },
+      ],
+      error: null,
+    })
+
+    mockedUpdateNextAdPosition.mockResolvedValue({ success: true })
+
+    await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
+
+    expect(mockedUpdateNextAdPosition).toHaveBeenCalledWith('pub-1', 1)
+  })
+
+  it('throws when updateNextAdPosition reports failure', async () => {
+    responseQueue.push({
+      data: { display_order: 1, times_used: 0 },
+      error: null,
+    })
+    responseQueue.push({ data: { id: 'asgn-1' }, error: null })
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({ data: null, error: null })
+    responseQueue.push({
+      data: [{ display_order: 1 }, { display_order: 2 }],
+      error: null,
+    })
+
+    mockedUpdateNextAdPosition.mockResolvedValue({
+      success: false,
+      error: 'settings write failed',
+    })
+
+    await expect(
+      AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
+    ).rejects.toThrow(/settings write failed/)
+  })
+})

--- a/src/lib/__tests__/ad-scheduler.test.ts
+++ b/src/lib/__tests__/ad-scheduler.test.ts
@@ -204,7 +204,7 @@ describe('AdScheduler.assignAdToIssue', () => {
 
     await expect(
       AdScheduler.assignAdToIssue('issue-1', 'ad-1', '2026-01-01')
-    ).rejects.toBeTruthy()
+    ).rejects.toMatchObject({ message: 'insert failed' })
   })
 })
 
@@ -214,7 +214,7 @@ describe('AdScheduler.recordAdUsage', () => {
 
     await expect(
       AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
-    ).rejects.toBeTruthy()
+    ).rejects.toMatchObject({ message: 'not found' })
   })
 
   it('updates an existing assignment with used_at timestamp', async () => {
@@ -227,9 +227,8 @@ describe('AdScheduler.recordAdUsage', () => {
 
     await AdScheduler.recordAdUsage('issue-1', 'ad-1', '2026-01-01', 'pub-1')
 
-    // updateCalls[0] is the assignment update.
-    expect(updateCalls[0]).toHaveProperty('used_at')
-    expect(typeof updateCalls[0].used_at).toBe('string')
+    // updateCalls[0] is the assignment update; used_at must be an ISO timestamp.
+    expect(updateCalls[0].used_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
   })
 
   it('inserts a new assignment when none exists', async () => {
@@ -248,7 +247,7 @@ describe('AdScheduler.recordAdUsage', () => {
       advertisement_id: 'ad-1',
       issue_date: '2026-01-01',
     })
-    expect(insertCalls[0]).toHaveProperty('used_at')
+    expect(insertCalls[0].used_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
   })
 
   it('increments times_used by 1', async () => {


### PR DESCRIPTION
## Summary
- Adds 20 unit tests for `src/lib/ad-scheduler.ts`, which had zero coverage despite controlling ad rotation across all newsletters (`priority:p0` per #59 — wrong rotation directly costs advertiser revenue).
- Covers all three public methods: `selectAdForissue` (rotation, gap-skip, end-loop, error paths), `assignAdToIssue` (idempotency, no-`used_at`-on-assign), and `recordAdUsage` (`times_used` increment, `last_used_date`, next-position advance, end-of-list loopback to 1, error paths).
- No production code changed — pure retroactive coverage. Mocks `supabaseAdmin` and `publication-settings` per the existing repo convention (matches `schedule-checker.test.ts`).

## Review history
- Plan approved before implementation (`indexed-snuggling-quail.md`).
- `simplify` pass: extracted `pushRecordAdUsageMocks` helper, trimmed WHAT-narrating comments (-71 lines).
- `requesting-code-review` pass: tightened `.rejects.toBeTruthy()` → `.rejects.toMatchObject({ message })` and `typeof string` → ISO 8601 regex on `used_at` assertions.
- `review:pre-push` gate: suppressed production `console.log` noise in tests, replaced positional `updateCalls[0/1]` with find-by-shape, added a documenting test that locks in the issue_id-only existence-check contract in `assignAdToIssue`.

## Test plan
- [x] `npm run test:run -- src/lib/__tests__/ad-scheduler.test.ts` — 20/20 pass (12ms)
- [x] `npm run type-check` — clean
- [x] `npm run test:run` (full suite) — 484/484 pass, no regressions
- [x] Pre-push hooks: type-check, lint, bug-pattern checks all pass

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for ad scheduling functionality, including selection logic, filtering, assignment behavior, usage recording, and error handling scenarios with deterministic mocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->