### PR TITLE
perf(dashboard): lazy-load recharts on metrics + sparkloop pages

### DIFF
--- a/src/app/dashboard/[slug]/metrics/MetricChart.tsx
+++ b/src/app/dashboard/[slug]/metrics/MetricChart.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, BarChart, Bar } from 'recharts'
+
+interface ChartData {
+  hour: string
+  avg: number
+  min: number
+  max: number
+  count: number
+}
+
+interface MetricChartConfig {
+  label: string
+  unit: string
+  color: string
+  chartType: 'line' | 'bar'
+}
+
+interface Props {
+  data: ChartData[]
+  config: MetricChartConfig
+  formatHour: (hour: string) => string
+}
+
+export default function MetricChart({ data, config, formatHour }: Props) {
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      {config.chartType === 'line' ? (
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis dataKey="hour" tickFormatter={formatHour} tick={{ fontSize: 10 }} />
+          <YAxis tick={{ fontSize: 10 }} />
+          <Tooltip
+            labelFormatter={(label: any) => formatHour(String(label))}
+            formatter={(value: any) => [`${value}${config.unit}`, config.label]}
+          />
+          <Line type="monotone" dataKey="avg" stroke={config.color} strokeWidth={2} dot={false} />
+        </LineChart>
+      ) : (
+        <BarChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis dataKey="hour" tickFormatter={formatHour} tick={{ fontSize: 10 }} />
+          <YAxis tick={{ fontSize: 10 }} />
+          <Tooltip
+            labelFormatter={(label: any) => formatHour(String(label))}
+            formatter={(value: any) => [`${value}${config.unit}`, config.label]}
+          />
+          <Bar dataKey="avg" fill={config.color} radius={[2, 2, 0, 0]} />
+        </BarChart>
+      )}
+    </ResponsiveContainer>
+  )
+}

--- a/src/app/dashboard/[slug]/metrics/page.tsx
+++ b/src/app/dashboard/[slug]/metrics/page.tsx
@@ -2,8 +2,21 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useParams } from 'next/navigation'
+import dynamic from 'next/dynamic'
 import Layout from '@/components/Layout'
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, BarChart, Bar } from 'recharts'
+
+const MetricChart = dynamic(() => import('./MetricChart'), {
+  ssr: false,
+  loading: () => (
+    <div
+      role="status"
+      aria-busy="true"
+      className="h-[200px] flex items-center justify-center text-gray-400 text-sm"
+    >
+      Loading chart...
+    </div>
+  ),
+})
 
 interface ChartData {
   hour: string
@@ -83,31 +96,7 @@ function MetricCard({ metricConfig, publicationId, days }: {
       ) : data.length === 0 ? (
         <div className="h-48 flex items-center justify-center text-gray-400 text-sm">No data yet</div>
       ) : (
-        <ResponsiveContainer width="100%" height={200}>
-          {metricConfig.chartType === 'line' ? (
-            <LineChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-              <XAxis dataKey="hour" tickFormatter={formatHour} tick={{ fontSize: 10 }} />
-              <YAxis tick={{ fontSize: 10 }} />
-              <Tooltip
-                labelFormatter={(label: any) => formatHour(String(label))}
-                formatter={(value: any) => [`${value}${metricConfig.unit}`, metricConfig.label]}
-              />
-              <Line type="monotone" dataKey="avg" stroke={metricConfig.color} strokeWidth={2} dot={false} />
-            </LineChart>
-          ) : (
-            <BarChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-              <XAxis dataKey="hour" tickFormatter={formatHour} tick={{ fontSize: 10 }} />
-              <YAxis tick={{ fontSize: 10 }} />
-              <Tooltip
-                labelFormatter={(label: any) => formatHour(String(label))}
-                formatter={(value: any) => [`${value}${metricConfig.unit}`, metricConfig.label]}
-              />
-              <Bar dataKey="avg" fill={metricConfig.color} radius={[2, 2, 0, 0]} />
-            </BarChart>
-          )}
-        </ResponsiveContainer>
+        <MetricChart data={data} config={metricConfig} formatHour={formatHour} />
       )}
     </div>
   )

--- a/src/app/dashboard/[slug]/sparkloop/components/OffersChart.tsx
+++ b/src/app/dashboard/[slug]/sparkloop/components/OffersChart.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  Line,
+  ComposedChart,
+} from 'recharts'
+
+interface DailyStats {
+  date: string
+  impressions: number
+  claims: number
+  claimRate: number
+}
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    const impressions = payload.find((p: any) => p.dataKey === 'impressions')?.value || 0
+    const claims = payload.find((p: any) => p.dataKey === 'claims')?.value || 0
+    const rate = impressions > 0 ? ((claims / impressions) * 100).toFixed(1) : '0.0'
+    return (
+      <div className="bg-gray-900 text-white p-3 rounded-lg shadow-lg text-sm">
+        <div className="font-medium mb-1">{label}</div>
+        <div className="text-blue-300">Impressions: {impressions}</div>
+        <div className="text-green-300">Claims: {claims}</div>
+        <div className="text-yellow-300">Claim Rate: {rate}%</div>
+      </div>
+    )
+  }
+  return null
+}
+
+interface Props {
+  dailyStats: DailyStats[]
+}
+
+export default function OffersChart({ dailyStats }: Props) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <ComposedChart data={dailyStats}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis
+          dataKey="date"
+          tick={{ fontSize: 11 }}
+          tickFormatter={(value) => {
+            const date = new Date(value)
+            return `${date.getMonth() + 1}/${date.getDate()}`
+          }}
+        />
+        <YAxis yAxisId="left" tick={{ fontSize: 12 }} />
+        <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 12 }} />
+        <Tooltip content={<CustomTooltip />} />
+        <Legend />
+        <Bar yAxisId="left" dataKey="impressions" name="Impressions" fill="#93c5fd" radius={[2, 2, 0, 0]} />
+        <Bar yAxisId="left" dataKey="claims" name="Claims" fill="#86efac" radius={[2, 2, 0, 0]} />
+        <Line yAxisId="right" type="monotone" dataKey="claimRate" name="Claim Rate %" stroke="#a78bfa" strokeWidth={2} dot={{ r: 3 }} />
+      </ComposedChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/app/dashboard/[slug]/sparkloop/components/OffersTab.tsx
+++ b/src/app/dashboard/[slug]/sparkloop/components/OffersTab.tsx
@@ -1,19 +1,21 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import dynamic from 'next/dynamic'
 import { Eye, MousePointerClick, TrendingUp, Calendar } from 'lucide-react'
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  Legend,
-  Line,
-  ComposedChart,
-} from 'recharts'
+
+const OffersChart = dynamic(() => import('./OffersChart'), {
+  ssr: false,
+  loading: () => (
+    <div
+      role="status"
+      aria-busy="true"
+      className="h-[300px] flex items-center justify-center text-gray-400 text-sm"
+    >
+      Loading chart...
+    </div>
+  ),
+})
 
 interface Summary {
   totalImpressions: number
@@ -74,23 +76,6 @@ export default function OffersTab({ publicationId }: OffersTabProps) {
       console.error('Failed to fetch offer stats:', error)
     }
     setLoading(false)
-  }
-
-  const CustomTooltip = ({ active, payload, label }: any) => {
-    if (active && payload && payload.length) {
-      const impressions = payload.find((p: any) => p.dataKey === 'impressions')?.value || 0
-      const claims = payload.find((p: any) => p.dataKey === 'claims')?.value || 0
-      const rate = impressions > 0 ? ((claims / impressions) * 100).toFixed(1) : '0.0'
-      return (
-        <div className="bg-gray-900 text-white p-3 rounded-lg shadow-lg text-sm">
-          <div className="font-medium mb-1">{label}</div>
-          <div className="text-blue-300">Impressions: {impressions}</div>
-          <div className="text-green-300">Claims: {claims}</div>
-          <div className="text-yellow-300">Claim Rate: {rate}%</div>
-        </div>
-      )
-    }
-    return null
   }
 
   if (loading) {
@@ -163,26 +148,7 @@ export default function OffersTab({ publicationId }: OffersTabProps) {
         </div>
 
         {dailyStats.length > 0 ? (
-          <ResponsiveContainer width="100%" height={300}>
-            <ComposedChart data={dailyStats}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-              <XAxis
-                dataKey="date"
-                tick={{ fontSize: 11 }}
-                tickFormatter={(value) => {
-                  const date = new Date(value)
-                  return `${date.getMonth() + 1}/${date.getDate()}`
-                }}
-              />
-              <YAxis yAxisId="left" tick={{ fontSize: 12 }} />
-              <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 12 }} />
-              <Tooltip content={<CustomTooltip />} />
-              <Legend />
-              <Bar yAxisId="left" dataKey="impressions" name="Impressions" fill="#93c5fd" radius={[2, 2, 0, 0]} />
-              <Bar yAxisId="left" dataKey="claims" name="Claims" fill="#86efac" radius={[2, 2, 0, 0]} />
-              <Line yAxisId="right" type="monotone" dataKey="claimRate" name="Claim Rate %" stroke="#a78bfa" strokeWidth={2} dot={{ r: 3 }} />
-            </ComposedChart>
-          </ResponsiveContainer>
+          <OffersChart dailyStats={dailyStats} />
         ) : (
           <div className="h-64 flex items-center justify-center text-gray-500">
             No data available for this timeframe

--- a/src/app/dashboard/[slug]/sparkloop/components/OverviewChart.tsx
+++ b/src/app/dashboard/[slug]/sparkloop/components/OverviewChart.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  LabelList,
+} from 'recharts'
+
+interface DailyStats {
+  date: string
+  pending: number
+  confirmed: number
+  rejected: number
+  projectedEarnings: number
+  confirmedEarnings: number
+  newPending: number | null
+}
+
+function formatDollars(value: number) {
+  return `$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatNumber(value: number) {
+  return value.toLocaleString('en-US')
+}
+
+function CustomTooltip({ active, payload, label }: any) {
+  if (active && payload && payload.length) {
+    const dataRow = payload[0]?.payload
+    const pending = dataRow?.pending || 0
+    const confirmed = dataRow?.confirmed || 0
+    const rejected = dataRow?.rejected || 0
+    const projectedEarnings = dataRow?.projectedEarnings || 0
+    const confirmedEarnings = dataRow?.confirmedEarnings || 0
+    const newPending = dataRow?.newPending
+    return (
+      <div className="bg-gray-900 text-white p-3 rounded-lg shadow-lg text-sm">
+        <div className="font-medium mb-1">{label}</div>
+        {pending > 0 && (
+          <>
+            <div className="text-purple-300">Pending Referrals: {formatNumber(pending)}</div>
+            <div className="text-purple-300">Projected Earnings: {formatDollars(projectedEarnings)}</div>
+          </>
+        )}
+        {confirmed > 0 && (
+          <>
+            <div className="text-gray-300">Confirmed Referrals: {formatNumber(confirmed)}</div>
+            <div className="text-gray-300">Confirmed Earnings: {formatDollars(confirmedEarnings)}</div>
+          </>
+        )}
+        {rejected > 0 && (
+          <div className="text-gray-500">Rejected Referrals: {formatNumber(rejected)}</div>
+        )}
+        {newPending !== null && newPending !== undefined && newPending > 0 && (
+          <div className="text-amber-300">
+            New Pending (SL): {formatNumber(newPending)}
+          </div>
+        )}
+        {(projectedEarnings > 0 || confirmedEarnings > 0) && (
+          <div className="text-green-300 mt-1 pt-1 border-t border-gray-700">
+            Total: {formatDollars(projectedEarnings + confirmedEarnings)}
+          </div>
+        )}
+      </div>
+    )
+  }
+  return null
+}
+
+interface Props {
+  dailyStats: DailyStats[]
+}
+
+export default function OverviewChart({ dailyStats }: Props) {
+  const chartData = dailyStats.map((d) => ({
+    ...d,
+    earningsLabel:
+      d.projectedEarnings + d.confirmedEarnings > 0
+        ? `$${(d.projectedEarnings + d.confirmedEarnings).toLocaleString('en-US', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })}`
+        : '',
+    newPendingDisplay: d.newPending !== null && d.newPending > 0 ? d.newPending : 0,
+    newPendingLabel:
+      d.newPending !== null && d.newPending > 0 ? d.newPending.toLocaleString('en-US') : '',
+  }))
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={chartData}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis
+          dataKey="date"
+          tick={{ fontSize: 11 }}
+          tickFormatter={(value) => {
+            const [, m, d] = value.split('-')
+            return `${parseInt(m)}/${parseInt(d)}`
+          }}
+        />
+        <YAxis tick={{ fontSize: 12 }} />
+        <Tooltip content={<CustomTooltip />} />
+        <Legend />
+        <Bar dataKey="pending" name="Pending" stackId="a" fill="#c4b5fd" />
+        <Bar dataKey="confirmed" name="Confirmed" stackId="a" fill="#9ca3af" />
+        <Bar dataKey="rejected" name="Rejected" stackId="a" fill="#4b5563" radius={[2, 2, 0, 0]}>
+          <LabelList dataKey="earningsLabel" position="top" style={{ fontSize: 10, fill: '#7c3aed' }} />
+        </Bar>
+        <Bar dataKey="newPendingDisplay" name="New Pending (SL)" fill="#f59e0b" radius={[2, 2, 0, 0]}>
+          <LabelList dataKey="newPendingLabel" position="top" style={{ fontSize: 9, fill: '#d97706' }} />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/app/dashboard/[slug]/sparkloop/components/OverviewTab.tsx
+++ b/src/app/dashboard/[slug]/sparkloop/components/OverviewTab.tsx
@@ -1,19 +1,22 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { CheckCircle, TrendingUp, DollarSign, Clock, Users } from 'lucide-react'
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  Legend,
-  LabelList,
-} from 'recharts'
 import type { Recommendation } from '../types'
 import type { ChartStats, EstimatedValue } from './useSparkLoopData'
+
+const OverviewChart = dynamic(() => import('./OverviewChart'), {
+  ssr: false,
+  loading: () => (
+    <div
+      role="status"
+      aria-busy="true"
+      className="h-[300px] flex items-center justify-center text-gray-400 text-sm"
+    >
+      Loading chart...
+    </div>
+  ),
+})
 
 // --- Formatters ---
 
@@ -41,51 +44,6 @@ export function getSourceLabel(source: string) {
   if (source === 'ours') return 'ours'
   if (source === 'sparkloop') return 'SL'
   return 'default'
-}
-
-// --- Chart Tooltip ---
-
-function CustomTooltip({ active, payload, label }: any) {
-  if (active && payload && payload.length) {
-    const dataRow = payload[0]?.payload
-    const pending = dataRow?.pending || 0
-    const confirmed = dataRow?.confirmed || 0
-    const rejected = dataRow?.rejected || 0
-    const projectedEarnings = dataRow?.projectedEarnings || 0
-    const confirmedEarnings = dataRow?.confirmedEarnings || 0
-    const newPending = dataRow?.newPending
-    return (
-      <div className="bg-gray-900 text-white p-3 rounded-lg shadow-lg text-sm">
-        <div className="font-medium mb-1">{label}</div>
-        {pending > 0 && (
-          <>
-            <div className="text-purple-300">Pending Referrals: {formatNumber(pending)}</div>
-            <div className="text-purple-300">Projected Earnings: {formatDollars(projectedEarnings)}</div>
-          </>
-        )}
-        {confirmed > 0 && (
-          <>
-            <div className="text-gray-300">Confirmed Referrals: {formatNumber(confirmed)}</div>
-            <div className="text-gray-300">Confirmed Earnings: {formatDollars(confirmedEarnings)}</div>
-          </>
-        )}
-        {rejected > 0 && (
-          <div className="text-gray-500">Rejected Referrals: {formatNumber(rejected)}</div>
-        )}
-        {newPending !== null && newPending !== undefined && newPending > 0 && (
-          <div className="text-amber-300">
-            New Pending (SL): {formatNumber(newPending)}
-          </div>
-        )}
-        {(projectedEarnings > 0 || confirmedEarnings > 0) && (
-          <div className="text-green-300 mt-1 pt-1 border-t border-gray-700">
-            Total: {formatDollars(projectedEarnings + confirmedEarnings)}
-          </div>
-        )}
-      </div>
-    )
-  }
-  return null
 }
 
 // --- Recommendation Row ---
@@ -261,47 +219,7 @@ export default function OverviewTab({
             Loading chart...
           </div>
         ) : chartStats?.dailyStats && chartStats.dailyStats.length > 0 ? (
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={chartStats.dailyStats.map(d => ({
-              ...d,
-              earningsLabel: (d.projectedEarnings + d.confirmedEarnings) > 0
-                ? `$${(d.projectedEarnings + d.confirmedEarnings).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
-                : '',
-              newPendingDisplay: d.newPending !== null && d.newPending > 0 ? d.newPending : 0,
-              newPendingLabel: d.newPending !== null && d.newPending > 0
-                ? d.newPending.toLocaleString('en-US')
-                : '',
-            }))}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-              <XAxis
-                dataKey="date"
-                tick={{ fontSize: 11 }}
-                tickFormatter={(value) => {
-                  const [, m, d] = value.split('-')
-                  return `${parseInt(m)}/${parseInt(d)}`
-                }}
-              />
-              <YAxis tick={{ fontSize: 12 }} />
-              <Tooltip content={<CustomTooltip />} />
-              <Legend />
-              <Bar dataKey="pending" name="Pending" stackId="a" fill="#c4b5fd" />
-              <Bar dataKey="confirmed" name="Confirmed" stackId="a" fill="#9ca3af" />
-              <Bar dataKey="rejected" name="Rejected" stackId="a" fill="#4b5563" radius={[2, 2, 0, 0]}>
-                <LabelList
-                  dataKey="earningsLabel"
-                  position="top"
-                  style={{ fontSize: 10, fill: '#7c3aed' }}
-                />
-              </Bar>
-              <Bar dataKey="newPendingDisplay" name="New Pending (SL)" fill="#f59e0b" radius={[2, 2, 0, 0]}>
-                <LabelList
-                  dataKey="newPendingLabel"
-                  position="top"
-                  style={{ fontSize: 9, fill: '#d97706' }}
-                />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          <OverviewChart dailyStats={chartStats.dailyStats} />
         ) : (
           <div className="h-64 flex items-center justify-center text-gray-500">
             No data available for this timeframe


### PR DESCRIPTION
Closes #69 (recharts scope only — see follow-ups below)

## Summary
Extract recharts JSX from 3 dashboard client components into sibling wrapper files; replace inline charts with `next/dynamic({ ssr: false })` imports of those wrappers. Recharts (~400 KB minified) now ships in a separate chunk that loads only when the chart mounts, not in initial page JS.

## Files changed
**Created (3 wrapper components):**
- `src/app/dashboard/[slug]/metrics/MetricChart.tsx`
- `src/app/dashboard/[slug]/sparkloop/components/OffersChart.tsx`
- `src/app/dashboard/[slug]/sparkloop/components/OverviewChart.tsx`

**Edited (3 callers):**
- `src/app/dashboard/[slug]/metrics/page.tsx`
- `src/app/dashboard/[slug]/sparkloop/components/OffersTab.tsx`
- `src/app/dashboard/[slug]/sparkloop/components/OverviewTab.tsx`

Net: 6 files, +287 / −172 lines (mostly relocation, not new code).

## Build output
| Page | Size | First Load JS |
|------|------|---------------|
| `/dashboard/[slug]/metrics` | 2.8 kB | 118 kB |
| `/dashboard/[slug]/sparkloop` | 19.2 kB | 134 kB |

Recharts is now in its own chunk loaded on-demand.

## Loading placeholders
Each placeholder is a fixed-height div whose height matches the rendered chart's `ResponsiveContainer` height pixel-for-pixel — prevents CLS. Per usability gate review, includes `role="status"` and `aria-busy="true"` for screen-reader announcement (WCAG 4.1.3).

## Scope discipline
Issue #69 listed 3 libs but `next/dynamic` operates at the component level, not the library level. Only recharts has a clean component-extraction story across a small surface (3 importers).

**Deferred to dedicated follow-up issues:**
- **`@dnd-kit`** — 22 files / 55 imports including hooks (`useSortable`, `useDraggable`) that can't be lazy-loaded at the import site. Real refactor: extract entire drag-and-drop component trees behind dynamic boundaries.
- **`react-image-crop`** — 18 importers, mostly `<ReactCrop>` usage in forms/modals. Doable as a follow-up PR with its own per-site wrapper extraction.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean (no new warnings)
- [x] `npm run build` — clean; recharts visibly code-split
- [x] `npm run test:run` — full suite passes (no tests reference these files)
- [x] `npm run test:coverage` — gate (#65) still passes (dashboard files outside coverage scope)
- [x] Pre-push gate: simplify (clean) + frontend (layout cleared, usability fixed the a11y warning)
- [ ] Manual smoke in dev:
  - Open `/dashboard/[slug]/metrics` — see brief skeleton, then chart renders. Network tab confirms separate chunk load.
  - Same for `/dashboard/[slug]/sparkloop` (Offers + Overview tabs)
  - Resize / hover / interact — no behavior regression

## Out of scope
- @dnd-kit + react-image-crop lazy loading — separate follow-up issues
- Adding `@next/bundle-analyzer` — useful but separate tooling PR
- Splitting the 6 files >1,000 lines flagged in #69 body — orthogonal (component decomposition, not bundle splitting)
- Tests for the new chart wrappers — no existing dashboard tests; future test-coverage PR

## Follow-up actions after merge
Open two new issues with accurate scope:
- "Lazy-load @dnd-kit: extract drag-and-drop trees into dynamic boundaries (22 files)"
- "Lazy-load react-image-crop: wrap `<ReactCrop>` usages in dynamic components (18 files)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted dashboard chart rendering into dedicated, reusable components with improved code organization and modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->