### PR TITLE
test(coverage): enforce minimum thresholds in vitest + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,8 @@ jobs:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
 
-      - name: Unit tests
-        run: npm run test:run
+      - name: Unit tests with coverage
+        run: npm run test:coverage
 
       - name: RSS workflow tests (scoped to changed files)
         run: npm run test:rss-workflow:pr

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,5 +17,28 @@ export default defineConfig({
       TZ: 'UTC',
       LANG: 'en_US.UTF-8',
     },
+    // Coverage enforcement (#65). To raise these, add tests then bump the
+    // numbers below. Never lower without writing tests to compensate.
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'text-summary'],
+      include: [
+        'src/lib/**/*.ts',
+        'src/app/api/cron/**/route.ts',
+      ],
+      exclude: [
+        '**/__tests__/**',
+        '**/*.test.ts',
+        '**/_fixtures.ts',
+        'src/lib/**/index.ts', // barrel files only — keep logic out of index.ts
+        'src/lib/**/types.ts',
+      ],
+      thresholds: {
+        lines: 15,
+        statements: 14,
+        functions: 15,
+        branches: 15,
+      },
+    },
   },
 })


### PR DESCRIPTION
Closes #65

## Summary
- Add `coverage` block to `vitest.config.ts` (v8 provider, scoped includes/excludes)
- Switch CI from `npm run test:run` → `npm run test:coverage`
- Thresholds set ~2 points below measured baseline so test deletions or large untested additions fail CI

## Thresholds (and why)
| Metric     | Baseline | Threshold |
|------------|---------:|----------:|
| Lines      | 17.51%   | 15        |
| Statements | 16.89%   | 14        |
| Functions  | 17.57%   | 15        |
| Branches   | 17.00%   | 15        |

Manual ratchet: when adding tests, bump these numbers. Never lower without writing tests to compensate. (Comment in the config makes this explicit.)

## Coverage scope
```ts
include: [
  'src/lib/**/*.ts',
  'src/app/api/cron/**/route.ts',  // covers the cron route tests just shipped (#64)
],
exclude: [
  '**/__tests__/**',
  '**/*.test.ts',
  '**/_fixtures.ts',
  'src/lib/**/index.ts',  // barrel files only — keep logic out of index.ts
  'src/lib/**/types.ts',
],
```

## Verified
- `npm run test:coverage` → exits 0 at baseline
- Forcing `lines: 99` → `ERROR: Coverage for lines (17.51%) does not meet global threshold (99%)` (exit 1) — regression detection works
- `npm run type-check`, `npm run lint`, `npm run build` — all clean
- Pre-push gate (ops + junior-dev) passed

## Test plan
- [x] Local coverage run passes
- [x] Threshold breach forces non-zero exit
- [ ] Verify on PR CI run that the workflow step prints the coverage summary

## Out of scope
- Adding tests to raise the threshold — pure infra PR
- Per-file thresholds (global only — finer control is brittle)
- PR coverage delta comments / Codecov integration
- Coverage on UI / pages / debug routes — explicitly excluded by scope
- Enforcing the "no logic in index.ts" rule via lint — convention only today

🤖 Generated with [Claude Code](https://claude.com/claude-code)