### PR TITLE
fix(scoring): NaN guard, moduleId propagation, ContentEvaluation widening

### DIFF
--- a/src/lib/rss-processor/__tests__/scoring.test.ts
+++ b/src/lib/rss-processor/__tests__/scoring.test.ts
@@ -137,7 +137,7 @@ describe('Scoring.evaluatePost', () => {
     })
     mockCallWithStructuredPrompt.mockResolvedValueOnce({ score: 8, reason: 'good' })
 
-    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1') as any
+    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1')
 
     expect(mockCallWithStructuredPrompt).toHaveBeenCalledTimes(1)
     expect(result.total_score).toBe(40) // 8 * 5
@@ -175,7 +175,7 @@ describe('Scoring.evaluatePost', () => {
       .mockResolvedValueOnce({ score: 6, reason: 'r2' })
       .mockResolvedValueOnce({ score: 7, reason: 'r3' })
 
-    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1') as any
+    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1')
 
     expect(mockCallWithStructuredPrompt).toHaveBeenCalledTimes(3)
     expect(result.total_score).toBe(5 * 1 + 6 * 2 + 7 * 3) // 38
@@ -271,7 +271,7 @@ describe('Scoring.evaluatePost', () => {
     mockCallWithStructuredPrompt.mockResolvedValueOnce({ score: 4, reason: 'below min' })
     // Criteria 2 & 3 must NOT be called — no further mockResolvedValueOnce queued.
 
-    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1') as any
+    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1')
 
     expect(mockCallWithStructuredPrompt).toHaveBeenCalledTimes(1)
     expect(result.criteria_scores).toHaveLength(1)
@@ -293,7 +293,7 @@ describe('Scoring.evaluatePost', () => {
       .mockResolvedValueOnce({ score: 1, reason: '' })
       .mockResolvedValueOnce({ score: 2, reason: '' })
 
-    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1') as any
+    const result = await new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1')
 
     expect(mockCallWithStructuredPrompt).toHaveBeenCalledTimes(2)
     expect(result.criteria_scores).toHaveLength(2)
@@ -340,23 +340,16 @@ describe('Scoring.evaluatePost', () => {
   })
 
   it.each([
-    { score: -1, label: 'below 0', shouldThrow: true },
-    { score: 11, label: 'above 10', shouldThrow: true },
-    { score: '5' as any, label: 'non-number string', shouldThrow: true },
-    // NaN gap (junior-dev gate W1): typeof NaN === 'number' and NaN < 0 / > 10
-    // are both false, so the guard at scoring.ts:203 lets NaN through. This row
-    // locks the bypass; a future SUT fix should add `Number.isNaN(score)` to
-    // the guard and flip this row to shouldThrow: true.
-    { score: NaN, label: 'NaN (bypasses guard — bug-lock)', shouldThrow: false },
-  ])('AI score $label: shouldThrow=$shouldThrow', async ({ score, shouldThrow }) => {
+    { score: -1, label: 'below 0' },
+    { score: 11, label: 'above 10' },
+    { score: '5' as any, label: 'non-number string' },
+    { score: NaN, label: 'NaN' },
+  ])('throws when AI score is $label ($score)', async ({ score }) => {
     supabase.responseQueue.push({ data: [makeCriterion()], error: null })
     mockCallWithStructuredPrompt.mockResolvedValueOnce({ score, reason: '' })
-    const promise = new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1')
-    if (shouldThrow) {
-      await expect(promise).rejects.toThrow(/score must be between 0-10/)
-    } else {
-      await expect(promise).resolves.toBeDefined()
-    }
+    await expect(
+      new Scoring().evaluatePost(makePost(), 'pub-1', 'primary', 'mod-1'),
+    ).rejects.toThrow(/score must be between 0-10/)
   })
 })
 
@@ -410,7 +403,7 @@ describe('Scoring.scorePostsForSection', () => {
         { score: 8, reason: 'b', weight: 2, criteria_number: 2 },
       ],
       total_score: 99,
-    } as any)
+    })
 
     const result = await scoring.scorePostsForSection('issue-1', 'primary')
 
@@ -446,7 +439,7 @@ describe('Scoring.scorePostsForSection', () => {
       reasoning: 'r',
       criteria_scores: [],
       // total_score intentionally absent
-    } as any)
+    })
 
     await scoring.scorePostsForSection('issue-1', 'primary')
 
@@ -455,24 +448,58 @@ describe('Scoring.scorePostsForSection', () => {
     expect(payload.total_score).toBe(60)
   })
 
-  it('locks current bug-shape: scorePostsForSection does not pass moduleId, so every post errors out', async () => {
-    // Locks bug from issue #62: scorePostsForSection at scoring.ts:61 calls
-    // evaluatePost(post, newsletterId, section) with no moduleId, but
-    // evaluatePost throws on missing moduleId at scoring.ts:121 BEFORE any DB
-    // call. Every post lands in the catch branch and increments errorCount.
-    //
-    // When a fix threads moduleId through scorePostsForSection, this test will
-    // break — update it to verify successful scoring instead of the error path.
+  it('passes post.article_module_id through to evaluatePost', async () => {
     supabase.responseQueue.push({ data: [{ id: 'feed-1' }], error: null }) // feeds
     supabase.responseQueue.push({
-      data: [makePost({ id: 'p-1' }), makePost({ id: 'p-2' }), makePost({ id: 'p-3' })],
+      data: [
+        makePost({ id: 'p-1', article_module_id: 'mod-1' }),
+        makePost({ id: 'p-2', article_module_id: 'mod-1' }),
+      ],
       error: null,
     })
-    // No further DB responses — evaluatePost throws before any from() call.
+
+    const scoring = new Scoring()
+    const evalSpy = vi.spyOn(scoring, 'evaluatePost').mockResolvedValue({
+      interest_level: 5,
+      local_relevance: 5,
+      community_impact: 5,
+      reasoning: 'r',
+      criteria_scores: [{ score: 5, reason: 'r', weight: 1, criteria_number: 1 }],
+      total_score: 50,
+    })
+
+    // Each successful evaluation triggers a post_ratings insert.
+    supabase.responseQueue.push({ data: null, error: null })
+    supabase.responseQueue.push({ data: null, error: null })
+
+    const result = await scoring.scorePostsForSection('issue-1', 'primary')
+
+    expect(result).toEqual({ scored: 2, errors: 0 })
+    expect(evalSpy).toHaveBeenCalledTimes(2)
+    // Fourth arg is moduleId — verify it came from the post.
+    expect(evalSpy.mock.calls[0][3]).toBe('mod-1')
+    expect(evalSpy.mock.calls[1][3]).toBe('mod-1')
+  })
+
+  it('errors out gracefully when post.article_module_id is null', async () => {
+    // The existing guard at scoring.ts:121 throws when moduleId is missing.
+    // scorePostsForSection catches this, increments errorCount, and continues.
+    // Locks the no-module fallback shape — posts without module assignment
+    // are surfaced as errors rather than crashing the whole batch.
+    supabase.responseQueue.push({ data: [{ id: 'feed-1' }], error: null })
+    supabase.responseQueue.push({
+      data: [
+        makePost({ id: 'p-1', article_module_id: null }),
+        makePost({ id: 'p-2', article_module_id: null }),
+      ],
+      error: null,
+    })
+    // No further DB responses — evaluatePost throws on missing moduleId
+    // before any from() call.
 
     const result = await new Scoring().scorePostsForSection('issue-1', 'primary')
 
-    expect(result).toEqual({ scored: 0, errors: 3 })
+    expect(result).toEqual({ scored: 0, errors: 2 })
     expect(supabase.insertCalls).toHaveLength(0)
   })
 })

--- a/src/lib/rss-processor/feed-ingestion.ts
+++ b/src/lib/rss-processor/feed-ingestion.ts
@@ -415,11 +415,11 @@ export class FeedIngestion {
       local_relevance: evaluation.local_relevance,
       community_impact: evaluation.community_impact,
       ai_reasoning: evaluation.reasoning,
-      total_score: (evaluation as any).total_score ||
+      total_score: evaluation.total_score ??
         ((evaluation.interest_level + evaluation.local_relevance + evaluation.community_impact) / 30 * 100)
     }
 
-    const criteriaScores = (evaluation as any).criteria_scores
+    const criteriaScores = evaluation.criteria_scores
     if (criteriaScores && Array.isArray(criteriaScores)) {
       for (let k = 0; k < criteriaScores.length && k < 5; k++) {
         const criterionNum = k + 1

--- a/src/lib/rss-processor/legacy.ts
+++ b/src/lib/rss-processor/legacy.ts
@@ -439,10 +439,10 @@ export class Legacy {
             local_relevance: evaluation.local_relevance,
             community_impact: evaluation.community_impact,
             ai_reasoning: evaluation.reasoning,
-            total_score: (evaluation as any).total_score || ((evaluation.interest_level + evaluation.local_relevance + evaluation.community_impact) / 30 * 100)
+            total_score: evaluation.total_score ?? ((evaluation.interest_level + evaluation.local_relevance + evaluation.community_impact) / 30 * 100)
           }
 
-          const criteriaScores = (evaluation as any).criteria_scores
+          const criteriaScores = evaluation.criteria_scores
           if (criteriaScores && Array.isArray(criteriaScores)) {
             for (let k = 0; k < criteriaScores.length && k < 5; k++) {
               const criterionNum = k + 1

--- a/src/lib/rss-processor/scoring.ts
+++ b/src/lib/rss-processor/scoring.ts
@@ -58,7 +58,7 @@ export class Scoring {
       for (let j = 0; j < batch.length; j++) {
         const post = batch[j]
         try {
-          const evaluation = await this.evaluatePost(post, newsletterId, section)
+          const evaluation = await this.evaluatePost(post, newsletterId, section, post.article_module_id)
 
           if (typeof evaluation.interest_level !== 'number' ||
               typeof evaluation.local_relevance !== 'number' ||
@@ -72,10 +72,10 @@ export class Scoring {
             local_relevance: evaluation.local_relevance,
             community_impact: evaluation.community_impact,
             ai_reasoning: evaluation.reasoning,
-            total_score: (evaluation as any).total_score || ((evaluation.interest_level + evaluation.local_relevance + evaluation.community_impact) / 30 * 100)
+            total_score: evaluation.total_score ?? ((evaluation.interest_level + evaluation.local_relevance + evaluation.community_impact) / 30 * 100)
           }
 
-          const criteriaScores = (evaluation as any).criteria_scores
+          const criteriaScores = evaluation.criteria_scores
           if (criteriaScores && Array.isArray(criteriaScores)) {
             for (let k = 0; k < criteriaScores.length && k < 5; k++) {
               const criterionNum = criteriaScores[k].criteria_number || (k + 1)
@@ -97,6 +97,7 @@ export class Scoring {
           batchSuccess++
 
         } catch (error) {
+          console.error(`[Score] evaluatePost failed for post ${post.id}:`, error instanceof Error ? error.message : error)
           errorCount++
           batchErrors++
         }
@@ -200,7 +201,7 @@ export class Scoring {
         const score = result.score
         const reason = result.reason || ''
 
-        if (typeof score !== 'number' || score < 0 || score > 10) {
+        if (typeof score !== 'number' || Number.isNaN(score) || score < 0 || score > 10) {
           throw new Error(`Criterion ${criterion.number} score must be between 0-10, got ${score} (type: ${typeof score})`)
         }
 
@@ -234,12 +235,12 @@ export class Scoring {
 
     // Return evaluation in legacy format for backward compatibility
     return {
-      interest_level: criteriaScores[0]?.score || 0,
-      local_relevance: criteriaScores[1]?.score || 0,
-      community_impact: criteriaScores[2]?.score || 0,
+      interest_level: criteriaScores[0]?.score ?? 0,
+      local_relevance: criteriaScores[1]?.score ?? 0,
+      community_impact: criteriaScores[2]?.score ?? 0,
       reasoning: criteriaScores.map((c, i) => `${criteria[i]?.name}: ${c.reason}`).join('\n\n'),
       criteria_scores: criteriaScores,
       total_score: totalWeightedScore
-    } as any
+    }
   }
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -959,6 +959,8 @@ export interface ContentEvaluation {
   local_relevance: number
   community_impact: number
   reasoning: string
+  criteria_scores?: Array<{ score: number; reason: string; weight: number; criteria_number: number }>
+  total_score?: number
 }
 
 export interface NewsletterContent {


### PR DESCRIPTION
## Summary

Followup to #231 — addresses 3 of the 5 SUT findings surfaced by its pre-push gate review. **Touches the active cron path through `feed-ingestion.ts:404`**; behavior change documented below.

## What's fixed

### Fix 1 — `scorePostsForSection` moduleId propagation (`scoring.ts:61`)
Pass `post.article_module_id` as the 4th arg to `evaluatePost`. Previously the function passed `undefined`, hitting `evaluatePost`'s missing-moduleId guard at `scoring.ts:121`, so every post errored. The active cron path (`feed-ingestion.ts:404`) was already passing it; this aligns the secondary path that's invoked from non-cron API routes (`/api/rss/steps/score-posts`, `/api/rss/combined-steps/step2-extract-score`, `/api/rss/combined-steps/step3-score`).

The PR #231 bug-lock test is converted to a happy-path test that asserts the moduleId is propagated; a new test covers the null-moduleId fallback (errorCount increments per post, no `post_ratings` insert).

### Fix 2 — NaN guard (`scoring.ts:203`)
Added `Number.isNaN(score)` to the score-range validation OR. `typeof NaN === 'number'` is true and `NaN < 0` / `NaN > 10` are both false, so NaN was slipping through and getting written to `post_ratings.total_score`, then poisoning downstream weighted totals at `module-articles.ts:146-147` and `article-selector.ts:69-70`. The NaN row in the score-validation `it.each` is now a regular throw case.

### Fix 3 — `ContentEvaluation` type widening (`database.ts:957`)
Added optional `criteria_scores` and `total_score` fields. Drops 9 `as any` casts across `scoring.ts` (3), `feed-ingestion.ts` (2), `legacy.ts` (2), and `scoring.test.ts` (6). Optional (not required) so consumers can still supply `ContentEvaluation` without those fields.

## Gate-driven cleanups (bundled in this PR)

- `||` → `??` for `total_score` fallback at 3 sites (`scoring.ts:75`, `feed-ingestion.ts:418`, `legacy.ts:442`) and legacy field defaults (`scoring.ts:237-239`). In practice the math means a true-0 weighted total only happens when legacy fields are also 0, so the `||` quirk produces the same value — but `??` is semantically correct against future scoring-model changes.
- Added `console.error` in `scoring.ts:99` catch so per-post failures surface in logs instead of just the per-batch count.

## Out of scope (followup PRs)

- **Logging in `feed-ingestion.ts:258-262`** — `Promise.allSettled` discards rejected results in the active cron path; ops gate flagged this as Warning. Touches the production cron, deserves its own scoped PR.
- **Monitoring alert** when `errorCount / total > 20%` per scoring run — DBA gate suggestion. Needs Slack hook setup.
- **UUID validation guard on moduleId before logging** (`scoring.ts:134, 139, 151`) — security gate flagged log-injection theory; low real-world risk (DB-sourced UUIDs), separate hardening.
- **`select('*')` on `rss_posts` and missing `publication_id` filters** — pre-existing project-rule violations, broader cleanup.
- **Test infra: chain mock `.select()` recording** — would let tests assert against `select('*')` violations.

## Production behavior change

NaN scores from a flaky AI now throw (and are caught one level up in `feed-ingestion.ts`'s `Promise.allSettled` block). Net effect: small uptick in errored-post count, no more NaN poisoning `post_ratings`. Monitor the 15-min `ingest-rss` cron after merge.

## Pre-push gate

- `/simplify` — clean
- `/requesting-code-review` — APPROVE; one Minor (drop sibling `as any` casts in `feed-ingestion.ts` and `legacy.ts`) applied inline
- `/review:pre-push` — 1 Critical (`||` zero-falsy quirk) and 4 Warnings; Critical fixed inline (`||→??`), Warnings deferred per scope

## Test plan

- [x] `npm run test:run -- src/lib/rss-processor/__tests__/scoring.test.ts` — 25/25 pass
- [x] `npm run type-check` — clean (verifies all `as any` removals are sound)
- [x] `npm run test:run` (full suite) — 38 files / 604 tests pass
- [x] Pre-push checks (lint, build, bug-pattern) — passed
- [ ] Post-merge: monitor next 1-2 `ingest-rss` cron runs for any NaN-related error logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)