### PR TITLE
fix(welcome): render intro arg in welcome section

### DIFF
--- a/src/lib/newsletter-templates/__tests__/sections.test.ts
+++ b/src/lib/newsletter-templates/__tests__/sections.test.ts
@@ -81,11 +81,7 @@ describe('generateWelcomeSection', () => {
     expect(html).toContain('CustomFont, sans-serif')
   })
 
-  // NOTE: sections.ts:27-34 computes a `fullIntro` variable but never uses it —
-  // the `intro` argument is silently dropped from rendered output. This test
-  // characterizes that current (buggy) behavior so we'd notice if it changed.
-  // TODO(#222): fix the dead code in generateWelcomeSection.
-  it('renders greeting, tagline, and summary (intro arg currently unused — see source bug)', async () => {
+  it('renders intro, tagline, and summary', async () => {
     const html = await generateWelcomeSection(
       'Hello there',
       'The bold tagline',
@@ -96,7 +92,7 @@ describe('generateWelcomeSection', () => {
     expect(html).toContain('The bold tagline')
     expect(html).toContain('A short summary.')
     expect(html).toContain(`{$name|default('Accounting Pro')}`)
-    expect(html).not.toContain('Hello there')
+    expect(html).toContain('Hello there')
   })
 })
 

--- a/src/lib/newsletter-templates/sections.ts
+++ b/src/lib/newsletter-templates/sections.ts
@@ -29,8 +29,8 @@ export async function generateWelcomeSection(
   const fullIntro = intro && intro.trim() ? `${greeting} ${intro.trim()}` : greeting
 
   // Build HTML for each part (only include non-empty parts)
-  const introPart = greeting
-    ? `<div style="font-size: 16px; line-height: 24px; color: #333; font-family: ${bodyFont}; margin-bottom: 8px;">${greeting.replace(/\n/g, '<br>')}</div>`
+  const introPart = fullIntro
+    ? `<div style="font-size: 16px; line-height: 24px; color: #333; font-family: ${bodyFont}; margin-bottom: 8px;">${fullIntro.replace(/\n/g, '<br>')}</div>`
     : ''
 
   const taglinePart = tagline && tagline.trim()


### PR DESCRIPTION
Closes #222

## Summary
`generateWelcomeSection` computed `fullIntro` (greeting prepended to caller-supplied `intro`) but rendered only `greeting` — the `intro` arg was silently dropped from the welcome card HTML. Two-character substitution (`greeting` → `fullIntro` at the `introPart` conditional and the `.replace()` call) makes the function honor its declared `intro` parameter.

## Why this didn't show up earlier
The function still returned valid HTML, tagline + summary still rendered, no errors thrown. Caught while writing characterization tests for #58. The previous test deliberately pinned the buggy behavior (`expect(html).not.toContain('Hello there')`) with a `TODO(#222)` tag; this PR flips it to `toContain('Hello there')` and renames accordingly.

## Files changed (2)
- `src/lib/newsletter-templates/sections.ts:32-33` — `greeting` → `fullIntro`
- `src/lib/newsletter-templates/__tests__/sections.test.ts:84-100` — comment cleanup, test rename, assertion flip

## Test plan
- [x] `npm run test:run` — 42 files / 630 tests pass (sections.test.ts: 18/18)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean (no new warnings)
- [x] `npm run build` — clean
- [x] `npm run test:coverage` — coverage gate (#65) still passes
- [x] Pre-push gate (security + junior-dev) cleared — security verified `intro` flows from DB (admin/AI-controlled), same unescaped pattern as tagline/summary in the same function (lines 36-42); not new attack surface

## Subscriber-facing impact
Cosmetic only. Subscribers in flows that already passed an `intro` value start seeing the lead-in text they were supposed to see all along. No DB writes, no send-path changes, no regression risk.

## Out of scope
- Wider audit of caller-supplied `intro` values
- Refactoring the welcome section for clarity (e.g., extracting the greeting builder)
- Adding HTML escaping to tagline/summary/intro — pre-existing pattern across all three; would be a separate hardening PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed newsletter welcome sections to properly display the intro text when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->