### PR TITLE
feat(subscribe): pass phone end-to-end through subscribe → offers → info → personalize API

### DIFF
--- a/src/app/api/subscribe/personalize/route.ts
+++ b/src/app/api/subscribe/personalize/route.ts
@@ -33,12 +33,16 @@ export const POST = withApiHandler(
   { authTier: 'public', logContext: 'subscribe-personalize' },
   async ({ request, logger }) => {
     const body = await request.json()
-    const { email, original_email, name, last_name, job_type, yearly_clients } = body
+    const { email, original_email, name, last_name, phone, job_type, yearly_clients } = body
+
+    // Phone is optional — only persist when present and non-empty after trim.
+    const trimmedPhone = typeof phone === 'string' ? phone.trim() : ''
 
     console.log(`[Personalize] Received request for ${email}`, {
       original_email,
       name,
       last_name,
+      has_phone: Boolean(trimmedPhone),
       job_type,
       yearly_clients
     })
@@ -69,6 +73,7 @@ export const POST = withApiHandler(
 
       if (name) fields.first_name = name
       if (last_name) fields.last_name = last_name
+      if (trimmedPhone) fields.phone = trimmedPhone
       if (job_type) fields.job_type = job_type
       if (yearly_clients) fields.yearly_clients = yearly_clients
 
@@ -86,7 +91,11 @@ export const POST = withApiHandler(
           const upsertResult = await sendgrid.upsertContact(email, {
             firstName: name,
             lastName: last_name,
-            customFields: { job_type, yearly_clients }
+            customFields: {
+              ...(trimmedPhone ? { phone: trimmedPhone } : {}),
+              job_type,
+              yearly_clients,
+            }
           })
 
           if (!upsertResult.success) {
@@ -106,7 +115,11 @@ export const POST = withApiHandler(
           const upsertResult = await sendgrid.upsertContact(email, {
             firstName: name,
             lastName: last_name,
-            customFields: { job_type, yearly_clients }
+            customFields: {
+              ...(trimmedPhone ? { phone: trimmedPhone } : {}),
+              job_type,
+              yearly_clients,
+            }
           })
 
           if (!upsertResult.success) {
@@ -134,6 +147,7 @@ export const POST = withApiHandler(
       const beehiivCustomFields: Array<{ name: string; value: string }> = []
       if (name) beehiivCustomFields.push({ name: 'first_name', value: name })
       if (last_name) beehiivCustomFields.push({ name: 'last_name', value: last_name })
+      if (trimmedPhone) beehiivCustomFields.push({ name: 'phone', value: trimmedPhone })
       if (job_type) beehiivCustomFields.push({ name: 'job_type', value: job_type })
       if (yearly_clients) beehiivCustomFields.push({ name: 'yearly_clients', value: yearly_clients })
 
@@ -184,6 +198,7 @@ export const POST = withApiHandler(
 
       if (name) fields.name = name
       if (last_name) fields.last_name = last_name
+      if (trimmedPhone) fields.phone = trimmedPhone
       if (job_type) fields.job_type = job_type
       if (yearly_clients) fields.yearly_clients = yearly_clients
 

--- a/src/app/website/subscribe/info/personalization-form.tsx
+++ b/src/app/website/subscribe/info/personalization-form.tsx
@@ -40,6 +40,7 @@ export function PersonalizationForm({
 }: PersonalizationFormProps) {
   const searchParams = useSearchParams()
   const urlEmail = searchParams.get('email') || ''
+  const urlPhone = searchParams.get('phone') || ''
 
   // Check if URL email is valid, otherwise try sessionStorage
   const getInitialEmail = () => {
@@ -57,7 +58,20 @@ export function PersonalizationForm({
     return ''
   }
 
+  // Same dual-source pattern as email — URL first, sessionStorage fallback.
+  // Phone is optional; empty string is acceptable. Guard against
+  // unrendered Liquid/handlebars placeholders (e.g. `{{phone}}`) that an
+  // upstream template might have leaked, mirroring the email-side guard.
+  const getInitialPhone = () => {
+    if (urlPhone && !urlPhone.includes('{{')) return urlPhone
+    if (typeof window !== 'undefined') {
+      return sessionStorage.getItem('subscribe_phone') || ''
+    }
+    return ''
+  }
+
   const [email, setEmail] = useState('')
+  const [phone, setPhone] = useState('')
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')
   const [jobType, setJobType] = useState('')
@@ -73,7 +87,13 @@ export function PersonalizationForm({
     } else {
       setError('No email found. Please go back and subscribe first.')
     }
-  }, [urlEmail])
+
+    // Phone is optional — silently absent is fine, no error message needed.
+    const initialPhone = getInitialPhone()
+    if (initialPhone) {
+      setPhone(initialPhone)
+    }
+  }, [urlEmail, urlPhone])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -106,6 +126,7 @@ export function PersonalizationForm({
       const storedEmail = sessionStorage.getItem('subscribe_email') || ''
       const emailChanged = email !== storedEmail && storedEmail !== ''
 
+      const trimmedPhone = phone.trim()
       const response = await fetch('/api/subscribe/personalize', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -114,6 +135,7 @@ export function PersonalizationForm({
           original_email: emailChanged ? storedEmail : undefined,
           name: firstName.trim(),
           last_name: lastName.trim(),
+          ...(trimmedPhone ? { phone: trimmedPhone } : {}),
           ...(jobEnabled ? { job_type: jobType } : {}),
           ...(clientsEnabled ? { yearly_clients: yearlyClients } : {}),
         })

--- a/src/app/website/subscribe/offers/offers-content.tsx
+++ b/src/app/website/subscribe/offers/offers-content.tsx
@@ -24,6 +24,7 @@ export function OffersContent({ logoUrl, newsletterName, afteroffersFormId }: Of
   const searchParams = useSearchParams()
   const email = searchParams.get('email') || ''
   const urlClickId = searchParams.get('click_id') || ''
+  const urlPhone = searchParams.get('phone') || ''
   const [clickId, setClickId] = useState('')
   // Sized to fit the typical AfterOffers form (~5 offers + email + button).
   // The listener below expands this if AfterOffers reports a taller content
@@ -45,6 +46,17 @@ export function OffersContent({ logoUrl, newsletterName, afteroffersFormId }: Of
       console.log('[SparkLoop] User subscribed to recommendations:', subscribed === 'true')
     }
   }, [email])
+
+  // Forward phone to sessionStorage when present in the URL — keeps the
+  // downstream info page in sync with the subscribe-form's earlier write.
+  useEffect(() => {
+    if (!urlPhone) return
+    try {
+      sessionStorage.setItem('subscribe_phone', urlPhone)
+    } catch {
+      // Ignore storage errors (private mode, disabled storage, etc.)
+    }
+  }, [urlPhone])
 
   // Derive click_id from URL, sessionStorage, or generate a new one.
   // Always call setClickId even if sessionStorage fails.
@@ -157,6 +169,7 @@ export function OffersContent({ logoUrl, newsletterName, afteroffersFormId }: Of
                 frameBorder="0"
                 scrolling="auto"
                 sandbox="allow-forms allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox allow-same-origin"
+                referrerPolicy="strict-origin"
                 className="w-full block"
                 style={{ height: `${iframeHeight}px` }}
               />

--- a/src/app/website/subscribe/subscribe-form.tsx
+++ b/src/app/website/subscribe/subscribe-form.tsx
@@ -84,6 +84,7 @@ export function SubscribeForm({
   const [didYouMean, setDidYouMean] = useState('')
   const [showSparkLoopModal, setShowSparkLoopModal] = useState(false)
   const [subscribedEmail, setSubscribedEmail] = useState('')
+  const [subscribedPhone, setSubscribedPhone] = useState('')
 
   // Handle modal close
   const handleModalClose = useCallback(() => {
@@ -97,6 +98,9 @@ export function SubscribeForm({
     try {
       if (typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined') {
         window.sessionStorage.setItem('afteroffers_click_id', clickId)
+        if (subscribedPhone) {
+          window.sessionStorage.setItem('subscribe_phone', subscribedPhone)
+        }
         // eslint-disable-next-line no-console
         console.log('[AfterOffers] Generated click_id for subscribe flow', clickId)
       }
@@ -116,8 +120,9 @@ export function SubscribeForm({
       }),
     }).catch(() => { /* non-critical */ })
 
-    window.location.href = `/subscribe/offers?email=${encodeURIComponent(subscribedEmail)}&click_id=${encodeURIComponent(clickId)}`
-  }, [subscribedEmail, publicationId])
+    const phoneParam = subscribedPhone ? `&phone=${encodeURIComponent(subscribedPhone)}` : ''
+    window.location.href = `/subscribe/offers?email=${encodeURIComponent(subscribedEmail)}&click_id=${encodeURIComponent(clickId)}${phoneParam}`
+  }, [subscribedEmail, subscribedPhone, publicationId])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -160,8 +165,11 @@ export function SubscribeForm({
           window.fbq('track', 'Lead')
         }
 
-        // Store email and show custom SparkLoop modal
+        // Store email + phone snapshot for the post-modal redirect, then
+        // show the custom SparkLoop modal. Phone falls back to '' if the
+        // form didn't collect one.
         setSubscribedEmail(email)
+        setSubscribedPhone(trimmedPhone)
         setShowSparkLoopModal(true)
       } else {
         setError(data.error || 'Subscription failed. Please try again.')


### PR DESCRIPTION
## Summary

Wires phone number through the entire subscribe flow when a publication's subscribe page collects it (`subscribe_page.collect_phone === 'true'`). Previously phone was saved on the email provider during `/api/subscribe` but **dropped from every downstream page**. Now it flows end-to-end so the personalize step can see and re-persist it.

**No-phone path is byte-identical to before** — every new write is conditional on `trimmedPhone` being non-empty.

## Files changed (2 commits)

### Commit 1 — `feat(subscribe): pass phone to next page via URL + sessionStorage`
- **`src/app/website/subscribe/subscribe-form.tsx`** — captures `subscribedPhone` snapshot, writes to `sessionStorage.subscribe_phone`, conditionally appends `&phone=...` to the redirect URL
- **`src/app/website/subscribe/offers/offers-content.tsx`** — reads URL phone, mirrors to sessionStorage; AfterOffers iframe now uses `referrerPolicy=\"strict-origin\"` to keep PII out of Referer headers

### Commit 2 — `feat(subscribe): wire phone read on personalization form + persist via personalize API`
- **`src/app/website/subscribe/info/personalization-form.tsx`** — same dual-source read (URL → sessionStorage fallback), guards against unrendered `{{phone}}` placeholders, includes `phone: trimmedPhone` in the personalize POST body
- **`src/app/api/subscribe/personalize/route.ts`** — accepts optional `phone`, trims once, persists conditionally across SendGrid (`fields.phone` + upsert `customFields.phone`), Beehiiv (`{ name: 'phone', value: ... }` in `beehiivCustomFields`), and MailerLite (`fields.phone`). Log line uses `has_phone: Boolean(trimmedPhone)` instead of the raw value to keep PII out of logs.

## Field name symmetry

The `phone` custom-field name matches `/api/subscribe/route.ts:108-110` across all three providers — downstream segmentation/automations see one consistent field regardless of which entry point set it.

## Iframe Referer hardening

Switched the AfterOffers iframe to `referrerPolicy=\"strict-origin\"`. Prior to this PR the Referer header sent the full URL (email + click_id) to AfterOffers' logs. Now only the origin is sent — PII stays out of their logs while attribution / fraud detection still works. Considered `\"no-referrer\"` but QA gate flagged that stripping the Referer entirely could break postback attribution for all publications, not just phone-collecting ones.

## Pre-commit gates

- `/simplify` — clean across both commits
- `/requesting-code-review` — APPROVE on both commits; minor fixes applied inline (`strict-origin` over `no-referrer`, `{{phone}}` placeholder guard on `getInitialPhone`)
- `/review:pre-push` — frontend gate (commit 1) passed with documented warnings; backend changes (commit 2) reviewed via code-reviewer subagent

## Manual test plan

- [ ] **No phone collection**: Submit form on a publication with `collect_phone=false` — confirm redirect URL is byte-identical to pre-change (no `&phone=`), no sessionStorage key written, personalize body omits `phone`
- [ ] **Phone collection happy path**: Submit form with phone — confirm URL has `&phone=` (encoded), sessionStorage has trimmed value, offers page mirrors it, info page reads it, personalize POST includes `phone`, email provider's subscriber record shows phone in custom fields
- [ ] **Direct-load offers page** with `?phone=...` — sessionStorage gets populated by the useEffect
- [ ] **Direct-load info page** with `?phone=...` — phone state populated, included in personalize submit
- [ ] **AfterOffers postback attribution** still works after the `strict-origin` Referer change — complete an offer and confirm it lands in the AfterOffers dashboard against the correct `click_id`
- [ ] **Phone preservation**: User completes subscribe with phone, then completes personalize without phone in URL/sessionStorage (e.g. fresh tab) — confirm existing phone on subscriber is NOT overwritten (every provider branch gates on `if (trimmedPhone)`)

## Out of scope (worth filing as followups)

- The duplicated `generateAfterOffersClickId` helper between `subscribe-form.tsx` and `offers-content.tsx` (pre-existing)
- Unit tests for `personalization-form.tsx` — there's no existing test coverage for any client form component in this project
- SendGrid \`customFields\` builder duplication between primary and upsert paths in personalize/route.ts (pre-existing maintenance trap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now optionally provide their phone number during the subscription personalization process.
  * Phone information is automatically preserved across subscription workflow steps and synchronized with integrated services.

* **Security**
  * Enhanced referrer control for external iframe requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->