### PR TITLE
test(scoring): add unit test coverage for RSS scoring module (closes #62)

### DIFF
--- a/src/lib/rss-processor/__tests__/scoring.test.ts
+++ b/src/lib/rss-processor/__tests__/scoring.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// =============================================================================
+// Hoisted mock state — see article-selector.test.ts for the canonical template.
+// Strict variant (post-#63 gate-review): from() throws on empty queue so silent
+// extra DB calls surface as immediate failures.
+// =============================================================================
+
+type SupaResponse = { data: any; error: any }
+
+const supabase = vi.hoisted(() => ({
+  responseQueue: [] as SupaResponse[],
+  fromCalls: [] as Array<{
+    table: string
+    eqCalls: Array<[string, any]>
+    orderCalls: Array<[string, any]>
+  }>,
+  insertCalls: [] as Array<{ table: string; payload: any }>,
+}))
+
+function makeSupaChain(
+  table: string,
+  response: SupaResponse,
+  eqCalls: Array<[string, any]>,
+  orderCalls: Array<[string, any]>,
+): any {
+  const chain: any = {}
+  chain.select = vi.fn(() => chain)
+  chain.eq = vi.fn((col: string, val: any) => {
+    eqCalls.push([col, val])
+    return chain
+  })
+  chain.in = vi.fn(() => chain)
+  chain.order = vi.fn((col: string, opts?: any) => {
+    orderCalls.push([col, opts])
+    return chain
+  })
+  chain.limit = vi.fn(() => chain)
+  chain.single = vi.fn(() => Promise.resolve(response))
+  chain.maybeSingle = vi.fn(() => Promise.resolve(response))
+  chain.insert = vi.fn((payload: any) => {
+    supabase.insertCalls.push({ table, payload })
+    return chain
+  })
+  // Awaiting the chain (without .single()) resolves to the queued response.
+  // Required for queries that end with .order() or .limit().
+  chain.then = (resolve: any, reject: any) =>
+    Promise.resolve(response).then(resolve, reject)
+  return chain
+}
+
+vi.mock('../../supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn((table: string) => {
+      const response = supabase.responseQueue.shift()
+      if (!response) {
+        throw new Error(
+          `[test] Unexpected supabaseAdmin.from('${table}') — add a response to the queue`,
+        )
+      }
+      const eqCalls: Array<[string, any]> = []
+      const orderCalls: Array<[string, any]> = []
+      supabase.fromCalls.push({ table, eqCalls, orderCalls })
+      return makeSupaChain(table, response, eqCalls, orderCalls)
+    }),
+  },
+}))
+
+const mockCallWithStructuredPrompt = vi.hoisted(() => vi.fn())
+
+vi.mock('../../openai', () => ({
+  callWithStructuredPrompt: mockCallWithStructuredPrompt,
+}))
+
+vi.mock('../shared-context', () => ({
+  getNewsletterIdFromIssue: vi.fn().mockResolvedValue('pub-1'),
+}))
+
+import { Scoring } from '../scoring'
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeCriterion(overrides: Record<string, any> = {}) {
+  return {
+    criteria_number: 1,
+    name: 'Interest',
+    weight: 5,
+    ai_prompt: JSON.stringify({ model: 'gpt-4o' }),
+    is_active: true,
+    enforce_minimum: false,
+    minimum_score: null,
+    evaluation_order: 1,
+    ...overrides,
+  }
+}
+
+function makePost(overrides: Record<string, any> = {}) {
+  return {
+    id: 'post-1',
+    title: 'Sample post',
+    description: 'desc',
+    content: 'content',
+    full_article_text: 'full text',
+    feed_id: 'feed-1',
+    issue_id: 'issue-1',
+    ...overrides,
+  } as any
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  supabase.responseQueue.length = 0
+  supabase.fromCalls.length = 0
+  supabase.insertCalls.length = 0
+  mockCallWithStructuredPrompt.mockReset()
+})
+
+afterEach(() => {
+  expect(supabase.responseQueue).toHaveLength(0)
+  vi.restoreAllMocks()
+})
+
+// =============================================================================
+// evaluatePost — high-value method
+// =============================================================================
+
+describe('Scoring.evaluatePost', () => {
+  it('happy path with single criterion: weighted total, criteria_scores, legacy field mapping', async () => {
+    supabase.responseQueue.push({
+      data: [makeCriterion({ weight: 5 })],
+      error: null,
+    })
+    mockCallWithStructuredPrompt.mockResolvedValueOnce({ score: 8, reason: 'good' })
+
+    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1') as any
+
+    expect(mockCallWithStructuredPrompt).toHaveBeenCalledTimes(1)
+    expect(result.total_score).toBe(40) // 8 * 5
+    expect(result.criteria_scores).toEqual([
+      { score: 8, reason: 'good', weight: 5, criteria_number: 1 },
+    ])
+    expect(result.interest_level).toBe(8)
+    expect(result.local_relevance).toBe(0)
+    expect(result.community_impact).toBe(0)
+    expect(result.reasoning).toBe('Interest: good')
+
+    // Lock the criteria fetch ordering — evaluation_order then criteria_number.
+    expect(supabase.fromCalls[0].table).toBe('article_module_criteria')
+    expect(supabase.fromCalls[0].eqCalls).toEqual([
+      ['article_module_id', 'mod-1'],
+      ['is_active', true],
+    ])
+    expect(supabase.fromCalls[0].orderCalls).toEqual([
+      ['evaluation_order', { ascending: true }],
+      ['criteria_number', { ascending: true }],
+    ])
+  })
+
+  it('multiple criteria: weighted sum across all evaluated criteria; legacy fields = first 3 scores', async () => {
+    supabase.responseQueue.push({
+      data: [
+        makeCriterion({ criteria_number: 1, name: 'A', weight: 1 }),
+        makeCriterion({ criteria_number: 2, name: 'B', weight: 2 }),
+        makeCriterion({ criteria_number: 3, name: 'C', weight: 3 }),
+      ],
+      error: null,
+    })
+    mockCallWithStructuredPrompt
+      .mockResolvedValueOnce({ score: 5, reason: 'r1' })
+      .mockResolvedValueOnce({ score: 6, reason: 'r2' })
+      .mockResolvedValueOnce({ score: 7, reason: 'r3' })
+
+    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1') as any
+
+    expect(mockCallWithStructuredPrompt).toHaveBeenCalledTimes(3)
+    expect(result.total_score).toBe(5 * 1 + 6 * 2 + 7 * 3) // 38
+    expect(result.criteria_scores).toHaveLength(3)
+    expect(result.interest_level).toBe(5)
+    expect(result.local_relevance).toBe(6)
+    expect(result.community_impact).toBe(7)
+    expect(result.reasoning).toBe('A: r1\n\nB: r2\n\nC: r3')
+  })
+
+  it('provider auto-detect: claude model name routes to claude provider, others to openai', async () => {
+    supabase.responseQueue.push({
+      data: [
+        makeCriterion({
+          criteria_number: 1,
+          ai_prompt: JSON.stringify({ model: 'claude-sonnet-4-6' }),
+        }),
+      ],
+      error: null,
+    })
+    mockCallWithStructuredPrompt.mockResolvedValueOnce({ score: 5, reason: '' })
+
+    await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1')
+
+    const args = mockCallWithStructuredPrompt.mock.calls[0]
+    expect(args[2]).toBe('claude') // provider arg
+
+    // Now the openai branch.
+    supabase.responseQueue.push({
+      data: [makeCriterion({ ai_prompt: JSON.stringify({ model: 'gpt-4o' }) })],
+      error: null,
+    })
+    mockCallWithStructuredPrompt.mockResolvedValueOnce({ score: 5, reason: '' })
+    await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1')
+    expect(mockCallWithStructuredPrompt.mock.calls[1][2]).toBe('openai')
+  })
+
+  it('{{company_name}} placeholder: ticker uppercased, looked up via ticker_company_names; falls back to "" when no mapping', async () => {
+    supabase.responseQueue.push({ data: [makeCriterion()], error: null })
+    supabase.responseQueue.push({
+      data: { company_name: 'Acme Corp' },
+      error: null,
+    })
+    mockCallWithStructuredPrompt.mockResolvedValueOnce({ score: 5, reason: '' })
+
+    await new Scoring().evaluatePost(makePost({ ticker: 'acme' }), 'pub-1', 'primary', 'mod-1')
+
+    expect(supabase.fromCalls[1].table).toBe('ticker_company_names')
+    expect(supabase.fromCalls[1].eqCalls).toEqual([['ticker', 'ACME']])
+    expect(mockCallWithStructuredPrompt.mock.calls[0][1].company_name).toBe('Acme Corp')
+
+    // No-mapping fallback: ticker present but lookup returns null.
+    supabase.responseQueue.push({ data: [makeCriterion()], error: null })
+    supabase.responseQueue.push({ data: null, error: null })
+    mockCallWithStructuredPrompt.mockResolvedValueOnce({ score: 5, reason: '' })
+    await new Scoring().evaluatePost(makePost({ ticker: 'XYZ' }), 'pub-1', 'primary', 'mod-1')
+    expect(mockCallWithStructuredPrompt.mock.calls[1][1].company_name).toBe('')
+
+    // No ticker: ticker_company_names is NOT queried (strict mock asserts this).
+    supabase.responseQueue.push({ data: [makeCriterion()], error: null })
+    mockCallWithStructuredPrompt.mockResolvedValueOnce({ score: 5, reason: '' })
+    await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1')
+    expect(mockCallWithStructuredPrompt.mock.calls[2][1].company_name).toBe('')
+  })
+
+  it.each([
+    { input: 'Sale (Partial)', expected: 'Sale' },
+    { input: 'Purchase (Partial)', expected: 'Purchase' }, // verifies partial-handling claim
+    { input: 'PURCHASE', expected: 'Purchase' },
+    { input: null, expected: '' },
+  ])('{{transaction_type}}: $input → $expected (real normalizeTransactionType)', async ({ input, expected }) => {
+    supabase.responseQueue.push({ data: [makeCriterion()], error: null })
+    mockCallWithStructuredPrompt.mockResolvedValueOnce({ score: 5, reason: '' })
+    await new Scoring().evaluatePost(
+      makePost({ transaction_type: input }),
+      'pub-1', 'primary', 'mod-1',
+    )
+    expect(mockCallWithStructuredPrompt.mock.calls[0][1].transaction_type).toBe(expected)
+  })
+
+  it('early termination: enforce_minimum=true and score < minimum_score skips remaining criteria', async () => {
+    supabase.responseQueue.push({
+      data: [
+        makeCriterion({
+          criteria_number: 1, weight: 4,
+          enforce_minimum: true, minimum_score: 5,
+        }),
+        makeCriterion({ criteria_number: 2, weight: 3 }),
+        makeCriterion({ criteria_number: 3, weight: 2 }),
+      ],
+      error: null,
+    })
+    mockCallWithStructuredPrompt.mockResolvedValueOnce({ score: 4, reason: 'below min' })
+    // Criteria 2 & 3 must NOT be called — no further mockResolvedValueOnce queued.
+
+    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1') as any
+
+    expect(mockCallWithStructuredPrompt).toHaveBeenCalledTimes(1)
+    expect(result.criteria_scores).toHaveLength(1)
+    expect(result.total_score).toBe(4 * 4) // weighted sum over evaluated criteria only
+  })
+
+  it('no early termination when enforce_minimum=false (even if minimum_score is set)', async () => {
+    supabase.responseQueue.push({
+      data: [
+        makeCriterion({
+          criteria_number: 1, weight: 1,
+          enforce_minimum: false, minimum_score: 5,
+        }),
+        makeCriterion({ criteria_number: 2, weight: 1 }),
+      ],
+      error: null,
+    })
+    mockCallWithStructuredPrompt
+      .mockResolvedValueOnce({ score: 1, reason: '' })
+      .mockResolvedValueOnce({ score: 2, reason: '' })
+
+    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1') as any
+
+    expect(mockCallWithStructuredPrompt).toHaveBeenCalledTimes(2)
+    expect(result.criteria_scores).toHaveLength(2)
+  })
+
+  it('throws when moduleId is missing', async () => {
+    await expect(
+      new Scoring().evaluatePost(makePost(), 'pub-1', 'primary'),
+    ).rejects.toThrow(/moduleId is required for scoring/)
+    // Strict mock asserts no DB call was made.
+    expect(supabase.fromCalls).toHaveLength(0)
+  })
+
+  it('throws when criteria fetch returns DB error', async () => {
+    supabase.responseQueue.push({ data: null, error: { message: 'boom' } })
+    await expect(
+      new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1'),
+    ).rejects.toThrow(/Failed to fetch criteria for mod/)
+  })
+
+  it('throws when no active criteria are found', async () => {
+    supabase.responseQueue.push({ data: [], error: null })
+    await expect(
+      new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1'),
+    ).rejects.toThrow(/No active criteria found for mod/)
+  })
+
+  it('throws when a criterion has no ai_prompt configured', async () => {
+    supabase.responseQueue.push({
+      data: [makeCriterion({ ai_prompt: null })],
+      error: null,
+    })
+    await expect(
+      new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1'),
+    ).rejects.toThrow(/has no ai_prompt configured/)
+  })
+
+  it('throws when AI returns non-object response', async () => {
+    supabase.responseQueue.push({ data: [makeCriterion()], error: null })
+    mockCallWithStructuredPrompt.mockResolvedValueOnce('hello' as any)
+    await expect(
+      new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1'),
+    ).rejects.toThrow(/Invalid AI response type/)
+  })
+
+  it.each([
+    { score: -1, label: 'below 0', shouldThrow: true },
+    { score: 11, label: 'above 10', shouldThrow: true },
+    { score: '5' as any, label: 'non-number string', shouldThrow: true },
+    // NaN gap (junior-dev gate W1): typeof NaN === 'number' and NaN < 0 / > 10
+    // are both false, so the guard at scoring.ts:203 lets NaN through. This row
+    // locks the bypass; a future SUT fix should add `Number.isNaN(score)` to
+    // the guard and flip this row to shouldThrow: true.
+    { score: NaN, label: 'NaN (bypasses guard — bug-lock)', shouldThrow: false },
+  ])('AI score $label: shouldThrow=$shouldThrow', async ({ score, shouldThrow }) => {
+    supabase.responseQueue.push({ data: [makeCriterion()], error: null })
+    mockCallWithStructuredPrompt.mockResolvedValueOnce({ score, reason: '' })
+    const promise = new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1')
+    if (shouldThrow) {
+      await expect(promise).rejects.toThrow(/score must be between 0-10/)
+    } else {
+      await expect(promise).resolves.toBeDefined()
+    }
+  })
+})
+
+// =============================================================================
+// scorePostsForSection — orchestration around evaluatePost
+// =============================================================================
+
+describe('Scoring.scorePostsForSection', () => {
+  it('returns {scored:0, errors:0} when no active feeds match the section', async () => {
+    supabase.responseQueue.push({ data: [], error: null })
+
+    const result = await new Scoring().scorePostsForSection('issue-1', 'primary')
+
+    expect(result).toEqual({ scored: 0, errors: 0 })
+    expect(supabase.fromCalls).toHaveLength(1)
+    expect(supabase.fromCalls[0].table).toBe('rss_feeds')
+    expect(supabase.insertCalls).toHaveLength(0)
+  })
+
+  it('section filter: primary uses use_for_primary_section, secondary uses use_for_secondary_section', async () => {
+    // primary
+    supabase.responseQueue.push({ data: [], error: null })
+    await new Scoring().scorePostsForSection('issue-1', 'primary')
+    expect(supabase.fromCalls[0].eqCalls).toEqual([
+      ['active', true],
+      ['use_for_primary_section', true],
+    ])
+
+    // secondary
+    supabase.responseQueue.push({ data: [], error: null })
+    await new Scoring().scorePostsForSection('issue-1', 'secondary')
+    expect(supabase.fromCalls[1].eqCalls).toEqual([
+      ['active', true],
+      ['use_for_secondary_section', true],
+    ])
+  })
+
+  it('inserts a post_ratings row with the expected shape when evaluatePost succeeds', async () => {
+    supabase.responseQueue.push({ data: [{ id: 'feed-1' }], error: null }) // feeds
+    supabase.responseQueue.push({ data: [makePost({ id: 'p-1' })], error: null }) // posts
+    supabase.responseQueue.push({ data: null, error: null }) // post_ratings.insert
+
+    const scoring = new Scoring()
+    vi.spyOn(scoring, 'evaluatePost').mockResolvedValue({
+      interest_level: 7,
+      local_relevance: 8,
+      community_impact: 9,
+      reasoning: 'r',
+      criteria_scores: [
+        { score: 7, reason: 'a', weight: 1, criteria_number: 1 },
+        { score: 8, reason: 'b', weight: 2, criteria_number: 2 },
+      ],
+      total_score: 99,
+    } as any)
+
+    const result = await scoring.scorePostsForSection('issue-1', 'primary')
+
+    expect(result).toEqual({ scored: 1, errors: 0 })
+
+    const insert = supabase.insertCalls.find(c => c.table === 'post_ratings')
+    expect(insert).toBeDefined()
+    const payload = insert!.payload[0]
+    expect(payload.post_id).toBe('p-1')
+    expect(payload.interest_level).toBe(7)
+    expect(payload.local_relevance).toBe(8)
+    expect(payload.community_impact).toBe(9)
+    expect(payload.ai_reasoning).toBe('r')
+    expect(payload.total_score).toBe(99) // explicit total_score wins over fallback
+    expect(payload.criteria_1_score).toBe(7)
+    expect(payload.criteria_1_reason).toBe('a')
+    expect(payload.criteria_1_weight).toBe(1)
+    expect(payload.criteria_2_score).toBe(8)
+    expect(payload.criteria_2_reason).toBe('b')
+    expect(payload.criteria_2_weight).toBe(2)
+  })
+
+  it('total_score fallback when evaluation.total_score is absent: (interest+local+community)/30 * 100', async () => {
+    supabase.responseQueue.push({ data: [{ id: 'feed-1' }], error: null })
+    supabase.responseQueue.push({ data: [makePost()], error: null })
+    supabase.responseQueue.push({ data: null, error: null })
+
+    const scoring = new Scoring()
+    vi.spyOn(scoring, 'evaluatePost').mockResolvedValue({
+      interest_level: 6,
+      local_relevance: 6,
+      community_impact: 6,
+      reasoning: 'r',
+      criteria_scores: [],
+      // total_score intentionally absent
+    } as any)
+
+    await scoring.scorePostsForSection('issue-1', 'primary')
+
+    const payload = supabase.insertCalls[0].payload[0]
+    // (6 + 6 + 6) / 30 * 100 = 60
+    expect(payload.total_score).toBe(60)
+  })
+
+  it('locks current bug-shape: scorePostsForSection does not pass moduleId, so every post errors out', async () => {
+    // Locks bug from issue #62: scorePostsForSection at scoring.ts:61 calls
+    // evaluatePost(post, newsletterId, section) with no moduleId, but
+    // evaluatePost throws on missing moduleId at scoring.ts:121 BEFORE any DB
+    // call. Every post lands in the catch branch and increments errorCount.
+    //
+    // When a fix threads moduleId through scorePostsForSection, this test will
+    // break — update it to verify successful scoring instead of the error path.
+    supabase.responseQueue.push({ data: [{ id: 'feed-1' }], error: null }) // feeds
+    supabase.responseQueue.push({
+      data: [makePost({ id: 'p-1' }), makePost({ id: 'p-2' }), makePost({ id: 'p-3' })],
+      error: null,
+    })
+    // No further DB responses — evaluatePost throws before any from() call.
+
+    const result = await new Scoring().scorePostsForSection('issue-1', 'primary')
+
+    expect(result).toEqual({ scored: 0, errors: 3 })
+    expect(supabase.insertCalls).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

Adds 24 unit tests for `src/lib/rss-processor/scoring.ts` — the multi-criteria AI scoring algorithm that ranks every article in the newsletter pipeline. Closes #62. **Test-only PR; no production code changed.**

## Why this still applies (issue was filed 2026-03-02)

`scoring.ts` is now 245 lines (was 216 in the issue), same two methods, still zero tests. Six commits since the issue was filed added behavior that's all currently untested:
- `88c37316` — early termination when `enforce_minimum=true` and score < `minimum_score`
- `eb29cd91` — configurable `evaluation_order` ordering
- `20332c29` / `19bb50d1` / `1eb89d1c` — `{{company_name}}` placeholder fed from `ticker_company_names` lookup
- `77e261dc` — `{{transaction_type}}` placeholder via `normalizeTransactionType`

## What's covered

**`evaluatePost` (19 sub-tests across 12 `it`/`it.each` blocks):**
- Single-criterion happy path: weighted total math, criteria_scores, legacy `interest_level`/`local_relevance`/`community_impact` mapping, criteria fetch ordering (evaluation_order then criteria_number)
- Multi-criterion weighted sum + reasoning concatenation
- Provider auto-detect (claude vs openai based on model name)
- `{{company_name}}` placeholder via `ticker_company_names` lookup with uppercased ticker; covers has-mapping, no-mapping, and no-ticker branches (last enforced via strict-mock — ticker_company_names must NOT be queried)
- `{{transaction_type}}` placeholder using **real** `normalizeTransactionType` (no mock) — 4 cases including partial-handling and null
- Early termination fires when `enforce_minimum=true` and `score < minimum_score`
- No early termination when `enforce_minimum=false` even if `minimum_score` is set
- Validation throws: missing `moduleId`, criteria fetch DB error, no active criteria, missing `ai_prompt`, non-object AI response
- Score out-of-range (`it.each`): below 0, above 10, non-number string
- **NaN bug-lock**: locks the current bypass at scoring.ts:203 (`typeof NaN === 'number'` and the comparisons return false). When the SUT is fixed to use `Number.isNaN`, this row should flip to `shouldThrow: true`.

**`scorePostsForSection` (5 tests):**
- No active feeds → `{scored: 0, errors: 0}` immediately
- Section filter: primary uses `use_for_primary_section`, secondary uses `use_for_secondary_section`
- post_ratings insert payload shape (with `vi.spyOn` on `evaluatePost`)
- `total_score` fallback: `(interest+local+community)/30 * 100` when `evaluation.total_score` is absent
- **Bug-lock**: scoring.ts:61 calls `this.evaluatePost(post, newsletterId, section)` with no `moduleId`, but evaluatePost throws on missing moduleId at scoring.ts:121. Test asserts `{scored: 0, errors: <postCount>}` and zero inserts. When the underlying bug is fixed, this test will break and force a deliberate update.

## Mocking strategy

Strict-supabase chainable mock pattern (post-#63 / PR #230 variant): `from()` throws on empty queue so silent extra DB calls surface as immediate failures. `afterEach` asserts queue exhaustion. Hoisted `vi.fn` for `callWithStructuredPrompt`. Real `normalizeTransactionType` (no mock). `getNewsletterIdFromIssue` mocked to fixed publication id.

## Pre-push gate

- `/simplify` — clean (one `it.each` refactor for `transaction_type`)
- `/requesting-code-review` — Ready to merge with 3 minor suggestions (all applied: added Purchase (Partial) row, added issue #62 reference to bug-lock comment, added comment on `chain.then` thenable)
- `/review:pre-push` — passed. 5 Warnings, all pre-existing SUT issues outside this PR's test-only scope (see Followups). Pushed back on one DBA Critical: the flagged criteria query is unchanged by this PR.

## Followup issues to file (separate PRs)

These were surfaced by gate review but are out of scope for a test-only PR:
- **SUT bug**: `scorePostsForSection` doesn't propagate `moduleId` to `evaluatePost` (scoring.ts:61 vs 121) — currently locked by test 16
- **SUT bug**: NaN bypasses the score-range guard at scoring.ts:203 — currently locked by the `it.each` row
- **Project-rule violations**: `select('*')` on rss_posts; feeds/criteria/posts queries missing `publication_id` filters
- **Test infra**: chain mock should record `.select()` args so `select('*')` violations are catchable in tests
- **Type widening**: `ContentEvaluation` should formally include `criteria_scores` and `total_score` so the SUT and tests can drop `as any` casts

## Test plan

- [x] `npm run test:run -- src/lib/rss-processor/__tests__/scoring.test.ts` — 24/24 pass
- [x] `npm run type-check` — clean
- [x] `npm run test:run` (full suite) — 38 files / 599 → 622 tests pass
- [x] Pre-push gate — passed (5 Warnings, all pre-existing SUT)
- [ ] Post-merge: nothing to verify in production (test-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the scoring evaluation logic, including end-to-end evaluation workflows, error handling, and edge case validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->