### PR TITLE
test(openai): add unit test coverage for AI dispatch pipeline (closes #61)

### DIFF
--- a/src/lib/openai/__tests__/core.test.ts
+++ b/src/lib/openai/__tests__/core.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// ---------------------------------------------------------------------------
-// Supabase chainable response queue (same pattern as ad-scheduler.test.ts).
-// ---------------------------------------------------------------------------
 type SupaResponse = { data: any; error: any }
 const supabase = vi.hoisted(() => ({
   responseQueue: [] as SupaResponse[],
@@ -13,8 +10,6 @@ function makeSupaChain(response: SupaResponse): any {
   chain.select = vi.fn(() => chain)
   chain.eq = vi.fn(() => chain)
   chain.single = vi.fn(() => Promise.resolve(response))
-  chain.then = (resolve: any, reject: any) =>
-    Promise.resolve(response).then(resolve, reject)
   return chain
 }
 
@@ -27,9 +22,6 @@ vi.mock('@/lib/supabase', () => ({
   },
 }))
 
-// ---------------------------------------------------------------------------
-// OpenAI / Anthropic SDK clients — stub the calls used by callWithStructuredPrompt.
-// ---------------------------------------------------------------------------
 const mockOpenAI = vi.hoisted(() => ({
   responses: { create: vi.fn() },
 }))
@@ -42,9 +34,8 @@ vi.mock('../clients', () => ({
   anthropic: mockAnthropic,
 }))
 
-// ---------------------------------------------------------------------------
-// MetricsRecorder — dynamic-imported inside callAIWithPrompt; stub the class.
-// ---------------------------------------------------------------------------
+// MetricsRecorder is dynamically imported inside callAIWithPrompt, so the
+// mock must expose a class shim with the recordTiming method.
 vi.mock('@/lib/monitoring/metrics-recorder', () => ({
   MetricsRecorder: class {
     constructor(_publicationId: string) {}
@@ -74,9 +65,6 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-// ===========================================================================
-// getPrompt
-// ===========================================================================
 describe('getPrompt', () => {
   it('returns publication_settings value when publicationId provided and key exists', async () => {
     supabase.responseQueue.push({ data: { value: 'pub-specific-prompt' }, error: null })
@@ -105,9 +93,6 @@ describe('getPrompt', () => {
   })
 })
 
-// ===========================================================================
-// getPromptJSON
-// ===========================================================================
 describe('getPromptJSON', () => {
   it('returns parsed JSON when stored as a string in publication_settings', async () => {
     const stored = JSON.stringify({
@@ -178,9 +163,6 @@ describe('getPromptJSON', () => {
   })
 })
 
-// ===========================================================================
-// callWithStructuredPrompt
-// ===========================================================================
 describe('callWithStructuredPrompt', () => {
   it('throws when promptConfig is null', async () => {
     await expect(callWithStructuredPrompt(null as any)).rejects.toThrow(
@@ -264,10 +246,7 @@ describe('callWithStructuredPrompt', () => {
   })
 })
 
-// ===========================================================================
-// callAIWithPrompt — integration of getPromptJSON + callWithStructuredPrompt
-// ===========================================================================
-describe('callAIWithPrompt', () => {
+describe('callAIWithPrompt (integration: getPromptJSON + callWithStructuredPrompt)', () => {
   it('end-to-end: loads prompt, dispatches via correct provider, returns parsed JSON', async () => {
     const stored = {
       model: 'gpt-4o',

--- a/src/lib/openai/__tests__/core.test.ts
+++ b/src/lib/openai/__tests__/core.test.ts
@@ -3,21 +3,29 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 type SupaResponse = { data: any; error: any }
 const supabase = vi.hoisted(() => ({
   responseQueue: [] as SupaResponse[],
+  // Records every (table, [eq calls]) pair in the order from() was invoked.
+  // Tests assert against this for tenant-filter and fallback-order regressions.
+  fromCalls: [] as Array<{ table: string; eqCalls: Array<[string, any]> }>,
 }))
 
-function makeSupaChain(response: SupaResponse): any {
+function makeSupaChain(response: SupaResponse, eqCalls: Array<[string, any]>): any {
   const chain: any = {}
   chain.select = vi.fn(() => chain)
-  chain.eq = vi.fn(() => chain)
+  chain.eq = vi.fn((col: string, val: any) => {
+    eqCalls.push([col, val])
+    return chain
+  })
   chain.single = vi.fn(() => Promise.resolve(response))
   return chain
 }
 
 vi.mock('@/lib/supabase', () => ({
   supabaseAdmin: {
-    from: vi.fn(() => {
+    from: vi.fn((table: string) => {
       const response = supabase.responseQueue.shift() ?? { data: null, error: null }
-      return makeSupaChain(response)
+      const eqCalls: Array<[string, any]> = []
+      supabase.fromCalls.push({ table, eqCalls })
+      return makeSupaChain(response, eqCalls)
     }),
   },
 }))
@@ -57,11 +65,16 @@ beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {})
 
   supabase.responseQueue.length = 0
+  supabase.fromCalls.length = 0
   mockOpenAI.responses.create.mockReset()
   mockAnthropic.messages.create.mockReset()
 })
 
 afterEach(() => {
+  // If queue still has entries, the SUT made fewer from() calls than the test
+  // queued — likely a future SUT change that needs updated mock setup. Catches
+  // silent drift early instead of hiding it behind the null/null fallback.
+  expect(supabase.responseQueue).toHaveLength(0)
   vi.restoreAllMocks()
 })
 
@@ -72,6 +85,9 @@ describe('getPrompt', () => {
     const result = await getPrompt('my_key', 'fallback', 'pub-1')
 
     expect(result).toBe('pub-specific-prompt')
+    // Tenant-filter regression guard: query must be scoped to publication_id.
+    expect(supabase.fromCalls[0]?.table).toBe('publication_settings')
+    expect(supabase.fromCalls[0]?.eqCalls).toContainEqual(['publication_id', 'pub-1'])
   })
 
   it('falls back to app_settings when publication_settings has no row', async () => {
@@ -81,6 +97,8 @@ describe('getPrompt', () => {
     const result = await getPrompt('my_key', 'fallback', 'pub-1')
 
     expect(result).toBe('app-default-prompt')
+    // Fallback-order regression guard: publication_settings tried FIRST, then app_settings.
+    expect(supabase.fromCalls.map(c => c.table)).toEqual(['publication_settings', 'app_settings'])
   })
 
   it('returns the provided fallback when both publication_settings and app_settings miss', async () => {
@@ -106,6 +124,9 @@ describe('getPromptJSON', () => {
     expect(result.model).toBe('gpt-4o')
     expect(result.messages).toEqual([{ role: 'user', content: 'hi' }])
     expect(result._provider).toBe('openai')
+    // Tenant-filter regression guard.
+    expect(supabase.fromCalls[0]?.table).toBe('publication_settings')
+    expect(supabase.fromCalls[0]?.eqCalls).toContainEqual(['publication_id', 'pub-1'])
   })
 
   it('falls back to app_settings when publication_settings is empty', async () => {
@@ -138,11 +159,13 @@ describe('getPromptJSON', () => {
     )
   })
 
-  it('auto-detects Claude provider from a Claude model name', async () => {
-    const stored = {
+  it('auto-detects Claude provider from a Claude model name (string-stored prompt)', async () => {
+    // Stored as a JSON string to exercise the string-parsing branch
+    // (object-stored hits the JSONB-already-parsed branch in core.ts:124).
+    const stored = JSON.stringify({
       model: 'claude-3-5-sonnet-20241022',
       messages: [{ role: 'user', content: 'hi' }],
-    }
+    })
     supabase.responseQueue.push({ data: { value: stored }, error: null })
 
     const result = await getPromptJSON('my_key', 'pub-1')

--- a/src/lib/openai/__tests__/core.test.ts
+++ b/src/lib/openai/__tests__/core.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Supabase chainable response queue (same pattern as ad-scheduler.test.ts).
+// ---------------------------------------------------------------------------
+type SupaResponse = { data: any; error: any }
+const supabase = vi.hoisted(() => ({
+  responseQueue: [] as SupaResponse[],
+}))
+
+function makeSupaChain(response: SupaResponse): any {
+  const chain: any = {}
+  chain.select = vi.fn(() => chain)
+  chain.eq = vi.fn(() => chain)
+  chain.single = vi.fn(() => Promise.resolve(response))
+  chain.then = (resolve: any, reject: any) =>
+    Promise.resolve(response).then(resolve, reject)
+  return chain
+}
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => {
+      const response = supabase.responseQueue.shift() ?? { data: null, error: null }
+      return makeSupaChain(response)
+    }),
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// OpenAI / Anthropic SDK clients — stub the calls used by callWithStructuredPrompt.
+// ---------------------------------------------------------------------------
+const mockOpenAI = vi.hoisted(() => ({
+  responses: { create: vi.fn() },
+}))
+const mockAnthropic = vi.hoisted(() => ({
+  messages: { create: vi.fn() },
+}))
+
+vi.mock('../clients', () => ({
+  openai: mockOpenAI,
+  anthropic: mockAnthropic,
+}))
+
+// ---------------------------------------------------------------------------
+// MetricsRecorder — dynamic-imported inside callAIWithPrompt; stub the class.
+// ---------------------------------------------------------------------------
+vi.mock('@/lib/monitoring/metrics-recorder', () => ({
+  MetricsRecorder: class {
+    constructor(_publicationId: string) {}
+    recordTiming = vi.fn().mockResolvedValue(undefined)
+  },
+}))
+
+import {
+  getPrompt,
+  getPromptJSON,
+  callWithStructuredPrompt,
+  callAIWithPrompt,
+} from '../core'
+
+beforeEach(() => {
+  // Suppress production console output.
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  supabase.responseQueue.length = 0
+  mockOpenAI.responses.create.mockReset()
+  mockAnthropic.messages.create.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ===========================================================================
+// getPrompt
+// ===========================================================================
+describe('getPrompt', () => {
+  it('returns publication_settings value when publicationId provided and key exists', async () => {
+    supabase.responseQueue.push({ data: { value: 'pub-specific-prompt' }, error: null })
+
+    const result = await getPrompt('my_key', 'fallback', 'pub-1')
+
+    expect(result).toBe('pub-specific-prompt')
+  })
+
+  it('falls back to app_settings when publication_settings has no row', async () => {
+    supabase.responseQueue.push({ data: null, error: { message: 'not found' } }) // pub_settings miss
+    supabase.responseQueue.push({ data: { value: 'app-default-prompt' }, error: null }) // app_settings hit
+
+    const result = await getPrompt('my_key', 'fallback', 'pub-1')
+
+    expect(result).toBe('app-default-prompt')
+  })
+
+  it('returns the provided fallback when both publication_settings and app_settings miss', async () => {
+    supabase.responseQueue.push({ data: null, error: { message: 'not found' } })
+    supabase.responseQueue.push({ data: null, error: { message: 'not found' } })
+
+    const result = await getPrompt('my_key', 'CODE_FALLBACK', 'pub-1')
+
+    expect(result).toBe('CODE_FALLBACK')
+  })
+})
+
+// ===========================================================================
+// getPromptJSON
+// ===========================================================================
+describe('getPromptJSON', () => {
+  it('returns parsed JSON when stored as a string in publication_settings', async () => {
+    const stored = JSON.stringify({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+    supabase.responseQueue.push({ data: { value: stored }, error: null })
+
+    const result = await getPromptJSON('my_key', 'pub-1')
+
+    expect(result.model).toBe('gpt-4o')
+    expect(result.messages).toEqual([{ role: 'user', content: 'hi' }])
+    expect(result._provider).toBe('openai')
+  })
+
+  it('falls back to app_settings when publication_settings is empty', async () => {
+    const stored = JSON.stringify({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'app default' }],
+    })
+    supabase.responseQueue.push({ data: null, error: { message: 'not found' } })
+    supabase.responseQueue.push({ data: { value: stored }, error: null })
+
+    const result = await getPromptJSON('my_key', 'pub-1')
+
+    expect(result.messages[0].content).toBe('app default')
+  })
+
+  it('throws when stored value is not valid JSON and no fallback provided', async () => {
+    supabase.responseQueue.push({ data: { value: '{this is not json}' }, error: null })
+
+    await expect(getPromptJSON('my_key', 'pub-1')).rejects.toThrow(
+      /not valid JSON/
+    )
+  })
+
+  it('throws when stored JSON is missing both messages and input arrays', async () => {
+    const stored = JSON.stringify({ model: 'gpt-4o', temperature: 0.5 })
+    supabase.responseQueue.push({ data: { value: stored }, error: null })
+
+    await expect(getPromptJSON('my_key', 'pub-1')).rejects.toThrow(
+      /missing 'messages' or 'input'/
+    )
+  })
+
+  it('auto-detects Claude provider from a Claude model name', async () => {
+    const stored = {
+      model: 'claude-3-5-sonnet-20241022',
+      messages: [{ role: 'user', content: 'hi' }],
+    }
+    supabase.responseQueue.push({ data: { value: stored }, error: null })
+
+    const result = await getPromptJSON('my_key', 'pub-1')
+
+    expect(result._provider).toBe('claude')
+  })
+
+  it('normalizes input array to messages when only input is provided (Responses API format)', async () => {
+    const stored = {
+      model: 'gpt-4o',
+      input: [{ role: 'user', content: 'via input field' }],
+    }
+    supabase.responseQueue.push({ data: { value: stored }, error: null })
+
+    const result = await getPromptJSON('my_key', 'pub-1')
+
+    expect(result.messages).toEqual([{ role: 'user', content: 'via input field' }])
+  })
+})
+
+// ===========================================================================
+// callWithStructuredPrompt
+// ===========================================================================
+describe('callWithStructuredPrompt', () => {
+  it('throws when promptConfig is null', async () => {
+    await expect(callWithStructuredPrompt(null as any)).rejects.toThrow(
+      /Invalid promptConfig/
+    )
+  })
+
+  it('throws when promptConfig has neither messages nor input array', async () => {
+    await expect(
+      callWithStructuredPrompt({ model: 'gpt-4o' } as any)
+    ).rejects.toThrow(/must have either "messages" or "input" array/)
+  })
+
+  it('routes to anthropic.messages.create when provider="claude"', async () => {
+    mockAnthropic.messages.create.mockResolvedValue({
+      content: [{ type: 'text', text: '{"ok":true}' }],
+    })
+
+    const config: any = {
+      model: 'claude-3-5-sonnet',
+      messages: [{ role: 'user', content: 'hi' }],
+    }
+    const result = await callWithStructuredPrompt(config, {}, 'claude')
+
+    expect(mockAnthropic.messages.create).toHaveBeenCalledTimes(1)
+    expect(mockOpenAI.responses.create).not.toHaveBeenCalled()
+    expect(result).toEqual({ ok: true })
+  })
+
+  it('routes to openai.responses.create when provider="openai" and translates messages→input', async () => {
+    mockOpenAI.responses.create.mockResolvedValue({
+      output: [{ content: [{ type: 'text', text: '{"ok":true}' }] }],
+    })
+
+    const config: any = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'hi' }],
+    }
+    const result = await callWithStructuredPrompt(config, {}, 'openai')
+
+    expect(mockOpenAI.responses.create).toHaveBeenCalledTimes(1)
+    expect(mockAnthropic.messages.create).not.toHaveBeenCalled()
+    // OpenAI Responses API uses 'input', not 'messages'.
+    const sentRequest = mockOpenAI.responses.create.mock.calls[0]?.[0]
+    expect(sentRequest.input).toEqual([{ role: 'user', content: 'hi' }])
+    expect(sentRequest.messages).toBeUndefined()
+    expect(result).toEqual({ ok: true })
+  })
+
+  it('replaces named placeholders ({{key}}) recursively in the request payload', async () => {
+    mockOpenAI.responses.create.mockResolvedValue({
+      output: [{ content: [{ type: 'text', text: '{"ok":true}' }] }],
+    })
+
+    const config: any = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello {{name}}, your topic is {{topic}}.' }],
+    }
+    await callWithStructuredPrompt(config, { name: 'Jake', topic: 'AI' }, 'openai')
+
+    const sent = mockOpenAI.responses.create.mock.calls[0]?.[0]
+    expect(sent.input[0].content).toBe('Hello Jake, your topic is AI.')
+  })
+
+  it('strips custom application fields (provider, response_field) before calling the API', async () => {
+    mockOpenAI.responses.create.mockResolvedValue({
+      output: [{ content: [{ type: 'text', text: '{}' }] }],
+    })
+
+    const config: any = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'hi' }],
+      provider: 'openai',
+      response_field: 'content',
+    }
+    await callWithStructuredPrompt(config, {}, 'openai')
+
+    const sent = mockOpenAI.responses.create.mock.calls[0]?.[0]
+    expect(sent.provider).toBeUndefined()
+    expect(sent.response_field).toBeUndefined()
+  })
+})
+
+// ===========================================================================
+// callAIWithPrompt — integration of getPromptJSON + callWithStructuredPrompt
+// ===========================================================================
+describe('callAIWithPrompt', () => {
+  it('end-to-end: loads prompt, dispatches via correct provider, returns parsed JSON', async () => {
+    const stored = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Generate {{topic}}' }],
+    }
+    supabase.responseQueue.push({ data: { value: stored }, error: null })
+
+    mockOpenAI.responses.create.mockResolvedValue({
+      output: [{ content: [{ type: 'text', text: '{"title":"hello"}' }] }],
+    })
+
+    const result = await callAIWithPrompt('article_title_prompt', 'pub-1', { topic: 'AI' })
+
+    expect(result).toEqual({ title: 'hello' })
+    const sent = mockOpenAI.responses.create.mock.calls[0]?.[0]
+    expect(sent.input[0].content).toBe('Generate AI')
+    // Internal _provider field must NOT leak to the API request.
+    expect(sent._provider).toBeUndefined()
+  })
+})

--- a/src/lib/openai/__tests__/core.test.ts
+++ b/src/lib/openai/__tests__/core.test.ts
@@ -227,6 +227,40 @@ describe('callWithStructuredPrompt', () => {
     expect(sent.input[0].content).toBe('Hello Jake, your topic is AI.')
   })
 
+  it('replaces {{random_X-Y}} placeholders with an integer in the inclusive range', async () => {
+    mockOpenAI.responses.create.mockResolvedValue({
+      output: [{ content: [{ type: 'text', text: '{"ok":true}' }] }],
+    })
+
+    const config: any = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Pick a number: {{random_5-10}}' }],
+    }
+    await callWithStructuredPrompt(config, {}, 'openai')
+
+    const sent = mockOpenAI.responses.create.mock.calls[0]?.[0]
+    const match = (sent.input[0].content as string).match(/Pick a number: (\d+)/)
+    expect(match).not.toBeNull()
+    const n = parseInt(match![1], 10)
+    expect(n).toBeGreaterThanOrEqual(5)
+    expect(n).toBeLessThanOrEqual(10)
+  })
+
+  it('leaves invalid {{random_X-Y}} placeholders unchanged when min > max', async () => {
+    mockOpenAI.responses.create.mockResolvedValue({
+      output: [{ content: [{ type: 'text', text: '{"ok":true}' }] }],
+    })
+
+    const config: any = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Bad range: {{random_10-5}}' }],
+    }
+    await callWithStructuredPrompt(config, {}, 'openai')
+
+    const sent = mockOpenAI.responses.create.mock.calls[0]?.[0]
+    expect(sent.input[0].content).toBe('Bad range: {{random_10-5}}')
+  })
+
   it('strips custom application fields (provider, response_field) before calling the API', async () => {
     mockOpenAI.responses.create.mockResolvedValue({
       output: [{ content: [{ type: 'text', text: '{}' }] }],

--- a/src/lib/openai/__tests__/response-parser.test.ts
+++ b/src/lib/openai/__tests__/response-parser.test.ts
@@ -85,6 +85,39 @@ describe('extractResponseContent', () => {
     expect(extractResponseContent(response)).toEqual({ a: 1, b: 'x' })
   })
 
+  it('falls back to json_schema item.input_json when .json is absent', () => {
+    const response = {
+      output: [{
+        content: [
+          { type: 'json_schema', input_json: { a: 1 } },
+        ],
+      }],
+    }
+    expect(extractResponseContent(response)).toEqual({ a: 1 })
+  })
+
+  it('falls back to positional content[0].json when no item type-tag matches', () => {
+    const response = {
+      output: [{
+        content: [
+          { json: { a: 1 } }, // no type field — positional fallback
+        ],
+      }],
+    }
+    expect(extractResponseContent(response)).toEqual({ a: 1 })
+  })
+
+  it('unwraps a response wrapper that has text but not output_text', () => {
+    const response = {
+      output: [{
+        content: [
+          { type: 'json_schema', json: { id: 'wrapper-1', text: 'inner via text' } },
+        ],
+      }],
+    }
+    expect(extractResponseContent(response)).toBe('inner via text')
+  })
+
   it('returns text item content as a string for downstream parsing', () => {
     const response = {
       output: [{

--- a/src/lib/openai/__tests__/response-parser.test.ts
+++ b/src/lib/openai/__tests__/response-parser.test.ts
@@ -11,10 +11,6 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-// ===========================================================================
-// parseAIResponseJSON — historically buggy, 29 fix commits in git history.
-// Pure function, no mocks needed.
-// ===========================================================================
 describe('parseAIResponseJSON', () => {
   it('parses a plain JSON object string', () => {
     expect(parseAIResponseJSON('{"a":1,"b":"x"}')).toEqual({ a: 1, b: 'x' })
@@ -77,10 +73,6 @@ describe('parseAIResponseJSON', () => {
   })
 })
 
-// ===========================================================================
-// extractResponseContent — handles OpenAI Responses API shape variants.
-// Throws when no content is found.
-// ===========================================================================
 describe('extractResponseContent', () => {
   it('returns parsed object from json_schema item directly', () => {
     const response = {

--- a/src/lib/openai/__tests__/response-parser.test.ts
+++ b/src/lib/openai/__tests__/response-parser.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { parseAIResponseJSON, extractResponseContent } from '../response-parser'
+
+// Suppress production console.error called by extractResponseContent's
+// "no content found" diagnostic logging — keeps CI logs clean.
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ===========================================================================
+// parseAIResponseJSON — historically buggy, 29 fix commits in git history.
+// Pure function, no mocks needed.
+// ===========================================================================
+describe('parseAIResponseJSON', () => {
+  it('parses a plain JSON object string', () => {
+    expect(parseAIResponseJSON('{"a":1,"b":"x"}')).toEqual({ a: 1, b: 'x' })
+  })
+
+  it('parses a plain JSON array string', () => {
+    expect(parseAIResponseJSON('[1,2,3]')).toEqual([1, 2, 3])
+  })
+
+  it('strips a json-labeled markdown code fence', () => {
+    const input = '```json\n{"a":1}\n```'
+    expect(parseAIResponseJSON(input)).toEqual({ a: 1 })
+  })
+
+  it('strips an unlabeled markdown code fence', () => {
+    const input = '```\n{"a":1}\n```'
+    expect(parseAIResponseJSON(input)).toEqual({ a: 1 })
+  })
+
+  it('handles leading/trailing whitespace', () => {
+    expect(parseAIResponseJSON('  {"a":1}  ')).toEqual({ a: 1 })
+  })
+
+  it('extracts the JSON block when prose precedes it (mixed content)', () => {
+    const input = 'Here is the data:\n```json\n{"a":1}\n```\nThanks!'
+    expect(parseAIResponseJSON(input)).toEqual({ a: 1 })
+  })
+
+  it('returns {raw} for empty string', () => {
+    expect(parseAIResponseJSON('')).toEqual({ raw: '' })
+  })
+
+  it('returns {raw} for null input', () => {
+    expect(parseAIResponseJSON(null as any)).toEqual({ raw: null })
+  })
+
+  it('returns {raw} for undefined input', () => {
+    expect(parseAIResponseJSON(undefined as any)).toEqual({ raw: undefined })
+  })
+
+  it('returns {raw} for non-string input (e.g. number)', () => {
+    expect(parseAIResponseJSON(42 as any)).toEqual({ raw: 42 })
+  })
+
+  it('returns {raw: <original>} for invalid JSON inside braces', () => {
+    expect(parseAIResponseJSON('{not json}')).toEqual({ raw: '{not json}' })
+  })
+
+  it('returns {raw: <original>} for plain prose with no JSON', () => {
+    expect(parseAIResponseJSON('This is just text.')).toEqual({ raw: 'This is just text.' })
+  })
+
+  it('locks current behavior: double-stringified input returns {raw}', () => {
+    // Known limitation: '"{\\"a\\":1}"' isn't unwrapped automatically.
+    // Locks the current contract; any future fix to auto-unwrap will break
+    // this test and force a deliberate decision.
+    const input = '"{\\"a\\":1}"'
+    const result = parseAIResponseJSON(input)
+    expect(result).toEqual({ raw: input })
+  })
+})
+
+// ===========================================================================
+// extractResponseContent — handles OpenAI Responses API shape variants.
+// Throws when no content is found.
+// ===========================================================================
+describe('extractResponseContent', () => {
+  it('returns parsed object from json_schema item directly', () => {
+    const response = {
+      output: [{
+        content: [
+          { type: 'json_schema', json: { a: 1, b: 'x' } },
+        ],
+      }],
+    }
+    expect(extractResponseContent(response)).toEqual({ a: 1, b: 'x' })
+  })
+
+  it('returns text item content as a string for downstream parsing', () => {
+    const response = {
+      output: [{
+        content: [
+          { type: 'text', text: '{"a":1}' },
+        ],
+      }],
+    }
+    expect(extractResponseContent(response)).toBe('{"a":1}')
+  })
+
+  it('falls back to response.output_text when output array is missing', () => {
+    const response = { output_text: 'hello' }
+    expect(extractResponseContent(response)).toBe('hello')
+  })
+
+  it('falls back to response.text as last resort', () => {
+    const response = { text: 'hello' }
+    expect(extractResponseContent(response)).toBe('hello')
+  })
+
+  it('returns parsed array directly when content is already an array', () => {
+    const response = {
+      output: [{
+        content: [
+          { type: 'json_schema', json: [1, 2, 3] },
+        ],
+      }],
+    }
+    expect(extractResponseContent(response)).toEqual([1, 2, 3])
+  })
+
+  it('unwraps a response wrapper that has output_text', () => {
+    const response = {
+      output: [{
+        content: [
+          { type: 'json_schema', json: { id: 'wrapper-1', output_text: 'inner content' } },
+        ],
+      }],
+    }
+    expect(extractResponseContent(response)).toBe('inner content')
+  })
+
+  it('throws when no content is found anywhere', () => {
+    const response = { output: [] }
+    expect(() => extractResponseContent(response)).toThrow(/No response from OpenAI/)
+  })
+
+  it('throws when output_text is empty string and no other source', () => {
+    const response = { output_text: '' }
+    expect(() => extractResponseContent(response)).toThrow(/No response from OpenAI/)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds 42 unit tests across two new files for the AI dispatch pipeline (`src/lib/openai/core.ts` + `src/lib/openai/response-parser.ts`), per #61 (`priority:p1`, 29 historical AI-response fix commits, prior zero coverage).
- `response-parser.test.ts` (24 pure-function tests, no mocks): exhaustive coverage of `parseAIResponseJSON` input shapes (plain JSON, markdown code fences with/without language label, mixed content, leading/trailing whitespace, null/undefined/empty/non-string, invalid-JSON-in-braces, plain prose, double-stringified — locked as known limitation), and `extractResponseContent` Responses API shape variants (json_schema item, input_json fallback, text item, output_text fallback, response.text fallback, parsed array passthrough, response wrapper unwrapping with output_text vs text, positional content[0].json fallback, two no-content throws).
- `core.test.ts` (18 mocked tests): `getPrompt` (3, fallback chain with tenant-filter assertion), `getPromptJSON` (6, db fallback + provider auto-detect with string-stored prompt + input→messages normalization + invalid-JSON/missing-array throws), `callWithStructuredPrompt` (7, validation + claude/openai routing + messages→input translation + named placeholder replacement + `{{random_X-Y}}` placeholder happy + invalid-range passthrough + custom-field stripping), `callAIWithPrompt` (1, end-to-end integration).
- No production code changed.

## Notable: scope correction from issue text
Issue #61 said `parseJSONResponse()` lives in `core.ts` and the parsing logic is "duplicated in 3 places." Both are out of date — commit `218cf140` already deduplicated by extracting `parseAIResponseJSON()` and `extractResponseContent()` into `response-parser.ts`. This PR tests both files (the cohesive AI dispatch pipeline) since the parser is where the buggy logic lives.

## Tenant-isolation regression guards
Per gate-review feedback, the supabase mock now records `(table, eq calls)` per `from()` invocation. Tests assert:
- `.eq('publication_id', 'pub-1')` was called on every `publication_settings` query — a tenant-filter regression would now fail loudly.
- The `from()` call sequence is `['publication_settings', 'app_settings']` — a fallback inversion would fail instead of silently returning the right value from the wrong tier.
- `afterEach` asserts the response queue is exhausted — catches silent drift if a future SUT change adds a `from()` call without updating test setup.

## Review history
- Plan approved before implementation (`indexed-snuggling-quail.md`).
- `simplify` pass: removed decorative banner comments, removed dead `chain.then` thenable in core.test.ts (the SUT only awaits `.single()`, never the chain object).
- `requesting-code-review` pass: added 5 tests for previously-uncovered `extractResponseContent` fallback chains (`input_json`, positional fallback, wrapper-with-text) and the `{{random_X-Y}}` placeholder branch (happy + invalid range).
- `review:pre-push` gate: added tenant-filter assertion infrastructure, fallback-order assertion, queue-exhaustion check in `afterEach`, and switched the Claude auto-detect test to use a JSON-stringified prompt (was using a raw object, bypassing the string-parsing branch).

## Out of scope (worth filing as separate issues)
- `src/lib/openai/legacy.ts` (deprecated `callOpenAI`)
- `console.warn` assertions on the random-placeholder invalid-range path
- Speculative fake-timer infrastructure for hypothetical future timeout tests
- Coverage of `pushCampaignContent` swallow path and `getPromptJSON` app_settings-fallback provider-detection branch (S2/S3 from review)

## Test plan
- [x] `npm run test:run -- src/lib/openai/__tests__/` — 42/42 pass (~30ms)
- [x] `npm run type-check` — clean
- [x] `npm run test:run` (full suite, post-rebase) — no regressions
- [x] Pre-push hooks: type-check, lint, bug-pattern checks all pass

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for AI prompt lookup and response handling functionality across multiple scenarios.
  * New tests validate end-to-end workflows, edge cases, and error handling for response parsing and JSON extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->