### PR TITLE
fix(tracking): per-publication base URL for newsletter tracking links

### DIFF
--- a/src/lib/ad-modules/ad-renderer.ts
+++ b/src/lib/ad-modules/ad-renderer.ts
@@ -129,7 +129,8 @@ export class AdModuleRenderer {
           context.issueDate,
           context.mailerliteIssueId,
           context.issueId,
-          'ad'
+          'ad',
+          settings.website_url
         )
       : baseUrl
 

--- a/src/lib/ai-app-modules/app-module-renderer.ts
+++ b/src/lib/ai-app-modules/app-module-renderer.ts
@@ -371,8 +371,8 @@ export class AppModuleRenderer {
 
     // Get publication styling (use passed-in settings if available)
     const baseStyles = businessSettings
-      ? { primaryColor: businessSettings.primaryColor, secondaryColor: businessSettings.secondaryColor, tertiaryColor: businessSettings.tertiaryColor, headingFont: businessSettings.headingFont, bodyFont: businessSettings.bodyFont }
-      : await getBusinessSettings(publicationId).then(s => ({ primaryColor: s.primary_color, secondaryColor: s.secondary_color, tertiaryColor: s.tertiary_color, headingFont: s.heading_font, bodyFont: s.body_font }))
+      ? { primaryColor: businessSettings.primaryColor, secondaryColor: businessSettings.secondaryColor, tertiaryColor: businessSettings.tertiaryColor, headingFont: businessSettings.headingFont, bodyFont: businessSettings.bodyFont, websiteUrl: businessSettings.websiteUrl }
+      : await getBusinessSettings(publicationId).then(s => ({ primaryColor: s.primary_color, secondaryColor: s.secondary_color, tertiaryColor: s.tertiary_color, headingFont: s.heading_font, bodyFont: s.body_font, websiteUrl: s.website_url }))
 
     // Merge default block config with mod's block config
     const blockConfig: ProductCardBlockConfig = {
@@ -413,7 +413,8 @@ export class AppModuleRenderer {
             context.issueDate,
             context.mailerliteIssueId,
             context.issueId,
-            'ai_app'
+            'ai_app',
+            baseStyles.websiteUrl
           )
         : baseUrl
 

--- a/src/lib/article-modules/feed-generator.ts
+++ b/src/lib/article-modules/feed-generator.ts
@@ -2,6 +2,7 @@ import { timingSafeEqual } from 'crypto'
 import { Feed } from 'feed'
 import { htmlToText } from 'html-to-text'
 import { supabaseAdmin } from '../supabase'
+import { getPublicationSetting } from '../publication-settings'
 import { normalizeTransactionType } from '../transaction-type'
 import { wrapTrackingUrl } from '../url-tracking'
 import type { IssueStatus } from '@/types/database'
@@ -82,7 +83,7 @@ export class ModuleFeedGenerator {
     // maybeSingle() on the issue query returns null (not an error) when no
     // matching issue exists — a normal state for the 'sent' variant on a
     // publication that hasn't sent anything yet.
-    const [pubResult, issueResult] = await Promise.all([
+    const [pubResult, issueResult, pubBaseUrl] = await Promise.all([
       supabaseAdmin
         .from('publications')
         .select('name, slug')
@@ -92,6 +93,7 @@ export class ModuleFeedGenerator {
         .order('date', { ascending: false })
         .limit(1)
         .maybeSingle(),
+      getPublicationSetting(publicationId, 'website_url'),
     ])
 
     const { data: pub, error: pubError } = pubResult
@@ -153,7 +155,7 @@ export class ModuleFeedGenerator {
 
       // Wrap source URL with tracking
       const trackedUrl = sourceUrl !== '#'
-        ? wrapTrackingUrl(sourceUrl, mod.name, recentIssue.date, undefined, recentIssue.id)
+        ? wrapTrackingUrl(sourceUrl, mod.name, recentIssue.date, undefined, recentIssue.id, undefined, pubBaseUrl || undefined)
         : '#'
 
       const itemData: any = {

--- a/src/lib/newsletter-templates/ads.ts
+++ b/src/lib/newsletter-templates/ads.ts
@@ -93,7 +93,7 @@ export async function generateAdvertorialSection(issue: any, _recordUsage: boole
     console.log('Generating Advertorial section for issue:', issue?.id)
 
     // Fetch colors from business settings (use passed-in settings if available)
-    const { primaryColor, headingFont, bodyFont } = businessSettings || await fetchBusinessSettings(issue?.publication_id)
+    const { primaryColor, headingFont, bodyFont, websiteUrl } = businessSettings || await fetchBusinessSettings(issue?.publication_id)
 
     // Check if ad already selected for this issue
     const { data: existingAd } = await supabaseAdmin
@@ -117,7 +117,7 @@ export async function generateAdvertorialSection(issue: any, _recordUsage: boole
     // Generate tracked URL for links
     const buttonUrl = selectedAd.button_url || '#'
     const trackedUrl = buttonUrl !== '#'
-      ? wrapTrackingUrl(buttonUrl, 'Advertorial', issue.date, issue.mailerlite_issue_id, issue.id)
+      ? wrapTrackingUrl(buttonUrl, 'Advertorial', issue.date, issue.mailerlite_issue_id, issue.id, undefined, websiteUrl)
       : '#'
 
     // Use the shared advertorial HTML generator
@@ -156,7 +156,7 @@ export async function generateAdModulesSection(issue: any, moduleId?: string, bu
   try {
     console.log('Generating Ad Modules sections for issue:', issue?.id, moduleId ? `(mod: ${moduleId})` : '(all modules)')
 
-    const { primaryColor, headingFont, bodyFont } = businessSettings || await fetchBusinessSettings(issue?.publication_id)
+    const { primaryColor, headingFont, bodyFont, websiteUrl } = businessSettings || await fetchBusinessSettings(issue?.publication_id)
 
     // Use pre-fetched data or fall back to DB query (legacy callers)
     let selections: any[]
@@ -209,7 +209,7 @@ export async function generateAdModulesSection(issue: any, moduleId?: string, bu
       // Generate tracked URL for the ad
       const buttonUrl = ad.button_url || '#'
       const trackedUrl = buttonUrl !== '#'
-        ? wrapTrackingUrl(buttonUrl, mod.name, issue.date, issue.mailerlite_issue_id, issue.id)
+        ? wrapTrackingUrl(buttonUrl, mod.name, issue.date, issue.mailerlite_issue_id, issue.id, undefined, websiteUrl)
         : '#'
 
       // Get block order from mod config

--- a/src/lib/newsletter-templates/articles.ts
+++ b/src/lib/newsletter-templates/articles.ts
@@ -51,7 +51,7 @@ export async function generateArticleModuleSection(
     return ''
   }
 
-  const { primaryColor, secondaryColor, headingFont, bodyFont } = businessSettings || await fetchBusinessSettings(issue.publication_id)
+  const { primaryColor, secondaryColor, headingFont, bodyFont, websiteUrl } = businessSettings || await fetchBusinessSettings(issue.publication_id)
 
   // Get block order from mod settings
   const blockOrder: ArticleBlockType[] = mod.block_order || ['title', 'body']
@@ -67,7 +67,7 @@ export async function generateArticleModuleSection(
     const emoji = getArticleEmoji(headline, content)
 
     // Wrap URL with tracking
-    const trackedUrl = sourceUrl !== '#' ? wrapTrackingUrl(sourceUrl, mod.name, issue.date, issue.mailerlite_issue_id, issue.id) : '#'
+    const trackedUrl = sourceUrl !== '#' ? wrapTrackingUrl(sourceUrl, mod.name, issue.date, issue.mailerlite_issue_id, issue.id, undefined, websiteUrl) : '#'
 
     // Convert newlines to <br> for proper HTML display
     const formattedContent = content.replace(/\n/g, '<br>')

--- a/src/lib/newsletter-templates/sections.ts
+++ b/src/lib/newsletter-templates/sections.ts
@@ -211,7 +211,7 @@ export async function generateBreakingNewsSection(issue: any, businessSettings?:
   try {
     console.log('Generating Breaking News section for issue:', issue?.id)
 
-    const { primaryColor, headingFont, bodyFont } = businessSettings || await fetchBusinessSettings(issue?.publication_id)
+    const { primaryColor, headingFont, bodyFont, websiteUrl } = businessSettings || await fetchBusinessSettings(issue?.publication_id)
 
     // Use pre-fetched data or fall back to DB query (legacy callers)
     let selections = breakingNewsArticles
@@ -243,7 +243,7 @@ export async function generateBreakingNewsSection(issue: any, businessSettings?:
 
       // Wrap URL with tracking
       const trackedUrl = sourceUrl !== '#'
-        ? wrapTrackingUrl(sourceUrl, 'Breaking News', issue.date, issue.mailerlite_issue_id, issue.id)
+        ? wrapTrackingUrl(sourceUrl, 'Breaking News', issue.date, issue.mailerlite_issue_id, issue.id, undefined, websiteUrl)
         : '#'
 
       return `
@@ -286,7 +286,7 @@ export async function generateBeyondTheFeedSection(issue: any, businessSettings?
   try {
     console.log('Generating Beyond the Feed section for issue:', issue?.id)
 
-    const { primaryColor, headingFont, bodyFont } = businessSettings || await fetchBusinessSettings(issue?.publication_id)
+    const { primaryColor, headingFont, bodyFont, websiteUrl } = businessSettings || await fetchBusinessSettings(issue?.publication_id)
 
     // Use pre-fetched data or fall back to DB query (legacy callers)
     let selections = beyondFeedArticles
@@ -318,7 +318,7 @@ export async function generateBeyondTheFeedSection(issue: any, businessSettings?
 
       // Wrap URL with tracking
       const trackedUrl = sourceUrl !== '#'
-        ? wrapTrackingUrl(sourceUrl, 'Beyond the Feed', issue.date, issue.mailerlite_issue_id, issue.id)
+        ? wrapTrackingUrl(sourceUrl, 'Beyond the Feed', issue.date, issue.mailerlite_issue_id, issue.id, undefined, websiteUrl)
         : '#'
 
       return `

--- a/src/lib/url-tracking.ts
+++ b/src/lib/url-tracking.ts
@@ -30,7 +30,7 @@ export function wrapTrackingUrl(
   linkType?: LinkType,
   pubBaseUrl?: string
 ): string {
-  const baseUrl = pubBaseUrl || process.env.NEXT_PUBLIC_APP_URL || 'https://www.aiaccountingdaily.com'
+  const baseUrl = pubBaseUrl || process.env.NEXT_PUBLIC_APP_URL || 'https://www.aiprodaily.com'
 
   const params = new URLSearchParams({
     url: url,


### PR DESCRIPTION
Closes #234

## Summary
- Thread each publication's `websiteUrl` through `wrapTrackingUrl()` at every newsletter render path so click-tracking URLs use the publication's own domain instead of falling back to a hardcoded `aiaccountingdaily.com` for every tenant
- Switch `wrapTrackingUrl`'s last-resort fallback from `aiaccountingdaily.com` to `aiprodaily.com` (`src/lib/url-tracking.ts:33`)
- Use lighter `getPublicationSetting('website_url')` in `feed-generator.ts` instead of `getBusinessSettings()` to avoid an unnecessary 10-key fetch on every RSS feed render (cache-miss path)

## Files changed
- `src/lib/url-tracking.ts` — fallback domain
- `src/lib/newsletter-templates/sections.ts` — Breaking News, Beyond the Feed
- `src/lib/newsletter-templates/articles.ts` — article module links
- `src/lib/newsletter-templates/ads.ts` — advertorial, ad modules
- `src/lib/article-modules/feed-generator.ts` — RSS feed tracking URLs (parallel `getPublicationSetting` fetch)
- `src/lib/ai-app-modules/app-module-renderer.ts` — AI app module links
- `src/lib/ad-modules/ad-renderer.ts` — ad module links

`src/lib/newsletter-templates/layout.ts` is intentionally untouched — header / footer / honeypot links were already correct (the reference pattern).

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run lint` clean (no new warnings)
- [x] `npm run build` succeeds
- [x] Pre-push gate (security, junior-dev, dba, ops) passed
- [x] After staging deploy lands, render newsletters for AI Pros Daily, AI Accounting Daily, and Trader Leak in preview and confirm `/api/link-tracking/click` URLs host on each publication's own domain
- [ ] RSS feed: `curl https://aiprodaily-staging.vercel.app/api/modules/[moduleId]/feed.xml` and verify `<link>` URLs point at the publication's domain
- [x] Spot-check unchanged surfaces (header Sign Up, footer social, honeypot) — should still resolve correctly

## Out of scope (per #234)
- Already-sent newsletter HTML — no backfill, links in delivered email cannot be rewritten
- Subscribe / preference pages, public website links
- DNS / MailerLite domain configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking URL generation across ads, articles, feeds, and newsletters by consistently including website URL information in tracked links.
  * Updated default tracking domain fallback for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->