### PR TITLE
test(cron): integration tests for 4 critical cron routes

### DIFF
--- a/src/app/api/cron/send-final/__tests__/route.test.ts
+++ b/src/app/api/cron/send-final/__tests__/route.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const {
+  fromMock,
+  sendGridFinalMock,
+  mailerliteFinalMock,
+  slackAlertMock,
+  archiveMock,
+  recordAdUsageMock,
+  recordAppUsageMock,
+  recordPollUsageMock,
+  recordSparkLoopUsageMock,
+} = vi.hoisted(() => ({
+  fromMock: vi.fn(),
+  sendGridFinalMock: vi.fn(),
+  mailerliteFinalMock: vi.fn(),
+  slackAlertMock: vi.fn(),
+  archiveMock: vi.fn(),
+  recordAdUsageMock: vi.fn(),
+  recordAppUsageMock: vi.fn(),
+  recordPollUsageMock: vi.fn(),
+  recordSparkLoopUsageMock: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: (...args: unknown[]) => fromMock(...args) },
+}))
+
+const shouldRunFinalSendMock = vi.fn()
+vi.mock('@/lib/schedule-checker', () => ({
+  ScheduleChecker: {
+    shouldRunFinalSend: (...args: unknown[]) => shouldRunFinalSendMock(...args),
+  },
+}))
+
+const getEmailProviderSettingsMock = vi.fn()
+vi.mock('@/lib/publication-settings', () => ({
+  getEmailProviderSettings: (...args: unknown[]) => getEmailProviderSettingsMock(...args),
+}))
+
+vi.mock('@/lib/sendgrid', () => ({
+  SendGridService: class MockSendGridService {
+    createFinalCampaign = sendGridFinalMock
+  },
+}))
+
+vi.mock('@/lib/mailerlite', () => ({
+  MailerLiteService: class MockMailerLiteService {
+    createFinalissue = mailerliteFinalMock
+  },
+}))
+
+vi.mock('@/lib/slack', () => ({
+  SlackNotificationService: class MockSlackService {
+    sendScheduledSendFailureAlert = slackAlertMock
+  },
+}))
+
+vi.mock('@/lib/newsletter-archiver', () => ({
+  newsletterArchiver: {
+    archiveNewsletter: (...args: unknown[]) => archiveMock(...args),
+  },
+}))
+
+vi.mock('@/lib/ad-modules', () => ({
+  ModuleAdSelector: {
+    recordUsageSimple: (...args: unknown[]) => recordAdUsageMock(...args),
+  },
+}))
+
+vi.mock('@/lib/ai-app-modules', () => ({
+  AppModuleSelector: {
+    recordUsage: (...args: unknown[]) => recordAppUsageMock(...args),
+  },
+}))
+
+vi.mock('@/lib/poll-modules', () => ({
+  PollModuleSelector: {
+    recordUsage: (...args: unknown[]) => recordPollUsageMock(...args),
+  },
+}))
+
+vi.mock('@/lib/sparkloop-rec-modules', () => ({
+  SparkLoopRecModuleSelector: {
+    recordUsage: (...args: unknown[]) => recordSparkLoopUsageMock(...args),
+  },
+}))
+
+vi.mock('@/lib/env-guard', () => ({
+  getEnvironment: () => 'test',
+  isProduction: () => false,
+  shouldSkipScheduleCheck: () => false,
+}))
+
+vi.mock('@/lib/api-handler', () => ({
+  withApiHandler: (_opts: unknown, fn: any) => async (req: any) =>
+    fn({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }, request: req }),
+}))
+
+import { GET } from '../route'
+
+function buildRequest() {
+  return new Request('http://localhost/api/cron/send-final') as any
+}
+
+interface Cfg {
+  publications?: any[]
+  issueRow?: any
+  issueError?: any
+  pollRow?: any
+  pollError?: any
+}
+
+function setupFromMock(cfg: Cfg = {}) {
+  const issueUpdateMock = vi.fn().mockReturnValue({
+    eq: () => Promise.resolve({ data: null, error: null }),
+  })
+
+  const defaultIssue = {
+    id: 'issue-1',
+    publication_id: 'pub-1',
+    date: '2026-05-04',
+    status: 'in_review',
+    subject_line: 'Final Subject',
+    metrics: {},
+    module_articles: [{ id: 'a-1', is_active: true, headline: 'h1', rank: 1, article_module_id: 'm1' }],
+  }
+
+  fromMock.mockImplementation((table: string) => {
+    if (table === 'publications') {
+      return {
+        select: () => ({
+          eq: () =>
+            Promise.resolve({
+              data: cfg.publications ?? [{ id: 'pub-1', name: 'AI Pros Daily', slug: 'aiprodaily' }],
+              error: null,
+            }),
+        }),
+      }
+    }
+    if (table === 'publication_issues') {
+      return {
+        select: () => ({
+          eq: () => ({
+            in: () => ({
+              order: () => ({
+                limit: () => ({
+                  single: () =>
+                    Promise.resolve({
+                      data: cfg.issueRow === undefined ? defaultIssue : cfg.issueRow,
+                      error: cfg.issueError ?? null,
+                    }),
+                }),
+              }),
+            }),
+          }),
+        }),
+        update: issueUpdateMock,
+      }
+    }
+    if (table === 'module_articles') {
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              order: () =>
+                Promise.resolve({
+                  data: [{ id: 'a-1', headline: 'h1', rank: 1, is_active: true, article_module_id: 'm1', article_module: { name: 'Top' } }],
+                  error: null,
+                }),
+            }),
+            is: () => Promise.resolve({ data: [], error: null }),
+          }),
+        }),
+        update: () => ({
+          eq: () => Promise.resolve({ data: null, error: null }),
+        }),
+      }
+    }
+    if (table === 'manual_articles') {
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              limit: () => Promise.resolve({ data: [], error: null }),
+            }),
+          }),
+        }),
+      }
+    }
+    if (table === 'polls') {
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              limit: () => ({
+                single: () =>
+                  Promise.resolve({
+                    data: cfg.pollRow ?? null,
+                    error: cfg.pollError ?? { code: 'PGRST116', message: 'no rows' },
+                  }),
+              }),
+            }),
+          }),
+        }),
+      }
+    }
+    if (table === 'rss_posts') {
+      return {
+        update: () => ({
+          in: () => Promise.resolve({ data: null, error: null }),
+        }),
+      }
+    }
+    return {}
+  })
+
+  return { issueUpdateMock }
+}
+
+describe('send-final cron', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupFromMock()
+    shouldRunFinalSendMock.mockResolvedValue(true)
+    getEmailProviderSettingsMock.mockResolvedValue({ provider: 'sendgrid' })
+    sendGridFinalMock.mockResolvedValue({ success: true, campaignId: 'sg-1' })
+    mailerliteFinalMock.mockResolvedValue({ success: true, issueId: 'ml-1' })
+    archiveMock.mockResolvedValue({ success: true })
+    recordAdUsageMock.mockResolvedValue({ recorded: 1 })
+    recordAppUsageMock.mockResolvedValue({ recorded: 0 })
+    recordPollUsageMock.mockResolvedValue({ recorded: 0 })
+    recordSparkLoopUsageMock.mockResolvedValue({ recorded: 0 })
+    slackAlertMock.mockResolvedValue(undefined)
+  })
+
+  it('happy path: SendGrid sends, status set to sent, archiver called', async () => {
+    const { issueUpdateMock } = setupFromMock()
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(true)
+    expect(body.results[0]).toMatchObject({ success: true })
+    expect(sendGridFinalMock).toHaveBeenCalledTimes(1)
+    expect(archiveMock).toHaveBeenCalledTimes(1)
+    expect(issueUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'sent',
+        status_before_send: 'in_review',
+      })
+    )
+    expect(slackAlertMock).not.toHaveBeenCalled()
+  })
+
+  it('happy path: MailerLite sends when provider is mailerlite', async () => {
+    getEmailProviderSettingsMock.mockResolvedValue({ provider: 'mailerlite', mainGroupId: 'g-1' })
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(true)
+    expect(mailerliteFinalMock).toHaveBeenCalledTimes(1)
+    expect(sendGridFinalMock).not.toHaveBeenCalled()
+  })
+
+  it('schedule gate: skips when shouldRunFinalSend returns false', async () => {
+    shouldRunFinalSendMock.mockResolvedValue(false)
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.results[0].skipped).toBe(true)
+    expect(sendGridFinalMock).not.toHaveBeenCalled()
+  })
+
+  it('skips when no in_review or changes_made issue exists', async () => {
+    setupFromMock({ issueRow: null, issueError: { code: 'PGRST116' } })
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.results[0].skipped).toBe(true)
+    expect(body.results[0].message).toMatch(/No issue/i)
+    expect(sendGridFinalMock).not.toHaveBeenCalled()
+  })
+
+  it('module-recording failure tolerance: ad module throws, send still completes', async () => {
+    recordAdUsageMock.mockRejectedValueOnce(new Error('ad recorder broken'))
+    const { issueUpdateMock } = setupFromMock()
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(true)
+    expect(sendGridFinalMock).toHaveBeenCalled()
+    expect(issueUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'sent' })
+    )
+    expect(slackAlertMock).not.toHaveBeenCalled() // non-fatal, no slack alert
+  })
+
+  it('archiver failure tolerance: archiver throws, status still set to sent', async () => {
+    archiveMock.mockRejectedValueOnce(new Error('archive bucket down'))
+    const { issueUpdateMock } = setupFromMock()
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(true)
+    expect(issueUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'sent' })
+    )
+  })
+
+  it('provider failure: Slack alert fires, status NOT updated to sent', async () => {
+    sendGridFinalMock.mockResolvedValueOnce({ success: false, error: 'SendGrid 500' })
+    const { issueUpdateMock } = setupFromMock()
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body.success).toBe(false)
+    expect(slackAlertMock).toHaveBeenCalledTimes(1)
+    expect(issueUpdateMock).not.toHaveBeenCalled()
+  })
+
+  it('multi-publication: one pub fails, the other still sends', async () => {
+    setupFromMock({
+      publications: [
+        { id: 'pub-1', name: 'A', slug: 'a' },
+        { id: 'pub-2', name: 'B', slug: 'b' },
+      ],
+    })
+    // First call (pub-1) fails, second call (pub-2) succeeds
+    sendGridFinalMock
+      .mockResolvedValueOnce({ success: false, error: 'pub-1 failed' })
+      .mockResolvedValueOnce({ success: true, campaignId: 'sg-2' })
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.results).toHaveLength(2)
+    expect(body.results[0].success).toBe(false)
+    expect(body.results[1].success).toBe(true)
+    expect(sendGridFinalMock).toHaveBeenCalledTimes(2)
+    expect(slackAlertMock).toHaveBeenCalledTimes(1) // only for the failing pub
+  })
+})

--- a/src/app/api/cron/send-review/__tests__/route.test.ts
+++ b/src/app/api/cron/send-review/__tests__/route.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { fromMock, sendGridReviewMock, mailerliteReviewMock } = vi.hoisted(() => ({
+  fromMock: vi.fn(),
+  sendGridReviewMock: vi.fn(),
+  mailerliteReviewMock: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: (...args: unknown[]) => fromMock(...args) },
+}))
+
+const shouldRunReviewSendMock = vi.fn()
+const shouldCatchUpReviewSendMock = vi.fn()
+vi.mock('@/lib/schedule-checker', () => ({
+  ScheduleChecker: {
+    shouldRunReviewSend: (...args: unknown[]) => shouldRunReviewSendMock(...args),
+    shouldCatchUpReviewSend: (...args: unknown[]) => shouldCatchUpReviewSendMock(...args),
+  },
+}))
+
+const getEmailProviderSettingsMock = vi.fn()
+vi.mock('@/lib/publication-settings', () => ({
+  getEmailProviderSettings: (...args: unknown[]) => getEmailProviderSettingsMock(...args),
+}))
+
+vi.mock('@/lib/sendgrid', () => ({
+  SendGridService: class MockSendGridService {
+    createReviewCampaign = sendGridReviewMock
+  },
+}))
+
+vi.mock('@/lib/mailerlite', () => ({
+  MailerLiteService: class MockMailerLiteService {
+    createReviewissue = mailerliteReviewMock
+  },
+}))
+
+vi.mock('@/lib/env-guard', () => ({
+  getEnvironment: () => 'test',
+  isProduction: () => false,
+  shouldSkipScheduleCheck: () => false,
+}))
+
+vi.mock('@/lib/api-handler', () => ({
+  withApiHandler: (_opts: unknown, fn: any) => async (req: any) =>
+    fn({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }, request: req }),
+}))
+
+import { GET } from '../route'
+
+function buildRequest() {
+  return new Request('http://localhost/api/cron/send-review') as any
+}
+
+interface IssueCfg {
+  issueRow?: any
+  issueError?: any
+  publications?: any[]
+}
+
+function setupFromMock(cfg: IssueCfg = {}) {
+  const issueLookupArgs: Record<string, string> = {}
+
+  const defaultIssue = {
+    id: 'issue-1',
+    publication_id: 'pub-1',
+    date: '2026-05-05',
+    status: 'draft',
+    subject_line: 'Tomorrow tomorrow',
+    module_articles: [{ id: 'a-1', is_active: true }],
+    manual_articles: [],
+  }
+
+  const issueRow = cfg.issueRow === undefined ? defaultIssue : cfg.issueRow
+
+  fromMock.mockImplementation((table: string) => {
+    if (table === 'publications') {
+      return {
+        select: () => ({
+          eq: () =>
+            Promise.resolve({
+              data: cfg.publications ?? [{ id: 'pub-1', name: 'AI Pros Daily', slug: 'aiprodaily' }],
+              error: null,
+            }),
+        }),
+      }
+    }
+    if (table === 'publication_issues') {
+      return {
+        select: () => ({
+          eq: function captureEq(col: string, val: string): any {
+            issueLookupArgs[col] = val
+            return {
+              eq: function captureEq2(c2: string, v2: string): any {
+                issueLookupArgs[c2] = v2
+                return {
+                  eq: function captureEq3(c3: string, v3: string): any {
+                    issueLookupArgs[c3] = v3
+                    return {
+                      single: () => Promise.resolve({ data: issueRow, error: cfg.issueError ?? null }),
+                    }
+                  },
+                }
+              },
+            }
+          },
+        }),
+      }
+    }
+    return {}
+  })
+
+  return { issueLookupArgs }
+}
+
+describe('send-review cron', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Today CT = 2026-05-04, tomorrow CT = 2026-05-05
+    vi.setSystemTime(new Date('2026-05-04T20:00:00Z'))
+    vi.clearAllMocks()
+    setupFromMock()
+    shouldRunReviewSendMock.mockResolvedValue(true)
+    shouldCatchUpReviewSendMock.mockResolvedValue(false)
+    getEmailProviderSettingsMock.mockResolvedValue({ provider: 'sendgrid' })
+    sendGridReviewMock.mockResolvedValue({ success: true, campaignId: 'sg-1' })
+    mailerliteReviewMock.mockResolvedValue({ success: true, issueId: 'ml-1' })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('happy path: sends review for tomorrow\'s draft via SendGrid', async () => {
+    const { issueLookupArgs } = setupFromMock()
+    shouldRunReviewSendMock.mockResolvedValue(true)
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(true)
+    expect(body.results[0]).toMatchObject({ success: true })
+    expect(issueLookupArgs.publication_id).toBe('pub-1') // multi-tenant filter
+    expect(issueLookupArgs.date).toBe('2026-05-05') // tomorrow CT
+    expect(issueLookupArgs.status).toBe('draft')
+    expect(sendGridReviewMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('catch-up: proceeds when shouldRunReviewSend=false but shouldCatchUpReviewSend=true', async () => {
+    shouldRunReviewSendMock.mockResolvedValue(false)
+    shouldCatchUpReviewSendMock.mockResolvedValue(true)
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.results[0].success).toBe(true)
+    expect(sendGridReviewMock).toHaveBeenCalled()
+  })
+
+  it('skips when no draft issue found for tomorrow', async () => {
+    setupFromMock({ issueRow: null, issueError: { code: 'PGRST116', message: 'no rows' } })
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.results[0].skipped).toBe(true)
+    expect(body.results[0].message).toMatch(/No draft issue/i)
+    expect(sendGridReviewMock).not.toHaveBeenCalled()
+  })
+
+  it('reports error when subject line is missing', async () => {
+    setupFromMock({
+      issueRow: {
+        id: 'issue-1',
+        publication_id: 'pub-1',
+        date: '2026-05-05',
+        status: 'draft',
+        subject_line: '   ',
+        module_articles: [{ id: 'a-1', is_active: true }],
+      },
+    })
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(false)
+    expect(body.results[0].error).toMatch(/No subject line/i)
+    expect(sendGridReviewMock).not.toHaveBeenCalled()
+  })
+
+  it('schedule gate: skips when both shouldRun and shouldCatchUp are false', async () => {
+    shouldRunReviewSendMock.mockResolvedValue(false)
+    shouldCatchUpReviewSendMock.mockResolvedValue(false)
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.results[0].skipped).toBe(true)
+    expect(body.results[0].message).toMatch(/Not time/i)
+    expect(sendGridReviewMock).not.toHaveBeenCalled()
+  })
+
+  it('Central Time date rollover: tomorrow correctly crosses month boundary', async () => {
+    // Today CT = 2026-04-30, tomorrow CT = 2026-05-01
+    vi.setSystemTime(new Date('2026-04-30T20:00:00Z'))
+    const { issueLookupArgs } = setupFromMock()
+
+    await GET(buildRequest(), { params: Promise.resolve({}) })
+
+    expect(issueLookupArgs.date).toBe('2026-05-01')
+  })
+})

--- a/src/app/api/cron/send-secondary/__tests__/route.test.ts
+++ b/src/app/api/cron/send-secondary/__tests__/route.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { fromMock, sendGridFinalMock, mailerliteFinalMock } = vi.hoisted(() => ({
+  fromMock: vi.fn(),
+  sendGridFinalMock: vi.fn(),
+  mailerliteFinalMock: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: (...args: unknown[]) => fromMock(...args) },
+}))
+
+const getPublicationSettingMock = vi.fn()
+const getEmailProviderSettingsMock = vi.fn()
+vi.mock('@/lib/publication-settings', () => ({
+  getPublicationSetting: (...args: unknown[]) => getPublicationSettingMock(...args),
+  getEmailProviderSettings: (...args: unknown[]) => getEmailProviderSettingsMock(...args),
+}))
+
+vi.mock('@/lib/sendgrid', () => ({
+  SendGridService: class MockSendGridService {
+    createFinalCampaign = sendGridFinalMock
+  },
+}))
+
+vi.mock('@/lib/mailerlite', () => ({
+  MailerLiteService: class MockMailerLiteService {
+    createFinalissue = mailerliteFinalMock
+  },
+}))
+
+vi.mock('@/lib/env-guard', () => ({
+  getEnvironment: () => 'test',
+  isProduction: () => false,
+  shouldSkipScheduleCheck: () => false,
+}))
+
+vi.mock('@/lib/api-handler', () => ({
+  withApiHandler: (_opts: unknown, fn: any) => async (req: any) =>
+    fn({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }, request: req }),
+}))
+
+import { GET } from '../route'
+
+function buildRequest() {
+  return new Request('http://localhost/api/cron/send-secondary') as any
+}
+
+const TODAY_LOCAL = new Date('2026-05-04T20:00:00Z') // Monday in CT (dayOfWeek=1)
+const TODAY_DATE_STR = '2026-05-04'
+
+interface Cfg {
+  publications?: any[]
+  issueRow?: any
+  issueError?: any
+  moduleArticles?: any[]
+  updateError?: any
+}
+
+function setupFromMock(cfg: Cfg = {}) {
+  const updateMock = vi.fn().mockReturnValue({
+    eq: () => Promise.resolve({ data: null, error: cfg.updateError ?? null }),
+  })
+
+  const issueRow =
+    cfg.issueRow === undefined
+      ? {
+          id: 'issue-1',
+          date: TODAY_DATE_STR,
+          status: 'in_review',
+          subject_line: 'Subject',
+          secondary_sent_at: null,
+          publication_id: 'pub-1',
+          created_at: '2026-05-04T05:00:00Z',
+          metrics: {},
+        }
+      : cfg.issueRow
+
+  fromMock.mockImplementation((table: string) => {
+    if (table === 'publications') {
+      return {
+        select: () => ({
+          eq: () =>
+            Promise.resolve({
+              data: cfg.publications ?? [{ id: 'pub-1', name: 'AI Pros Daily', slug: 'aiprodaily' }],
+              error: null,
+            }),
+        }),
+      }
+    }
+    if (table === 'publication_issues') {
+      return {
+        select: () => ({
+          eq: () => ({
+            in: () => ({
+              eq: () => ({
+                order: () => ({
+                  limit: () => ({
+                    single: () => Promise.resolve({ data: issueRow, error: cfg.issueError ?? null }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+        update: updateMock,
+      }
+    }
+    if (table === 'module_articles') {
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              not: () =>
+                Promise.resolve({
+                  data:
+                    cfg.moduleArticles ?? [
+                      { id: 'a-1', headline: 'h', content: 'c', rank: 1, is_active: true, final_position: 1, article_module_id: 'm', post_id: 'p' },
+                    ],
+                  error: null,
+                }),
+            }),
+          }),
+        }),
+      }
+    }
+    return {}
+  })
+
+  return { updateMock }
+}
+
+function setupSettings(overrides: Record<string, string | null> = {}) {
+  const defaults: Record<string, string | null> = {
+    email_secondaryScheduleEnabled: 'true',
+    secondary_send_days: '[1,2,3,4,5]',
+    sendgrid_secondary_list_id: 'list-123',
+  }
+  const merged = { ...defaults, ...overrides }
+  getPublicationSettingMock.mockImplementation(async (_pub: string, key: string) => merged[key] ?? null)
+}
+
+describe('send-secondary cron', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(TODAY_LOCAL)
+    vi.clearAllMocks()
+    setupFromMock()
+    setupSettings()
+    getEmailProviderSettingsMock.mockResolvedValue({ provider: 'sendgrid' })
+    sendGridFinalMock.mockResolvedValue({ success: true, campaignId: 'sg-1', issueId: 'issue-1' })
+    mailerliteFinalMock.mockResolvedValue({ success: true, issueId: 'ml-1' })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('happy path: SendGrid secondary send updates secondary_sent_at and metrics', async () => {
+    const { updateMock } = setupFromMock()
+    setupSettings()
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(true)
+    expect(body.results[0]).toMatchObject({ pubId: 'pub-1', success: true })
+    expect(sendGridFinalMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'issue-1' }), true)
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secondary_sent_at: expect.any(String),
+        metrics: expect.objectContaining({ sendgrid_secondary_singlesend_id: 'sg-1' }),
+      })
+    )
+  })
+
+  it('skips when secondary schedule is disabled', async () => {
+    setupSettings({ email_secondaryScheduleEnabled: 'false' })
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.results[0].skipped).toBe(true)
+    expect(body.results[0].message).toMatch(/disabled/i)
+    expect(sendGridFinalMock).not.toHaveBeenCalled()
+  })
+
+  it('skips when day-of-week is not in configured send days', async () => {
+    // Today is Monday (1). Configure to only send on weekends.
+    setupSettings({ secondary_send_days: '[0,6]' })
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.results[0].skipped).toBe(true)
+    expect(body.results[0].message).toMatch(/Not a configured send day/i)
+    expect(sendGridFinalMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to Mon–Fri default when secondary_send_days JSON is invalid', async () => {
+    // Invalid JSON → fallback [1,2,3,4,5]. Today is Monday (1) → send proceeds.
+    setupSettings({ secondary_send_days: '{not json' })
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(true)
+    expect(sendGridFinalMock).toHaveBeenCalled()
+  })
+
+  it('reports error when secondary list ID is not configured', async () => {
+    setupSettings({ sendgrid_secondary_list_id: null })
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(false)
+    expect(body.results[0].success).toBe(false)
+    expect(body.results[0].error).toMatch(/Secondary list ID not configured/i)
+    expect(sendGridFinalMock).not.toHaveBeenCalled()
+  })
+
+  it('skips when secondary_sent_at is already set for today', async () => {
+    setupFromMock({
+      issueRow: {
+        id: 'issue-1',
+        date: TODAY_DATE_STR,
+        status: 'sent',
+        subject_line: 'S',
+        secondary_sent_at: TODAY_LOCAL.toISOString(),
+        publication_id: 'pub-1',
+        created_at: '2026-05-04T05:00:00Z',
+        metrics: {},
+      },
+    })
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.results[0].skipped).toBe(true)
+    expect(body.results[0].message).toMatch(/already completed/i)
+    expect(sendGridFinalMock).not.toHaveBeenCalled()
+  })
+
+  it('reports error and does not record send when provider call fails', async () => {
+    sendGridFinalMock.mockResolvedValueOnce({ success: false, error: 'SendGrid down' })
+    const { updateMock } = setupFromMock()
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(false)
+    expect(body.results[0].error).toMatch(/SendGrid down/i)
+    expect(updateMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/cron/trigger-workflow/__tests__/route.test.ts
+++ b/src/app/api/cron/trigger-workflow/__tests__/route.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const fromMock = vi.fn()
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: (...args: unknown[]) => fromMock(...args) },
+}))
+
+const shouldRunRSSProcessingMock = vi.fn()
+vi.mock('@/lib/schedule-checker', () => ({
+  ScheduleChecker: {
+    shouldRunRSSProcessing: (...args: unknown[]) => shouldRunRSSProcessingMock(...args),
+  },
+}))
+
+const startMock = vi.fn()
+vi.mock('workflow/api', () => ({
+  start: (...args: unknown[]) => startMock(...args),
+}))
+
+vi.mock('@/lib/workflows/process-rss-workflow', () => ({
+  processRSSWorkflow: { __mocked: true },
+}))
+
+vi.mock('@/lib/api-handler', () => ({
+  withApiHandler: (_opts: unknown, fn: any) => async (req: any) =>
+    fn({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }, request: req }),
+}))
+
+import { GET } from '../route'
+
+function buildRequest() {
+  return new Request('http://localhost/api/cron/trigger-workflow') as any
+}
+
+interface PublicationsConfig {
+  publications?: any[]
+  stuckCampaigns?: any[]
+  articleCounts?: Record<string, number>
+  welcomeSections?: Record<string, string | null>
+}
+
+function setupFromMock(cfg: PublicationsConfig = {}) {
+  const updateMock = vi.fn().mockReturnValue({
+    eq: () => Promise.resolve({ data: null, error: null }),
+  })
+
+  fromMock.mockImplementation((table: string) => {
+    if (table === 'publications') {
+      return {
+        select: () => ({
+          eq: () =>
+            Promise.resolve({
+              data: cfg.publications ?? [{ id: 'pub-1', name: 'AI Pros Daily', slug: 'aiprodaily' }],
+              error: null,
+            }),
+        }),
+      }
+    }
+    if (table === 'newsletter_campaigns') {
+      return {
+        select: (cols: string) => {
+          if (cols.includes('welcome_section')) {
+            return {
+              eq: (_col: string, id: string) => ({
+                single: () =>
+                  Promise.resolve({
+                    data: { welcome_section: cfg.welcomeSections?.[id] ?? null },
+                    error: null,
+                  }),
+              }),
+            }
+          }
+          return {
+            eq: () => ({
+              lt: () =>
+                Promise.resolve({
+                  data: cfg.stuckCampaigns ?? [],
+                  error: null,
+                }),
+            }),
+          }
+        },
+        update: updateMock,
+      }
+    }
+    if (table === 'module_articles') {
+      return {
+        select: () => ({
+          eq: (_col: string, id: string) => ({
+            eq: () =>
+              Promise.resolve({
+                data: null,
+                count: cfg.articleCounts?.[id] ?? 0,
+                error: null,
+              }),
+          }),
+        }),
+      }
+    }
+    return {}
+  })
+
+  return { updateMock }
+}
+
+describe('trigger-workflow cron', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupFromMock()
+    shouldRunRSSProcessingMock.mockResolvedValue(false)
+    startMock.mockResolvedValue(undefined)
+  })
+
+  it('starts workflow for an eligible publication', async () => {
+    shouldRunRSSProcessingMock.mockResolvedValue(true)
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(true)
+    expect(body.newsletters).toEqual(['AI Pros Daily'])
+    expect(startMock).toHaveBeenCalledTimes(1)
+    expect(startMock).toHaveBeenCalledWith(
+      expect.anything(),
+      [expect.objectContaining({ trigger: 'cron', publication_id: 'pub-1' })]
+    )
+  })
+
+  it('skips workflow start when schedule gate is closed', async () => {
+    shouldRunRSSProcessingMock.mockResolvedValue(false)
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(true)
+    expect(body.skipped).toBe(true)
+    expect(body.message).toBe('No workflows scheduled at this time')
+    expect(startMock).not.toHaveBeenCalled()
+  })
+
+  it('OIDC recovery: ≥3 articles + welcome_section → flips status to draft', async () => {
+    const stuckId = 'stuck-1'
+    const { updateMock } = setupFromMock({
+      stuckCampaigns: [
+        { id: stuckId, publication_id: 'pub-1', status: 'processing', created_at: '2026-04-01' },
+      ],
+      articleCounts: { [stuckId]: 5 },
+      welcomeSections: { [stuckId]: '<welcome>' },
+    })
+
+    await GET(buildRequest(), { params: Promise.resolve({}) })
+
+    expect(updateMock).toHaveBeenCalledWith({ status: 'draft' })
+  })
+
+  it('OIDC recovery: ≥3 articles but no welcome_section → leaves status as processing', async () => {
+    const stuckId = 'stuck-2'
+    const { updateMock } = setupFromMock({
+      stuckCampaigns: [
+        { id: stuckId, publication_id: 'pub-1', status: 'processing', created_at: '2026-04-01' },
+      ],
+      articleCounts: { [stuckId]: 5 },
+      welcomeSections: { [stuckId]: null },
+    })
+
+    await GET(buildRequest(), { params: Promise.resolve({}) })
+
+    expect(updateMock).not.toHaveBeenCalled()
+  })
+
+  it('propagates workflow start failure (no silent swallow)', async () => {
+    shouldRunRSSProcessingMock.mockResolvedValue(true)
+    startMock.mockRejectedValueOnce(new Error('workflow infra down'))
+
+    await expect(GET(buildRequest(), { params: Promise.resolve({}) })).rejects.toThrow(
+      'workflow infra down'
+    )
+  })
+})


### PR DESCRIPTION
Closes #64

## Summary
Adds **26 mock-based Vitest tests** covering the four cron routes that drive newsletter automation. Closes the highest-priority gap identified in the [CI Pipeline Analysis Report](docs/reports/ci-pipeline-analysis.md) Section 2.4 — *zero of 397 API routes had any test coverage*.

## Coverage

| Route | Tests | Key behaviors covered |
|-------|-------|----------------------|
| `trigger-workflow` | 5 | Happy path, schedule gate, OIDC recovery (welcome-section gate), recovery skip, workflow start failure |
| `send-secondary`   | 7 | Happy path, disabled, day-of-week gate, invalid-JSON fallback, missing list ID, dupe-send guard, provider failure |
| `send-review`      | 6 | Happy path (with `publication_id` filter assertion), catch-up condition, no draft, missing subject, schedule gate, Central Time month rollover |
| `send-final`       | 8 | SendGrid + MailerLite happy paths, schedule gate, no issue, ad-module + archiver failure tolerance, provider failure → Slack alert, multi-publication iteration |

## Approach
- Mock-based unit-style tests using `vi.hoisted()` + class-based service mocks + `withApiHandler` passthrough
- Pattern mirrors the existing `check-pending-webhooks/__tests__/route.test.ts`
- No source-code changes — pure additions under `src/app/api/cron/**/__tests__/`

## Decisions made
- **Mocked, not real DB** — matches the existing 38 tests in the repo. Real-DB integration is a separate concern (no infra exists today).
- **Coverage-threshold enforcement** intentionally deferred to **#65** (Phase 3 testing).
- **The other 19 cron routes** are P3+ per the CI report — separate follow-up.

## Test plan
- [x] `npm run test:run` — 42 test files, 630 tests pass (was 38/604; +4/+26)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean (no new warnings)
- [x] `npm run build` — clean
- [x] Pre-push gate (security, junior-dev, dba, ops) — passed; one DBA finding (`publication_id` filter assertion in send-review happy path) addressed
- [ ] Verify in CI on the PR

## Out of scope
- Real-DB integration test infrastructure (deferred — would require staging DB provisioning, seed scripts)
- Coverage threshold enforcement (#65)
- The other 19 cron routes
- Tests for the `processFinalSendForPub` helper internals (covered transitively via the route-level test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)