### PR TITLE
feat(dal): paginated query wrapper + posts/articles/dedup modules

### DIFF
--- a/src/app/api/cron/process-mailerlite-updates/route.ts
+++ b/src/app/api/cron/process-mailerlite-updates/route.ts
@@ -1,6 +1,7 @@
 import { withApiHandler } from '@/lib/api-handler'
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
+import { fetchAllPaginated } from '@/lib/dal/paginate'
 import { isIPExcluded, IPExclusion } from '@/lib/ip-utils'
 import { getEmailProviderSettings } from '@/lib/publication-settings'
 import { updateBeehiivSubscriberField } from '@/lib/beehiiv'
@@ -159,14 +160,20 @@ async function syncRealClickStatus(log: Logger): Promise<{
       const validClicks = allClicks.filter(c => !isIPExcluded(c.ip_address, exclusions))
       const emailsWithValidClicks = new Set(validClicks.map(c => c.subscriber_email.toLowerCase()))
 
-      // Get current stored state
-      const { data: currentStatus } = await supabaseAdmin
-        .from('subscriber_real_click_status')
-        .select('subscriber_email, has_real_click')
-        .eq('publication_id', publication.id)
+      // Get current stored state — paginate past Supabase's 1000-row default
+      // limit. Without this, every sync past 1000 rows silently dropped
+      // clickers and resent the same MailerLite updates indefinitely.
+      const currentStatus = await fetchAllPaginated<{ subscriber_email: string; has_real_click: boolean }>(
+        () =>
+          supabaseAdmin
+            .from('subscriber_real_click_status')
+            .select('subscriber_email, has_real_click')
+            .eq('publication_id', publication.id),
+        { label: 'process-mailerlite-updates:subscriber_real_click_status' }
+      )
 
       const currentStatusMap = new Map<string, boolean>()
-      for (const status of currentStatus || []) {
+      for (const status of currentStatus) {
         currentStatusMap.set(status.subscriber_email.toLowerCase(), status.has_real_click)
       }
 

--- a/src/lib/CLAUDE.md
+++ b/src/lib/CLAUDE.md
@@ -7,9 +7,25 @@ Check `docs/architecture/DEPENDENCY_MAP.md` for downstream impact. Files in `src
 ## Key Conventions
 
 ### Database Access
-- Always use `supabaseAdmin` — never the anon client
+- **Prefer the DAL** (`src/lib/dal/*`) over direct `supabaseAdmin` calls. New code should import from a DAL module; existing direct calls migrate as files are touched.
+- When writing direct queries, always use `supabaseAdmin` — never the anon client
 - Every query must filter by `publication_id`
 - Explicit column lists in `.select()` — never `select('*')`
+- For lists that can exceed 1000 rows, use `fetchAllPaginated` from `@/lib/dal/paginate` (Supabase's default `.select()` silently truncates at 1000)
+
+### Data Access Layer (`src/lib/dal/`)
+| Module | Domain | Tables |
+|--------|--------|--------|
+| `dal/issues.ts` | Issue lifecycle | `publication_issues` |
+| `dal/posts.ts` | RSS post lifecycle | `rss_posts`, `post_ratings` |
+| `dal/articles.ts` | Article rows per issue | `module_articles`, `manual_articles` |
+| `dal/dedup.ts` | Duplicate detection results | `duplicate_groups`, `duplicate_posts` |
+| `dal/paginate.ts` | Generic paginated reads | (helper, not table-bound) |
+| `dal/analytics.ts` | Analytics aggregates | (existing) |
+
+DAL conventions: exported functions (no classes); reads return `T | null` or `T[]`; writes return `boolean`; errors are logged via pino and swallowed (callers don't need try/catch). Mirror `dal/issues.ts` when adding a new module.
+
+**Module-type domains stay at `src/lib/*-modules/`** (`article-modules/`, `prompt-modules/`, `ai-app-modules/`, `ad-modules/`, `poll-modules/`, `text-box-modules/`, `feedback-modules/`, `sparkloop-rec-modules/`). Each selector class already follows the DAL pattern (DB access centralized, structured methods). Do NOT migrate them to `dal/`; keep new module-type code there too.
 
 ### Settings Access
 Two-tier fallback: publication-specific first, then app-wide:

--- a/src/lib/__tests__/date-utils.test.ts
+++ b/src/lib/__tests__/date-utils.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  toLocalDateStr,
+  toProjectDateStr,
+  buildDateRangeBoundaries,
+  getTodayStr,
+  getDaysAgoStr,
+  getTomorrowStr,
+} from '../date-utils'
+
+// vitest.config.ts pins TZ=UTC, so server-local time === UTC in tests.
+
+describe('toLocalDateStr', () => {
+  it('formats a Date as YYYY-MM-DD using local parts', () => {
+    expect(toLocalDateStr(new Date('2025-06-15T12:00:00Z'))).toBe('2025-06-15')
+  })
+
+  it('zero-pads single-digit months and days', () => {
+    expect(toLocalDateStr(new Date('2025-01-05T12:00:00Z'))).toBe('2025-01-05')
+  })
+})
+
+describe('toProjectDateStr', () => {
+  it('returns the CT calendar date for a UTC timestamp during CDT', () => {
+    // 2025-06-15 04:30 UTC === 2025-06-14 23:30 CDT (UTC-5)
+    expect(toProjectDateStr('2025-06-15T04:30:00Z')).toBe('2025-06-14')
+  })
+
+  it('returns the CT calendar date for a UTC timestamp during CST', () => {
+    // 2025-01-01 05:30 UTC === 2024-12-31 23:30 CST (UTC-6)
+    expect(toProjectDateStr('2025-01-01T05:30:00Z')).toBe('2024-12-31')
+  })
+
+  it('handles same-day midday UTC timestamps', () => {
+    expect(toProjectDateStr('2025-06-15T18:00:00Z')).toBe('2025-06-15')
+  })
+})
+
+describe('getTodayStr / getTomorrowStr — fake-time', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('getTodayStr("UTC") matches the current UTC date', () => {
+    vi.setSystemTime(new Date('2025-06-15T18:00:00Z'))
+    expect(getTodayStr('UTC')).toBe('2025-06-15')
+  })
+
+  it('getTodayStr("CST") returns the prior CT date when UTC is shortly past midnight', () => {
+    // 2025-06-15 04:30 UTC === 2025-06-14 23:30 CDT
+    vi.setSystemTime(new Date('2025-06-15T04:30:00Z'))
+    expect(getTodayStr('CST')).toBe('2025-06-14')
+    expect(getTodayStr('UTC')).toBe('2025-06-15')
+  })
+
+  it('getTomorrowStr("CST") rolls over at CT midnight, not UTC midnight', () => {
+    // 23:55 CDT on 2025-06-15 === 04:55 UTC on 2025-06-16
+    // "Today in CT" is 2025-06-15, so tomorrow in CT = 2025-06-16
+    vi.setSystemTime(new Date('2025-06-16T04:55:00Z'))
+    expect(getTomorrowStr('CST')).toBe('2025-06-16')
+  })
+
+  it('getTomorrowStr("UTC") returns the next UTC calendar day', () => {
+    vi.setSystemTime(new Date('2025-06-15T23:30:00Z'))
+    expect(getTomorrowStr('UTC')).toBe('2025-06-16')
+  })
+
+  it('getTomorrowStr handles month rollover', () => {
+    vi.setSystemTime(new Date('2025-01-31T18:00:00Z'))
+    expect(getTomorrowStr('UTC')).toBe('2025-02-01')
+  })
+
+  it('getTomorrowStr handles year rollover', () => {
+    vi.setSystemTime(new Date('2024-12-31T18:00:00Z'))
+    expect(getTomorrowStr('UTC')).toBe('2025-01-01')
+  })
+
+  it('getTomorrowStr("CST") is DST-safe across spring-forward', () => {
+    // 2025-03-09 18:00 UTC === 2025-03-09 13:00 CDT (already after spring-forward)
+    // Tomorrow should still be 2025-03-10 in CT calendar terms.
+    vi.setSystemTime(new Date('2025-03-09T18:00:00Z'))
+    expect(getTomorrowStr('CST')).toBe('2025-03-10')
+  })
+})
+
+describe('getDaysAgoStr', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-06-15T18:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('subtracts whole days in UTC', () => {
+    expect(getDaysAgoStr(7, 'UTC')).toBe('2025-06-08')
+  })
+
+  it('subtracts whole days in CST', () => {
+    // 2025-06-15 18:00 UTC === 2025-06-15 13:00 CDT; minus 7 days === 2025-06-08
+    expect(getDaysAgoStr(7, 'CST')).toBe('2025-06-08')
+  })
+
+  it('returns today for days=0', () => {
+    expect(getDaysAgoStr(0, 'UTC')).toBe('2025-06-15')
+  })
+})
+
+describe('buildDateRangeBoundaries', () => {
+  it('UTC: midnight-to-end-of-day', () => {
+    const { startDate, endDate } = buildDateRangeBoundaries('2025-06-01', '2025-06-30', 'UTC')
+    expect(startDate.toISOString()).toBe('2025-06-01T00:00:00.000Z')
+    expect(endDate.toISOString()).toBe('2025-06-30T23:59:59.999Z')
+  })
+
+  it('CST during summer (CDT, UTC-5): start = midnight CDT', () => {
+    // CDT is UTC-5, so midnight CDT === 05:00 UTC
+    const { startDate, endDate } = buildDateRangeBoundaries('2025-06-01', '2025-06-30', 'CST')
+    expect(startDate.toISOString()).toBe('2025-06-01T05:00:00.000Z')
+    expect(endDate.toISOString()).toBe('2025-07-01T04:59:59.999Z')
+  })
+
+  it('CST during winter (CST, UTC-6): start = midnight CST', () => {
+    // CST is UTC-6, so midnight CST === 06:00 UTC
+    const { startDate, endDate } = buildDateRangeBoundaries('2025-01-01', '2025-01-31', 'CST')
+    expect(startDate.toISOString()).toBe('2025-01-01T06:00:00.000Z')
+    expect(endDate.toISOString()).toBe('2025-02-01T05:59:59.999Z')
+  })
+
+  it('CST across spring-forward boundary (Mar 9 2025) — uses post-DST offset', () => {
+    // The implementation probes at noon UTC, which on spring-forward day already
+    // sees CDT (UTC-5). The whole local day is treated as CDT. This means
+    // 00:00 "local" maps to 05:00 UTC even though the real wall-clock midnight
+    // was in CST (06:00 UTC). Acceptable for analytics use; documented here so
+    // future contributors don't regress this trade-off.
+    const { startDate, endDate } = buildDateRangeBoundaries('2025-03-09', '2025-03-11', 'CST')
+    expect(startDate.toISOString()).toBe('2025-03-09T05:00:00.000Z')
+    expect(endDate.toISOString()).toBe('2025-03-12T04:59:59.999Z')
+  })
+
+  it('CST across fall-back boundary (Nov 2 2025) — uses post-DST offset', () => {
+    // Same noon-UTC probe behavior: on fall-back day, noon UTC is already in
+    // CST (UTC-6), so the whole local day is treated as CST. 00:00 "local"
+    // maps to 06:00 UTC even though wall-clock midnight was in CDT (05:00 UTC).
+    const { startDate, endDate } = buildDateRangeBoundaries('2025-11-02', '2025-11-03', 'CST')
+    expect(startDate.toISOString()).toBe('2025-11-02T06:00:00.000Z')
+    expect(endDate.toISOString()).toBe('2025-11-04T05:59:59.999Z')
+  })
+})

--- a/src/lib/dal/__tests__/articles.test.ts
+++ b/src/lib/dal/__tests__/articles.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+const mockSingle = vi.fn()
+const mockMaybeSingle = vi.fn()
+let mockChainResult: { data: any; error: any } = { data: null, error: null }
+
+const mockChain: Record<string, any> = {
+  select: vi.fn(function (this: any) { return mockChain }),
+  insert: vi.fn(function () { return mockChain }),
+  update: vi.fn(function () { return mockChain }),
+  delete: vi.fn(function () { return mockChain }),
+  eq: vi.fn(function () { return mockChain }),
+  neq: vi.fn(function () { return mockChain }),
+  in: vi.fn(function () { return mockChain }),
+  is: vi.fn(function () { return mockChain }),
+  not: vi.fn(function () { return mockChain }),
+  like: vi.fn(function () { return mockChain }),
+  gte: vi.fn(function () { return mockChain }),
+  lte: vi.fn(function () { return mockChain }),
+  order: vi.fn(function () { return mockChain }),
+  limit: vi.fn(function () { return mockChain }),
+  range: vi.fn(function () { return Promise.resolve(mockChainResult) }),
+  single: mockSingle,
+  maybeSingle: mockMaybeSingle,
+  then: function (onFulfilled: any) {
+    return Promise.resolve(mockChainResult).then(onFulfilled)
+  },
+}
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => mockChain),
+  },
+}))
+
+vi.mock('@/lib/logger', () => {
+  const log = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+    correlationId: 'test-id',
+  }
+  return { createLogger: vi.fn(() => log) }
+})
+
+import {
+  listModuleArticlesByIssue,
+  moduleArticleExists,
+  listArticlesNeedingBody,
+  listArticlesNeedingFactCheck,
+  insertModuleArticle,
+  updateModuleArticleContent,
+  updateModuleArticleFactCheck,
+  listManualArticlesByPublication,
+  findNextAvailableSlug,
+  insertManualArticle,
+  updateManualArticle,
+  deleteManualArticle,
+} from '../articles'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockChainResult = { data: null, error: null }
+  mockChain.select.mockReturnValue(mockChain)
+  mockChain.insert.mockReturnValue(mockChain)
+  mockChain.update.mockReturnValue(mockChain)
+  mockChain.delete.mockReturnValue(mockChain)
+  mockChain.eq.mockReturnValue(mockChain)
+  mockChain.neq.mockReturnValue(mockChain)
+  mockChain.in.mockReturnValue(mockChain)
+  mockChain.is.mockReturnValue(mockChain)
+  mockChain.not.mockReturnValue(mockChain)
+  mockChain.like.mockReturnValue(mockChain)
+  mockChain.gte.mockReturnValue(mockChain)
+  mockChain.lte.mockReturnValue(mockChain)
+  mockChain.order.mockReturnValue(mockChain)
+  mockChain.limit.mockReturnValue(mockChain)
+})
+
+// ---------------------------------------------------------------------------
+describe('listModuleArticlesByIssue', () => {
+  it('lists articles for an issue', async () => {
+    mockChainResult = { data: [{ id: 'a1' }, { id: 'a2' }], error: null }
+    const result = await listModuleArticlesByIssue('issue-1')
+    expect(result).toHaveLength(2)
+    expect(mockChain.eq).toHaveBeenCalledWith('issue_id', 'issue-1')
+  })
+
+  it('applies activeOnly + moduleId filters', async () => {
+    mockChainResult = { data: [], error: null }
+    await listModuleArticlesByIssue('issue-1', { moduleId: 'mod-1', activeOnly: true })
+    expect(mockChain.eq).toHaveBeenCalledWith('article_module_id', 'mod-1')
+    expect(mockChain.eq).toHaveBeenCalledWith('is_active', true)
+  })
+
+  it('uses lighter column shape for idsOnly', async () => {
+    mockChainResult = { data: [], error: null }
+    await listModuleArticlesByIssue('issue-1', { idsOnly: true })
+    expect(mockChain.select).toHaveBeenCalledWith('id')
+  })
+
+  it('uses post_id column shape for postIdsOnly', async () => {
+    mockChainResult = { data: [], error: null }
+    await listModuleArticlesByIssue('issue-1', { postIdsOnly: true })
+    expect(mockChain.select).toHaveBeenCalledWith('post_id')
+  })
+
+  it('returns [] on error', async () => {
+    mockChainResult = { data: null, error: { message: 'fail' } }
+    const result = await listModuleArticlesByIssue('issue-1')
+    expect(result).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('moduleArticleExists', () => {
+  it('returns true when row exists', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: { id: 'a1' }, error: null })
+    const exists = await moduleArticleExists('p1', 'issue-1', 'mod-1')
+    expect(exists).toBe(true)
+  })
+
+  it('returns false when no row', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: null })
+    const exists = await moduleArticleExists('p1', 'issue-1', 'mod-1')
+    expect(exists).toBe(false)
+  })
+
+  it('returns false on error', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: { message: 'fail' } })
+    const exists = await moduleArticleExists('p1', 'issue-1', 'mod-1')
+    expect(exists).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listArticlesNeedingBody', () => {
+  it('applies content==="" + headline NOT NULL filters and limit', async () => {
+    mockChainResult = { data: [], error: null }
+    await listArticlesNeedingBody('issue-1', 'mod-1', 5)
+    expect(mockChain.eq).toHaveBeenCalledWith('content', '')
+    expect(mockChain.not).toHaveBeenCalledWith('headline', 'is', null)
+    expect(mockChain.order).toHaveBeenCalledWith('post_id', { ascending: true })
+    expect(mockChain.limit).toHaveBeenCalledWith(5)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listArticlesNeedingFactCheck', () => {
+  it('applies content!="" + content NOT NULL + fact_check_score IS NULL', async () => {
+    mockChainResult = { data: [], error: null }
+    await listArticlesNeedingFactCheck('issue-1', 'mod-1')
+    expect(mockChain.neq).toHaveBeenCalledWith('content', '')
+    expect(mockChain.not).toHaveBeenCalledWith('content', 'is', null)
+    expect(mockChain.is).toHaveBeenCalledWith('fact_check_score', null)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('insertModuleArticle', () => {
+  it('returns ok=true on success', async () => {
+    mockChainResult = { data: null, error: null }
+    const result = await insertModuleArticle({ post_id: 'p1', issue_id: 'i1', article_module_id: 'm1' })
+    expect(result).toEqual({ ok: true, duplicate: false })
+  })
+
+  it('returns duplicate=true on 23505 (unique violation)', async () => {
+    mockChainResult = { data: null, error: { code: '23505', message: 'duplicate key' } }
+    const result = await insertModuleArticle({ post_id: 'p1', issue_id: 'i1', article_module_id: 'm1' })
+    expect(result).toEqual({ ok: false, duplicate: true })
+  })
+
+  it('returns ok=false on other errors', async () => {
+    mockChainResult = { data: null, error: { code: '99999', message: 'other' } }
+    const result = await insertModuleArticle({ post_id: 'p1', issue_id: 'i1', article_module_id: 'm1' })
+    expect(result).toEqual({ ok: false, duplicate: false })
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('updateModuleArticleContent', () => {
+  it('updates content + word_count', async () => {
+    mockChainResult = { data: null, error: null }
+    const ok = await updateModuleArticleContent('a1', { content: 'body', wordCount: 42 })
+    expect(ok).toBe(true)
+    expect(mockChain.update).toHaveBeenCalledWith({ content: 'body', word_count: 42 })
+  })
+
+  it('returns false on error', async () => {
+    mockChainResult = { data: null, error: { message: 'fail' } }
+    const ok = await updateModuleArticleContent('a1', { content: 'body', wordCount: 42 })
+    expect(ok).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('updateModuleArticleFactCheck', () => {
+  it('updates fact_check_score + fact_check_details', async () => {
+    mockChainResult = { data: null, error: null }
+    const ok = await updateModuleArticleFactCheck('a1', { score: 8, details: 'good' })
+    expect(ok).toBe(true)
+    expect(mockChain.update).toHaveBeenCalledWith({ fact_check_score: 8, fact_check_details: 'good' })
+  })
+
+  it('accepts null details', async () => {
+    mockChainResult = { data: null, error: null }
+    await updateModuleArticleFactCheck('a1', { score: 0, details: null })
+    expect(mockChain.update).toHaveBeenCalledWith({ fact_check_score: 0, fact_check_details: null })
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listManualArticlesByPublication', () => {
+  it('filters by publication_id and orders by publish_date', async () => {
+    mockChainResult = { data: [], error: null }
+    await listManualArticlesByPublication('pub-1')
+    expect(mockChain.eq).toHaveBeenCalledWith('publication_id', 'pub-1')
+    expect(mockChain.order).toHaveBeenCalledWith('publish_date', { ascending: false })
+  })
+
+  it('applies status array via .in()', async () => {
+    mockChainResult = { data: [], error: null }
+    await listManualArticlesByPublication('pub-1', { status: ['draft', 'published'] })
+    expect(mockChain.in).toHaveBeenCalledWith('status', ['draft', 'published'])
+  })
+
+  it('applies single status via .eq()', async () => {
+    mockChainResult = { data: [], error: null }
+    await listManualArticlesByPublication('pub-1', { status: 'used' })
+    expect(mockChain.eq).toHaveBeenCalledWith('status', 'used')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('findNextAvailableSlug', () => {
+  it('returns base slug when no matching slugs exist', async () => {
+    mockChainResult = { data: [], error: null }
+    const slug = await findNextAvailableSlug('hello-world', 'pub-1')
+    expect(slug).toBe('hello-world')
+  })
+
+  it('appends -2 when base slug is taken', async () => {
+    mockChainResult = { data: [{ slug: 'hello-world' }], error: null }
+    const slug = await findNextAvailableSlug('hello-world', 'pub-1')
+    expect(slug).toBe('hello-world-2')
+  })
+
+  it('finds first free numbered slot when multiple are taken', async () => {
+    mockChainResult = {
+      data: [{ slug: 'topic' }, { slug: 'topic-2' }, { slug: 'topic-3' }],
+      error: null,
+    }
+    const slug = await findNextAvailableSlug('topic', 'pub-1')
+    expect(slug).toBe('topic-4')
+  })
+
+  it('finds gap in numbered sequence', async () => {
+    mockChainResult = {
+      data: [{ slug: 'topic' }, { slug: 'topic-3' }, { slug: 'topic-4' }],
+      error: null,
+    }
+    const slug = await findNextAvailableSlug('topic', 'pub-1')
+    expect(slug).toBe('topic-2')
+  })
+
+  it('uses LIKE filter on the base slug', async () => {
+    mockChainResult = { data: [], error: null }
+    await findNextAvailableSlug('hello-world', 'pub-1')
+    expect(mockChain.like).toHaveBeenCalledWith('slug', 'hello-world%')
+  })
+
+  it('returns base slug on query error (best-effort fallback)', async () => {
+    mockChainResult = { data: null, error: { message: 'fail' } }
+    const slug = await findNextAvailableSlug('hello-world', 'pub-1')
+    expect(slug).toBe('hello-world')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('insertManualArticle', () => {
+  it('returns inserted row on success', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: { id: 'm1', title: 't', publication_id: 'pub-1' },
+      error: null,
+    })
+    const result = await insertManualArticle({
+      publication_id: 'pub-1',
+      title: 't',
+      slug: 't',
+      body: 'body',
+      image_url: null,
+      section_type: 'primary_articles',
+      category_id: null,
+      publish_date: '2025-01-01',
+      status: 'draft',
+    })
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe('m1')
+  })
+
+  it('returns null on error', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: { message: 'fail' } })
+    const result = await insertManualArticle({
+      publication_id: 'pub-1',
+      title: 't',
+      slug: 't',
+      body: 'body',
+      image_url: null,
+      section_type: 'primary_articles',
+      category_id: null,
+      publish_date: '2025-01-01',
+      status: 'draft',
+    })
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('updateManualArticle', () => {
+  it('enforces publicationId in WHERE clause', async () => {
+    mockChainResult = { data: null, error: null }
+    await updateManualArticle('m1', 'pub-1', { title: 'new' })
+    expect(mockChain.eq).toHaveBeenCalledWith('id', 'm1')
+    expect(mockChain.eq).toHaveBeenCalledWith('publication_id', 'pub-1')
+  })
+
+  it('returns false on error', async () => {
+    mockChainResult = { data: null, error: { message: 'fail' } }
+    const ok = await updateManualArticle('m1', 'pub-1', { title: 'new' })
+    expect(ok).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('deleteManualArticle', () => {
+  it('enforces publicationId in WHERE clause', async () => {
+    mockChainResult = { data: null, error: null }
+    await deleteManualArticle('m1', 'pub-1')
+    expect(mockChain.eq).toHaveBeenCalledWith('id', 'm1')
+    expect(mockChain.eq).toHaveBeenCalledWith('publication_id', 'pub-1')
+  })
+})

--- a/src/lib/dal/__tests__/dedup.test.ts
+++ b/src/lib/dal/__tests__/dedup.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+const mockSingle = vi.fn()
+const mockMaybeSingle = vi.fn()
+let mockChainResult: { data: any; error: any } = { data: null, error: null }
+
+const mockChain: Record<string, any> = {
+  select: vi.fn(function (this: any) { return mockChain }),
+  insert: vi.fn(function () { return mockChain }),
+  update: vi.fn(function () { return mockChain }),
+  delete: vi.fn(function () { return mockChain }),
+  eq: vi.fn(function () { return mockChain }),
+  in: vi.fn(function () { return mockChain }),
+  is: vi.fn(function () { return mockChain }),
+  not: vi.fn(function () { return mockChain }),
+  order: vi.fn(function () { return mockChain }),
+  limit: vi.fn(function () { return mockChain }),
+  range: vi.fn(function () { return Promise.resolve(mockChainResult) }),
+  single: mockSingle,
+  maybeSingle: mockMaybeSingle,
+  then: function (onFulfilled: any) {
+    return Promise.resolve(mockChainResult).then(onFulfilled)
+  },
+}
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => mockChain),
+  },
+}))
+
+vi.mock('@/lib/logger', () => {
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), correlationId: 'test-id' }
+  return { createLogger: vi.fn(() => log) }
+})
+
+import {
+  isIssueDeduplicated,
+  listDuplicateGroupIdsByIssue,
+  listDuplicatePostIdsByGroups,
+  listDuplicatePostsForGroup,
+  createDuplicateGroup,
+  addDuplicatePostToGroup,
+  storeDeduplicationResult,
+} from '../dedup'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockChainResult = { data: null, error: null }
+  mockChain.select.mockReturnValue(mockChain)
+  mockChain.insert.mockReturnValue(mockChain)
+  mockChain.eq.mockReturnValue(mockChain)
+  mockChain.in.mockReturnValue(mockChain)
+  mockChain.limit.mockReturnValue(mockChain)
+})
+
+// ---------------------------------------------------------------------------
+describe('isIssueDeduplicated', () => {
+  it('returns true when a group exists', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: { id: 'g1' }, error: null })
+    expect(await isIssueDeduplicated('issue-1')).toBe(true)
+  })
+
+  it('returns false when no group exists', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: null })
+    expect(await isIssueDeduplicated('issue-1')).toBe(false)
+  })
+
+  it('returns false on error', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: { code: 'XX', message: 'fail' } })
+    expect(await isIssueDeduplicated('issue-1')).toBe(false)
+  })
+
+  it('treats PGRST116 (not found) as not-deduplicated, not error', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: { code: 'PGRST116', message: 'no rows' } })
+    expect(await isIssueDeduplicated('issue-1')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listDuplicateGroupIdsByIssue', () => {
+  it('returns array of group ids', async () => {
+    mockChainResult = { data: [{ id: 'g1' }, { id: 'g2' }], error: null }
+    const result = await listDuplicateGroupIdsByIssue('issue-1')
+    expect(result).toEqual(['g1', 'g2'])
+    expect(mockChain.eq).toHaveBeenCalledWith('issue_id', 'issue-1')
+  })
+
+  it('returns [] on error', async () => {
+    mockChainResult = { data: null, error: { message: 'fail' } }
+    expect(await listDuplicateGroupIdsByIssue('issue-1')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listDuplicatePostIdsByGroups', () => {
+  it('returns empty Set when groupIds empty', async () => {
+    const result = await listDuplicatePostIdsByGroups([])
+    expect(result.size).toBe(0)
+  })
+
+  it('returns Set of post_ids across groups', async () => {
+    mockChainResult = { data: [{ post_id: 'p1' }, { post_id: 'p2' }], error: null }
+    const result = await listDuplicatePostIdsByGroups(['g1'])
+    expect(result).toEqual(new Set(['p1', 'p2']))
+    expect(mockChain.in).toHaveBeenCalledWith('group_id', ['g1'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listDuplicatePostsForGroup', () => {
+  it('returns rows', async () => {
+    mockChainResult = {
+      data: [{ id: 'd1', group_id: 'g1', post_id: 'p1', similarity_score: 0.9 }],
+      error: null,
+    }
+    const result = await listDuplicatePostsForGroup('g1')
+    expect(result).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('createDuplicateGroup', () => {
+  it('returns inserted row on success', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: { id: 'g1', issue_id: 'i1', primary_post_id: 'p1', topic_signature: 'sig' },
+      error: null,
+    })
+    const result = await createDuplicateGroup({
+      issueId: 'i1',
+      primaryPostId: 'p1',
+      topicSignature: 'sig',
+    })
+    expect(result?.id).toBe('g1')
+  })
+
+  it('returns null on error', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: { message: 'fail' } })
+    const result = await createDuplicateGroup({
+      issueId: 'i1',
+      primaryPostId: 'p1',
+      topicSignature: null,
+    })
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('addDuplicatePostToGroup', () => {
+  it('returns true on success', async () => {
+    mockChainResult = { data: null, error: null }
+    const ok = await addDuplicatePostToGroup('g1', {
+      postId: 'p1',
+      similarityScore: 0.85,
+      detectionMethod: 'ai_semantic',
+    })
+    expect(ok).toBe(true)
+  })
+
+  it('returns false on error', async () => {
+    mockChainResult = { data: null, error: { message: 'fail' } }
+    const ok = await addDuplicatePostToGroup('g1', { postId: 'p1', similarityScore: 0.85 })
+    expect(ok).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('storeDeduplicationResult', () => {
+  it('returns null group + 0 stored when group create fails', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: { message: 'fail' } })
+    const result = await storeDeduplicationResult({
+      issueId: 'i1',
+      primaryPostId: 'p1',
+      topicSignature: null,
+      duplicates: [{ postId: 'd1', similarityScore: 0.9 }],
+    })
+    expect(result.group).toBeNull()
+    expect(result.storedDuplicates).toBe(0)
+  })
+
+  it('bulk-inserts all duplicates after group creation', async () => {
+    // Group insert succeeds
+    mockSingle.mockResolvedValueOnce({
+      data: { id: 'g1', issue_id: 'i1', primary_post_id: 'p1', topic_signature: null },
+      error: null,
+    })
+    // Bulk insert succeeds
+    mockChainResult = { data: null, error: null }
+
+    const result = await storeDeduplicationResult({
+      issueId: 'i1',
+      primaryPostId: 'p1',
+      topicSignature: null,
+      duplicates: [
+        { postId: 'd1', similarityScore: 0.9 },
+        { postId: 'd2', similarityScore: 0.8 },
+      ],
+    })
+    expect(result.group?.id).toBe('g1')
+    expect(result.storedDuplicates).toBe(2)
+    // Verify exactly one INSERT call (bulk), not per-duplicate
+    expect(mockChain.insert).toHaveBeenCalledTimes(2) // 1 for group, 1 for bulk duplicates
+  })
+
+  it('returns group with storedDuplicates=0 when bulk insert fails', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: { id: 'g1', issue_id: 'i1', primary_post_id: 'p1', topic_signature: null },
+      error: null,
+    })
+    // Bulk insert fails
+    mockChainResult = { data: null, error: { message: 'bulk insert failed' } }
+
+    const result = await storeDeduplicationResult({
+      issueId: 'i1',
+      primaryPostId: 'p1',
+      topicSignature: null,
+      duplicates: [
+        { postId: 'd1', similarityScore: 0.9 },
+        { postId: 'd2', similarityScore: 0.8 },
+      ],
+    })
+    expect(result.group?.id).toBe('g1')
+    expect(result.storedDuplicates).toBe(0)
+  })
+
+  it('skips bulk insert entirely when duplicates is empty', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: { id: 'g1', issue_id: 'i1', primary_post_id: 'p1', topic_signature: null },
+      error: null,
+    })
+
+    const result = await storeDeduplicationResult({
+      issueId: 'i1',
+      primaryPostId: 'p1',
+      topicSignature: null,
+      duplicates: [],
+    })
+    expect(result.group?.id).toBe('g1')
+    expect(result.storedDuplicates).toBe(0)
+    // Only the group insert; no duplicate insert
+    expect(mockChain.insert).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/lib/dal/__tests__/paginate.test.ts
+++ b/src/lib/dal/__tests__/paginate.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/logger', () => {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    correlationId: 'test-id',
+  }
+  return { createLogger: vi.fn(() => log) }
+})
+
+import { fetchAllPaginated } from '../paginate'
+
+// ---------------------------------------------------------------------------
+// Test helpers — build a stub query whose .range(from, to) returns a slice
+// ---------------------------------------------------------------------------
+
+function makeRowSource<T>(allRows: T[]) {
+  // Returns a builder factory that, on each call, produces a fresh stub query
+  // whose .range() returns the requested slice. Tracks how many .range() calls
+  // were made so tests can assert page count.
+  const calls: Array<{ from: number; to: number }> = []
+  const buildQuery = () => ({
+    range: (from: number, to: number) => {
+      calls.push({ from, to })
+      const slice = allRows.slice(from, to + 1)
+      return Promise.resolve({ data: slice, error: null })
+    },
+  })
+  return { buildQuery, calls }
+}
+
+function makeErrorSource(errorOnPage: number) {
+  // Returns a builder that succeeds for the first N pages, then errors.
+  let pageIndex = 0
+  const calls: number[] = []
+  const buildQuery = () => ({
+    range: (from: number, to: number) => {
+      const thisPage = pageIndex
+      pageIndex += 1
+      calls.push(thisPage)
+      if (thisPage === errorOnPage) {
+        return Promise.resolve({
+          data: null,
+          error: { message: 'simulated postgrest error', code: 'XX000' } as any,
+        })
+      }
+      // Fill page with synthetic rows so the loop advances
+      const size = to - from + 1
+      const rows = Array.from({ length: size }, (_, i) => ({ id: from + i }))
+      return Promise.resolve({ data: rows, error: null })
+    },
+  })
+  return { buildQuery, calls: () => calls }
+}
+
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('fetchAllPaginated', () => {
+  it('returns [] for an empty source in 1 page', async () => {
+    const { buildQuery, calls } = makeRowSource<{ id: number }>([])
+    const result = await fetchAllPaginated<{ id: number }>(buildQuery)
+    expect(result).toEqual([])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toEqual({ from: 0, to: 999 })
+  })
+
+  it('returns all rows in 1 page when source is smaller than pageSize', async () => {
+    const rows = Array.from({ length: 42 }, (_, i) => ({ id: i }))
+    const { buildQuery, calls } = makeRowSource(rows)
+    const result = await fetchAllPaginated<{ id: number }>(buildQuery)
+    expect(result).toHaveLength(42)
+    expect(result[0]).toEqual({ id: 0 })
+    expect(result[41]).toEqual({ id: 41 })
+    expect(calls).toHaveLength(1)
+  })
+
+  it('uses 2 pages when source has exactly pageSize rows (second page empty)', async () => {
+    const rows = Array.from({ length: 1000 }, (_, i) => ({ id: i }))
+    const { buildQuery, calls } = makeRowSource(rows)
+    const result = await fetchAllPaginated<{ id: number }>(buildQuery)
+    expect(result).toHaveLength(1000)
+    expect(calls).toHaveLength(2)
+    expect(calls[0]).toEqual({ from: 0, to: 999 })
+    expect(calls[1]).toEqual({ from: 1000, to: 1999 })
+  })
+
+  it('pages through 2500 rows across 3 pages', async () => {
+    const rows = Array.from({ length: 2500 }, (_, i) => ({ id: i }))
+    const { buildQuery, calls } = makeRowSource(rows)
+    const result = await fetchAllPaginated<{ id: number }>(buildQuery)
+    expect(result).toHaveLength(2500)
+    expect(calls).toHaveLength(3)
+    expect(calls[2]).toEqual({ from: 2000, to: 2999 })
+  })
+
+  it('honors custom pageSize', async () => {
+    const rows = Array.from({ length: 1200 }, (_, i) => ({ id: i }))
+    const { buildQuery, calls } = makeRowSource(rows)
+    const result = await fetchAllPaginated<{ id: number }>(buildQuery, { pageSize: 500 })
+    expect(result).toHaveLength(1200)
+    expect(calls).toHaveLength(3)
+    expect(calls[0]).toEqual({ from: 0, to: 499 })
+    expect(calls[1]).toEqual({ from: 500, to: 999 })
+    expect(calls[2]).toEqual({ from: 1000, to: 1499 })
+  })
+
+  it('throws when an error is returned mid-loop and does not return partial', async () => {
+    const { buildQuery, calls } = makeErrorSource(1)
+    await expect(fetchAllPaginated<{ id: number }>(buildQuery)).rejects.toMatchObject({
+      message: 'simulated postgrest error',
+    })
+    expect(calls()).toEqual([0, 1])
+  })
+
+  it('throws when maxPages is exceeded', async () => {
+    // Source returns full pages forever. With pageSize=10 and maxPages=3 we
+    // should bail after the third successful page (since the loop never
+    // sees a short page).
+    const rows = Array.from({ length: 1000 }, (_, i) => ({ id: i }))
+    const { buildQuery } = makeRowSource(rows)
+    await expect(
+      fetchAllPaginated<{ id: number }>(buildQuery, { pageSize: 10, maxPages: 3 }),
+    ).rejects.toThrow(/maxPages/)
+  })
+
+  it('rejects pageSize <= 0', async () => {
+    const { buildQuery } = makeRowSource<{ id: number }>([])
+    await expect(
+      fetchAllPaginated<{ id: number }>(buildQuery, { pageSize: 0 }),
+    ).rejects.toThrow(/pageSize/)
+  })
+
+  it('rejects maxPages <= 0', async () => {
+    const { buildQuery } = makeRowSource<{ id: number }>([])
+    await expect(
+      fetchAllPaginated<{ id: number }>(buildQuery, { maxPages: 0 }),
+    ).rejects.toThrow(/maxPages/)
+  })
+})

--- a/src/lib/dal/__tests__/posts.test.ts
+++ b/src/lib/dal/__tests__/posts.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports that use them
+// ---------------------------------------------------------------------------
+const mockSingle = vi.fn()
+const mockMaybeSingle = vi.fn()
+// `mockTerminal` resolves the chain when no `.single()` is called (await query).
+// vitest auto-resolves the chain via `then`.
+let mockChainResult: { data: any; error: any } = { data: null, error: null }
+
+const mockChain: Record<string, any> = {
+  select: vi.fn(function (this: any) { return mockChain }),
+  insert: vi.fn(function () { return mockChain }),
+  update: vi.fn(function () { return mockChain }),
+  delete: vi.fn(function () { return mockChain }),
+  eq: vi.fn(function () { return mockChain }),
+  neq: vi.fn(function () { return mockChain }),
+  in: vi.fn(function () { return mockChain }),
+  is: vi.fn(function () { return mockChain }),
+  not: vi.fn(function () { return mockChain }),
+  gte: vi.fn(function () { return mockChain }),
+  lte: vi.fn(function () { return mockChain }),
+  order: vi.fn(function () { return mockChain }),
+  limit: vi.fn(function () { return mockChain }),
+  range: vi.fn(function () {
+    return Promise.resolve(mockChainResult)
+  }),
+  single: mockSingle,
+  maybeSingle: mockMaybeSingle,
+  // thenable so `await query` resolves to mockChainResult
+  then: function (onFulfilled: any) {
+    return Promise.resolve(mockChainResult).then(onFulfilled)
+  },
+}
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => mockChain),
+  },
+}))
+
+vi.mock('@/lib/logger', () => {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    correlationId: 'test-id',
+  }
+  return { createLogger: vi.fn(() => log) }
+})
+
+// Import after mocks are set up
+import {
+  getExistingExternalIds,
+  listPostsByIssue,
+  listPostsForScoring,
+  listAssignedPostsForModule,
+  listExtractedPostsByIds,
+  listPendingExtractionPosts,
+  listPostsForExtractionByIssue,
+  getRatedPostIds,
+  insertPost,
+  updatePostExtraction,
+  assignPostsToIssue,
+  unassignPosts,
+  insertPostRating,
+} from '../posts'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockChainResult = { data: null, error: null }
+  // Reset chain returns
+  mockChain.select.mockReturnValue(mockChain)
+  mockChain.insert.mockReturnValue(mockChain)
+  mockChain.update.mockReturnValue(mockChain)
+  mockChain.delete.mockReturnValue(mockChain)
+  mockChain.eq.mockReturnValue(mockChain)
+  mockChain.neq.mockReturnValue(mockChain)
+  mockChain.in.mockReturnValue(mockChain)
+  mockChain.is.mockReturnValue(mockChain)
+  mockChain.not.mockReturnValue(mockChain)
+  mockChain.gte.mockReturnValue(mockChain)
+  mockChain.lte.mockReturnValue(mockChain)
+  mockChain.order.mockReturnValue(mockChain)
+  mockChain.limit.mockReturnValue(mockChain)
+})
+
+// ---------------------------------------------------------------------------
+describe('getExistingExternalIds', () => {
+  it('returns empty Set when input is empty', async () => {
+    const result = await getExistingExternalIds([], ['feed-1'])
+    expect(result.size).toBe(0)
+    const result2 = await getExistingExternalIds(['ext-1'], [])
+    expect(result2.size).toBe(0)
+  })
+
+  it('returns Set of external_ids that exist in DB', async () => {
+    // fetchAllPaginated calls .range(); short page (< pageSize) terminates loop
+    mockChainResult = {
+      data: [{ external_id: 'a' }, { external_id: 'b' }],
+      error: null,
+    }
+    const result = await getExistingExternalIds(['a', 'b', 'c'], ['feed-1'])
+    expect(result).toEqual(new Set(['a', 'b']))
+  })
+
+  it('returns empty Set on error', async () => {
+    mockChainResult = { data: null, error: { message: 'boom', code: 'XX' } }
+    const result = await getExistingExternalIds(['a'], ['feed-1'])
+    expect(result.size).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listPostsByIssue', () => {
+  it('returns posts on success', async () => {
+    mockChainResult = {
+      data: [{ id: 'p1' }, { id: 'p2' }],
+      error: null,
+    }
+    const posts = await listPostsByIssue('issue-1')
+    expect(posts).toHaveLength(2)
+    expect(mockChain.eq).toHaveBeenCalledWith('issue_id', 'issue-1')
+  })
+
+  it('returns empty array on error', async () => {
+    mockChainResult = { data: null, error: { message: 'fail' } }
+    const posts = await listPostsByIssue('issue-1')
+    expect(posts).toEqual([])
+  })
+
+  it('passes idsOnly column hint through', async () => {
+    mockChainResult = { data: [{ id: 'p1' }], error: null }
+    await listPostsByIssue('issue-1', { idsOnly: true })
+    expect(mockChain.select).toHaveBeenCalledWith('id')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listPostsForScoring', () => {
+  it('returns [] when feedIds is empty', async () => {
+    const result = await listPostsForScoring([])
+    expect(result).toEqual([])
+  })
+
+  it('applies unassignedOnly + sinceTimestamp + requireRating filters', async () => {
+    mockChainResult = { data: [{ id: 'p1' }], error: null }
+    await listPostsForScoring(['feed-1'], {
+      unassignedOnly: true,
+      sinceTimestamp: '2025-01-01T00:00:00Z',
+      requireRating: true,
+    })
+    expect(mockChain.in).toHaveBeenCalledWith('feed_id', ['feed-1'])
+    expect(mockChain.is).toHaveBeenCalledWith('issue_id', null)
+    expect(mockChain.gte).toHaveBeenCalledWith('processed_at', '2025-01-01T00:00:00Z')
+    expect(mockChain.not).toHaveBeenCalledWith('post_ratings', 'is', null)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listAssignedPostsForModule', () => {
+  it('returns [] for empty feedIds', async () => {
+    const result = await listAssignedPostsForModule('issue-1', 'mod-1', [])
+    expect(result).toEqual([])
+  })
+
+  it('filters by issue, module, and feeds', async () => {
+    mockChainResult = { data: [{ id: 'p1' }], error: null }
+    await listAssignedPostsForModule('issue-1', 'mod-1', ['feed-1'])
+    expect(mockChain.eq).toHaveBeenCalledWith('issue_id', 'issue-1')
+    expect(mockChain.eq).toHaveBeenCalledWith('article_module_id', 'mod-1')
+    expect(mockChain.in).toHaveBeenCalledWith('feed_id', ['feed-1'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listExtractedPostsByIds', () => {
+  it('returns [] when ids is empty', async () => {
+    const result = await listExtractedPostsByIds([])
+    expect(result).toEqual([])
+  })
+
+  it('filters to extracted posts with full text', async () => {
+    mockChainResult = { data: [{ id: 'p1' }], error: null }
+    await listExtractedPostsByIds(['p1', 'p2'])
+    expect(mockChain.in).toHaveBeenCalledWith('id', ['p1', 'p2'])
+    expect(mockChain.eq).toHaveBeenCalledWith('extraction_status', 'success')
+    expect(mockChain.not).toHaveBeenCalledWith('full_article_text', 'is', null)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listPendingExtractionPosts', () => {
+  it('applies limit and order', async () => {
+    mockChainResult = { data: [{ id: 'p1', source_url: 'http://x' }], error: null }
+    await listPendingExtractionPosts('feed-1', { limit: 5 })
+    expect(mockChain.eq).toHaveBeenCalledWith('feed_id', 'feed-1')
+    expect(mockChain.eq).toHaveBeenCalledWith('extraction_status', 'pending')
+    expect(mockChain.order).toHaveBeenCalledWith('processed_at', { ascending: true })
+    expect(mockChain.limit).toHaveBeenCalledWith(5)
+  })
+
+  it('applies excludeIds via .not("id", "in", ...) when ids are valid UUIDs', async () => {
+    mockChainResult = { data: [], error: null }
+    const id1 = '11111111-1111-1111-1111-111111111111'
+    const id2 = '22222222-2222-2222-2222-222222222222'
+    await listPendingExtractionPosts('feed-1', { excludeIds: [id1, id2] })
+    expect(mockChain.not).toHaveBeenCalledWith('id', 'in', `(${id1},${id2})`)
+  })
+
+  it('drops non-UUID excludeIds and continues without injection', async () => {
+    mockChainResult = { data: [], error: null }
+    await listPendingExtractionPosts('feed-1', { excludeIds: ["a)'; DROP TABLE rss_posts; --"] })
+    // All inputs were invalid UUIDs, so .not() should never be called
+    expect(mockChain.not).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listPostsForExtractionByIssue', () => {
+  it('returns posts needing extraction', async () => {
+    mockChainResult = {
+      data: [{ id: 'p1', source_url: 'x', title: 't', full_article_text: null, processed_at: 'd' }],
+      error: null,
+    }
+    const result = await listPostsForExtractionByIssue('issue-1')
+    expect(result).toHaveLength(1)
+    expect(mockChain.eq).toHaveBeenCalledWith('issue_id', 'issue-1')
+    expect(mockChain.not).toHaveBeenCalledWith('source_url', 'is', null)
+  })
+
+  it('honors sinceHours by passing a gte filter', async () => {
+    mockChainResult = { data: [], error: null }
+    await listPostsForExtractionByIssue('issue-1', { sinceHours: 24 })
+    expect(mockChain.gte).toHaveBeenCalledWith('processed_at', expect.any(String))
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('getRatedPostIds', () => {
+  it('returns empty set when input empty', async () => {
+    const result = await getRatedPostIds([])
+    expect(result.size).toBe(0)
+  })
+
+  it('returns Set of rated post_ids', async () => {
+    mockChainResult = {
+      data: [{ post_id: 'p1' }, { post_id: 'p2' }],
+      error: null,
+    }
+    const result = await getRatedPostIds(['p1', 'p2', 'p3'])
+    expect(result).toEqual(new Set(['p1', 'p2']))
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('insertPost', () => {
+  it('returns inserted row on success', async () => {
+    mockSingle.mockResolvedValueOnce({ data: { id: 'p1', source_url: 'x' }, error: null })
+    const result = await insertPost({ feed_id: 'f1', external_id: 'e1', title: 't' })
+    expect(result).toEqual({ id: 'p1', source_url: 'x' })
+  })
+
+  it('returns null on error', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: { message: 'fail' } })
+    const result = await insertPost({ feed_id: 'f1', external_id: 'e1', title: 't' })
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('updatePostExtraction', () => {
+  it('returns true on success', async () => {
+    mockChainResult = { data: null, error: null }
+    const ok = await updatePostExtraction('p1', { extractionStatus: 'success', fullArticleText: 'text' })
+    expect(ok).toBe(true)
+    expect(mockChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraction_status: 'success',
+        full_article_text: 'text',
+      })
+    )
+  })
+
+  it('clears extraction_error on success', async () => {
+    mockChainResult = { data: null, error: null }
+    await updatePostExtraction('p1', { extractionStatus: 'success' })
+    expect(mockChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ extraction_error: null })
+    )
+  })
+
+  it('returns false on error', async () => {
+    mockChainResult = { data: null, error: { message: 'fail' } }
+    const ok = await updatePostExtraction('p1', { extractionStatus: 'failed' })
+    expect(ok).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('assignPostsToIssue', () => {
+  it('returns true (no-op) for empty postIds', async () => {
+    const ok = await assignPostsToIssue([], 'issue-1')
+    expect(ok).toBe(true)
+  })
+
+  it('updates issue_id only when no moduleId given', async () => {
+    mockChainResult = { data: null, error: null }
+    await assignPostsToIssue(['p1', 'p2'], 'issue-1')
+    expect(mockChain.update).toHaveBeenCalledWith({ issue_id: 'issue-1' })
+    expect(mockChain.in).toHaveBeenCalledWith('id', ['p1', 'p2'])
+  })
+
+  it('also stamps article_module_id when given', async () => {
+    mockChainResult = { data: null, error: null }
+    await assignPostsToIssue(['p1'], 'issue-1', { moduleId: 'mod-1' })
+    expect(mockChain.update).toHaveBeenCalledWith({ issue_id: 'issue-1', article_module_id: 'mod-1' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('unassignPosts', () => {
+  it('returns true (no-op) for empty list', async () => {
+    const ok = await unassignPosts([])
+    expect(ok).toBe(true)
+  })
+
+  it('sets issue_id to null', async () => {
+    mockChainResult = { data: null, error: null }
+    await unassignPosts(['p1'])
+    expect(mockChain.update).toHaveBeenCalledWith({ issue_id: null })
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('insertPostRating', () => {
+  it('returns { ok: true } on success', async () => {
+    mockChainResult = { data: null, error: null }
+    const result = await insertPostRating({ post_id: 'p1' })
+    expect(result).toEqual({ ok: true })
+  })
+
+  it('returns { ok: false, errorMessage } on error', async () => {
+    mockChainResult = { data: null, error: { message: 'duplicate key' } }
+    const result = await insertPostRating({ post_id: 'p1' })
+    expect(result.ok).toBe(false)
+    expect(result.errorMessage).toBe('duplicate key')
+  })
+})

--- a/src/lib/dal/articles.ts
+++ b/src/lib/dal/articles.ts
@@ -1,0 +1,443 @@
+/**
+ * Data Access Layer — Articles Domain
+ *
+ * Centralizes queries against `module_articles` (per-issue generated articles)
+ * and `manual_articles` (per-publication authored articles).
+ *
+ * Conventions match `dal/issues.ts`:
+ *  - Reads return `T | null` for single, `T[]` for list, never throw.
+ *  - Writes return `boolean` (or the inserted row when callers need the id).
+ *  - Errors are logged with structured pino fields and swallowed.
+ *  - Multi-tenant isolation: module_articles is scoped via issue_id;
+ *    manual_articles is directly scoped via publication_id.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { createLogger } from '@/lib/logger'
+import type { ModuleArticle, ManualArticleStatus } from '@/types/database'
+
+const log = createLogger({ module: 'dal:articles' })
+
+// ==================== module_articles ====================
+
+export const MODULE_ARTICLE_COLUMNS = `
+  id, post_id, issue_id, article_module_id,
+  headline, content, rank, is_active, skipped,
+  fact_check_score, fact_check_details, word_count,
+  review_position, final_position,
+  ticker, member_name, transaction_type,
+  trade_image_url, trade_image_alt,
+  created_at, updated_at
+` as const
+
+export const MODULE_ARTICLE_BODY_GEN_SELECT = `
+  id, headline, content, post_id,
+  rss_posts(id, title, description, content, full_article_text, source_url, transaction_type)
+` as const
+
+export const MODULE_ARTICLE_FACT_CHECK_SELECT = `
+  id, content, fact_check_score,
+  rss_posts(id, content, description)
+` as const
+
+/**
+ * List module_articles for an issue. Use `idsOnly` for `{ id }`-only rows,
+ * `postIdsOnly` for `{ post_id }`-only rows, or default for the full shape.
+ */
+export async function listModuleArticlesByIssue(
+  issueId: string,
+  opts: { idsOnly: true; moduleId?: string; activeOnly?: boolean }
+): Promise<Array<{ id: string }>>
+export async function listModuleArticlesByIssue(
+  issueId: string,
+  opts: { postIdsOnly: true; moduleId?: string; activeOnly?: boolean }
+): Promise<Array<{ post_id: string | null }>>
+export async function listModuleArticlesByIssue(
+  issueId: string,
+  opts?: { moduleId?: string; activeOnly?: boolean; idsOnly?: false; postIdsOnly?: false }
+): Promise<ModuleArticle[]>
+export async function listModuleArticlesByIssue(
+  issueId: string,
+  opts: {
+    moduleId?: string
+    activeOnly?: boolean
+    idsOnly?: boolean
+    postIdsOnly?: boolean
+  } = {}
+): Promise<any[]> {
+  try {
+    let cols: string = MODULE_ARTICLE_COLUMNS
+    if (opts.idsOnly) cols = 'id'
+    else if (opts.postIdsOnly) cols = 'post_id'
+
+    let query = supabaseAdmin
+      .from('module_articles')
+      .select(cols)
+      .eq('issue_id', issueId)
+
+    if (opts.moduleId) query = query.eq('article_module_id', opts.moduleId)
+    if (opts.activeOnly) query = query.eq('is_active', true)
+
+    const { data, error } = await query
+
+    if (error) {
+      log.error({ err: error, issueId }, 'listModuleArticlesByIssue failed')
+      return []
+    }
+    return data || []
+  } catch (err) {
+    log.error({ err, issueId }, 'listModuleArticlesByIssue exception')
+    return []
+  }
+}
+
+/**
+ * Check whether a (post, issue, module) row already exists. Used to short-
+ * circuit re-generation of titles for the same post.
+ */
+export async function moduleArticleExists(
+  postId: string,
+  issueId: string,
+  moduleId: string
+): Promise<boolean> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('module_articles')
+      .select('id')
+      .eq('post_id', postId)
+      .eq('issue_id', issueId)
+      .eq('article_module_id', moduleId)
+      .maybeSingle()
+
+    if (error) {
+      log.error({ err: error, postId, issueId, moduleId }, 'moduleArticleExists failed')
+      return false
+    }
+    return !!data
+  } catch (err) {
+    log.error({ err, postId }, 'moduleArticleExists exception')
+    return false
+  }
+}
+
+/**
+ * List articles awaiting body generation for a (issue, module).
+ * Definition: `content === ''` AND `headline` IS NOT NULL, ordered by post_id
+ * for deterministic batching, capped by `limit`.
+ */
+export async function listArticlesNeedingBody(
+  issueId: string,
+  moduleId: string,
+  limit: number
+): Promise<any[]> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('module_articles')
+      .select(MODULE_ARTICLE_BODY_GEN_SELECT)
+      .eq('issue_id', issueId)
+      .eq('article_module_id', moduleId)
+      .eq('content', '')
+      .not('headline', 'is', null)
+      .order('post_id', { ascending: true })
+      .limit(limit)
+
+    if (error) {
+      log.error({ err: error, issueId, moduleId }, 'listArticlesNeedingBody failed')
+      return []
+    }
+    return data || []
+  } catch (err) {
+    log.error({ err, issueId, moduleId }, 'listArticlesNeedingBody exception')
+    return []
+  }
+}
+
+/**
+ * List articles awaiting fact-check for a (issue, module).
+ * Definition: content NOT empty AND fact_check_score IS NULL.
+ */
+export async function listArticlesNeedingFactCheck(
+  issueId: string,
+  moduleId: string
+): Promise<any[]> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('module_articles')
+      .select(MODULE_ARTICLE_FACT_CHECK_SELECT)
+      .eq('issue_id', issueId)
+      .eq('article_module_id', moduleId)
+      .neq('content', '')
+      .not('content', 'is', null)
+      .is('fact_check_score', null)
+
+    if (error) {
+      log.error({ err: error, issueId, moduleId }, 'listArticlesNeedingFactCheck failed')
+      return []
+    }
+    return data || []
+  } catch (err) {
+    log.error({ err, issueId, moduleId }, 'listArticlesNeedingFactCheck exception')
+    return []
+  }
+}
+
+export type NewModuleArticle = {
+  post_id: string
+  issue_id: string
+  article_module_id: string
+} & Record<string, any> // The ModuleArticle type in database.ts is missing
+  // some columns the table actually has (e.g., `member_name`); fixing the
+  // type is out of scope for this DAL.
+
+/**
+ * Insert a single module_article row. Duplicate-key (23505) is silently
+ * tolerated — preserves the existing pattern used by title generation.
+ */
+export async function insertModuleArticle(
+  article: NewModuleArticle
+): Promise<{ ok: boolean; duplicate: boolean }> {
+  try {
+    const { error } = await supabaseAdmin
+      .from('module_articles')
+      .insert([article])
+
+    if (error) {
+      if (error.code === '23505') return { ok: false, duplicate: true }
+      log.error({ err: error, postId: article.post_id }, 'insertModuleArticle failed')
+      return { ok: false, duplicate: false }
+    }
+    return { ok: true, duplicate: false }
+  } catch (err) {
+    log.error({ err, postId: article.post_id }, 'insertModuleArticle exception')
+    return { ok: false, duplicate: false }
+  }
+}
+
+/**
+ * Update body content + word count on a module_article.
+ */
+export async function updateModuleArticleContent(
+  id: string,
+  patch: { content: string; wordCount: number }
+): Promise<boolean> {
+  try {
+    const { error } = await supabaseAdmin
+      .from('module_articles')
+      .update({ content: patch.content, word_count: patch.wordCount })
+      .eq('id', id)
+
+    if (error) {
+      log.error({ err: error, articleId: id }, 'updateModuleArticleContent failed')
+      return false
+    }
+    return true
+  } catch (err) {
+    log.error({ err, articleId: id }, 'updateModuleArticleContent exception')
+    return false
+  }
+}
+
+/**
+ * Update fact-check fields on a module_article. Used both on success
+ * (numeric score + details) and failure (score=0 + error string).
+ */
+export async function updateModuleArticleFactCheck(
+  id: string,
+  patch: { score: number; details: string | null }
+): Promise<boolean> {
+  try {
+    const { error } = await supabaseAdmin
+      .from('module_articles')
+      .update({ fact_check_score: patch.score, fact_check_details: patch.details })
+      .eq('id', id)
+
+    if (error) {
+      log.error({ err: error, articleId: id }, 'updateModuleArticleFactCheck failed')
+      return false
+    }
+    return true
+  } catch (err) {
+    log.error({ err, articleId: id }, 'updateModuleArticleFactCheck exception')
+    return false
+  }
+}
+
+// ==================== manual_articles ====================
+//
+// Note: the `ManualArticle` type in src/types/database.ts is stale; the actual
+// table schema is { publication_id, title, slug, body, image_url, section_type,
+// category_id, publish_date, status }. Local types here reflect the real shape;
+// fixing database.ts is out of scope for step 2.
+
+export type ManualArticleRow = {
+  id: string
+  publication_id: string
+  title: string
+  slug: string
+  body: string
+  image_url: string | null
+  section_type: string
+  category_id: string | null
+  publish_date: string
+  status: ManualArticleStatus
+  created_at?: string
+  updated_at?: string
+}
+
+export const MANUAL_ARTICLE_COLUMNS = `
+  id, publication_id, title, slug, body, image_url, section_type,
+  category_id, publish_date, status, created_at, updated_at
+` as const
+
+export const MANUAL_ARTICLE_WITH_CATEGORY_SELECT = `
+  ${MANUAL_ARTICLE_COLUMNS},
+  category:article_categories(id, name, slug)
+` as const
+
+/**
+ * List manual articles for a publication, optionally filtered by status.
+ */
+export async function listManualArticlesByPublication(
+  publicationId: string,
+  opts: { status?: ManualArticleStatus | ManualArticleStatus[] } = {}
+): Promise<any[]> {
+  try {
+    let query = supabaseAdmin
+      .from('manual_articles')
+      .select(MANUAL_ARTICLE_WITH_CATEGORY_SELECT)
+      .eq('publication_id', publicationId)
+      .order('publish_date', { ascending: false })
+
+    if (opts.status) {
+      if (Array.isArray(opts.status)) query = query.in('status', opts.status)
+      else query = query.eq('status', opts.status)
+    }
+
+    const { data, error } = await query
+
+    if (error) {
+      log.error({ err: error, publicationId }, 'listManualArticlesByPublication failed')
+      return []
+    }
+    return data || []
+  } catch (err) {
+    log.error({ err, publicationId }, 'listManualArticlesByPublication exception')
+    return []
+  }
+}
+
+/**
+ * Resolve a slug for a publication, suffixing `-2`, `-3`, ... until a free
+ * slot is found. Single round-trip: fetch all slugs starting with the base
+ * via `LIKE 'baseSlug%'`, then scan in memory for the first free candidate.
+ */
+export async function findNextAvailableSlug(
+  baseSlug: string,
+  publicationId: string
+): Promise<string> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('manual_articles')
+      .select('slug')
+      .eq('publication_id', publicationId)
+      .like('slug', `${baseSlug}%`)
+
+    if (error) {
+      log.error({ err: error, baseSlug, publicationId }, 'findNextAvailableSlug query failed')
+      return baseSlug
+    }
+
+    const taken = new Set((data || []).map(r => r.slug))
+    if (!taken.has(baseSlug)) return baseSlug
+
+    // Walk -2, -3, ... until we find a free slot. Bounded by `taken.size + 1`
+    // — at most one more than the number of rows fetched.
+    for (let counter = 2; counter <= taken.size + 1; counter += 1) {
+      const candidate = `${baseSlug}-${counter}`
+      if (!taken.has(candidate)) return candidate
+    }
+    // Unreachable in practice, but a defensive fallback.
+    return `${baseSlug}-${taken.size + 1}`
+  } catch (err) {
+    log.error({ err, baseSlug }, 'findNextAvailableSlug exception')
+    return baseSlug
+  }
+}
+
+export type NewManualArticle = Omit<ManualArticleRow, 'id' | 'created_at' | 'updated_at'>
+
+/**
+ * Insert a manual article. Returns the inserted row (with category join) or
+ * null on failure.
+ */
+export async function insertManualArticle(
+  article: NewManualArticle
+): Promise<ManualArticleRow | null> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('manual_articles')
+      .insert([article])
+      .select(MANUAL_ARTICLE_WITH_CATEGORY_SELECT)
+      .single()
+
+    if (error || !data) {
+      log.error({ err: error, publicationId: article.publication_id }, 'insertManualArticle failed')
+      return null
+    }
+    return data as any
+  } catch (err) {
+    log.error({ err, publicationId: article.publication_id }, 'insertManualArticle exception')
+    return null
+  }
+}
+
+/**
+ * Update a manual article. Requires `publicationId` for tenant isolation.
+ */
+export async function updateManualArticle(
+  id: string,
+  publicationId: string,
+  patch: Partial<Omit<ManualArticleRow, 'id' | 'publication_id' | 'created_at'>>
+): Promise<boolean> {
+  try {
+    const { error } = await supabaseAdmin
+      .from('manual_articles')
+      .update(patch)
+      .eq('id', id)
+      .eq('publication_id', publicationId)
+
+    if (error) {
+      log.error({ err: error, id, publicationId }, 'updateManualArticle failed')
+      return false
+    }
+    return true
+  } catch (err) {
+    log.error({ err, id }, 'updateManualArticle exception')
+    return false
+  }
+}
+
+/**
+ * Delete a manual article. Requires `publicationId` for tenant isolation.
+ */
+export async function deleteManualArticle(
+  id: string,
+  publicationId: string
+): Promise<boolean> {
+  try {
+    const { error } = await supabaseAdmin
+      .from('manual_articles')
+      .delete()
+      .eq('id', id)
+      .eq('publication_id', publicationId)
+
+    if (error) {
+      log.error({ err: error, id, publicationId }, 'deleteManualArticle failed')
+      return false
+    }
+    return true
+  } catch (err) {
+    log.error({ err, id }, 'deleteManualArticle exception')
+    return false
+  }
+}

--- a/src/lib/dal/dedup.ts
+++ b/src/lib/dal/dedup.ts
@@ -1,0 +1,250 @@
+/**
+ * Data Access Layer — Deduplication Domain
+ *
+ * Centralizes queries against `duplicate_groups` and `duplicate_posts`. The
+ * `storeDeduplicationResult` composite helper writes both tables in sequence;
+ * Supabase JS does not expose transactions, so the two writes are NOT atomic.
+ * If a process dies between them an issue will have a duplicate group with no
+ * duplicate posts attached. This matches the existing inline behavior; making
+ * it atomic requires a Postgres RPC. Tracked as a follow-up.
+ *
+ * Conventions match `dal/issues.ts`:
+ *  - Reads return `T | null` for single, `T[]` for list, never throw.
+ *  - Writes return `boolean` (or the inserted row when callers need the id).
+ *  - Errors are logged with structured pino fields and swallowed.
+ *  - Multi-tenant isolation: dedup tables are scoped via issue_id.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { createLogger } from '@/lib/logger'
+import type { DuplicateGroup, DuplicatePost } from '@/types/database'
+
+const log = createLogger({ module: 'dal:dedup' })
+
+// ==================== READ OPERATIONS ====================
+
+/**
+ * Cheap guard: does this issue already have any duplicate groups recorded?
+ */
+export async function isIssueDeduplicated(issueId: string): Promise<boolean> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('duplicate_groups')
+      .select('id')
+      .eq('issue_id', issueId)
+      .limit(1)
+      .maybeSingle()
+
+    if (error && error.code !== 'PGRST116') {
+      log.error({ err: error, issueId }, 'isIssueDeduplicated failed')
+      return false
+    }
+    return !!data
+  } catch (err) {
+    log.error({ err, issueId }, 'isIssueDeduplicated exception')
+    return false
+  }
+}
+
+/**
+ * Return just the group IDs for an issue. Callers join to `duplicate_posts`
+ * separately via `listDuplicatePostIdsByGroups`.
+ */
+export async function listDuplicateGroupIdsByIssue(issueId: string): Promise<string[]> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('duplicate_groups')
+      .select('id')
+      .eq('issue_id', issueId)
+
+    if (error) {
+      log.error({ err: error, issueId }, 'listDuplicateGroupIdsByIssue failed')
+      return []
+    }
+    return (data || []).map(g => g.id)
+  } catch (err) {
+    log.error({ err, issueId }, 'listDuplicateGroupIdsByIssue exception')
+    return []
+  }
+}
+
+/**
+ * Return the post IDs marked as duplicates within a set of groups.
+ * Useful when filtering candidate posts for article generation.
+ */
+export async function listDuplicatePostIdsByGroups(groupIds: string[]): Promise<Set<string>> {
+  if (groupIds.length === 0) return new Set()
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('duplicate_posts')
+      .select('post_id')
+      .in('group_id', groupIds)
+
+    if (error) {
+      log.error({ err: error, count: groupIds.length }, 'listDuplicatePostIdsByGroups failed')
+      return new Set()
+    }
+    return new Set((data || []).map(d => d.post_id))
+  } catch (err) {
+    log.error({ err }, 'listDuplicatePostIdsByGroups exception')
+    return new Set()
+  }
+}
+
+/**
+ * Return full duplicate-post rows for a single group (dashboard inspection).
+ */
+export async function listDuplicatePostsForGroup(groupId: string): Promise<DuplicatePost[]> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('duplicate_posts')
+      .select('id, group_id, post_id, similarity_score, detection_method, actual_similarity_score')
+      .eq('group_id', groupId)
+
+    if (error) {
+      log.error({ err: error, groupId }, 'listDuplicatePostsForGroup failed')
+      return []
+    }
+    return (data || []) as DuplicatePost[]
+  } catch (err) {
+    log.error({ err, groupId }, 'listDuplicatePostsForGroup exception')
+    return []
+  }
+}
+
+// ==================== WRITE OPERATIONS ====================
+
+/**
+ * Create a duplicate group. Returns the inserted row (with id) or null.
+ */
+export async function createDuplicateGroup(input: {
+  issueId: string
+  primaryPostId: string
+  topicSignature: string | null
+}): Promise<DuplicateGroup | null> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('duplicate_groups')
+      .insert([
+        {
+          issue_id: input.issueId,
+          primary_post_id: input.primaryPostId,
+          topic_signature: input.topicSignature,
+        },
+      ])
+      .select('id, issue_id, primary_post_id, topic_signature, created_at')
+      .single()
+
+    if (error || !data) {
+      log.error({ err: error, issueId: input.issueId }, 'createDuplicateGroup failed')
+      return null
+    }
+    return data as DuplicateGroup
+  } catch (err) {
+    log.error({ err, issueId: input.issueId }, 'createDuplicateGroup exception')
+    return null
+  }
+}
+
+export type NewDuplicatePost = {
+  postId: string
+  similarityScore: number
+  // Mirrors `DuplicatePost.detection_method` in database.ts plus
+  // `'ai_cross_section'` which the Deduplicator currently emits but the
+  // database type omits. String fallback covers both shipping callers.
+  detectionMethod?: string
+}
+
+/**
+ * Add a single duplicate-post row to an existing group.
+ */
+export async function addDuplicatePostToGroup(
+  groupId: string,
+  post: NewDuplicatePost
+): Promise<boolean> {
+  try {
+    const { error } = await supabaseAdmin
+      .from('duplicate_posts')
+      .insert([
+        {
+          group_id: groupId,
+          post_id: post.postId,
+          similarity_score: post.similarityScore,
+          detection_method: post.detectionMethod ?? null,
+          actual_similarity_score: post.similarityScore,
+        },
+      ])
+
+    if (error) {
+      log.error({ err: error, groupId, postId: post.postId }, 'addDuplicatePostToGroup failed')
+      return false
+    }
+    return true
+  } catch (err) {
+    log.error({ err, groupId, postId: post.postId }, 'addDuplicatePostToGroup exception')
+    return false
+  }
+}
+
+export interface DeduplicationResultInput {
+  issueId: string
+  primaryPostId: string
+  topicSignature: string | null
+  duplicates: NewDuplicatePost[]
+}
+
+export interface DeduplicationResultOutput {
+  group: DuplicateGroup | null
+  storedDuplicates: number
+}
+
+/**
+ * Composite write: create the group then bulk-insert all duplicate posts in a
+ * single round-trip. NOT atomic across the two tables — see file-header
+ * comment. Returns the group plus the count of inserted duplicate-post rows
+ * (0 on bulk-insert failure; the group still exists in that case).
+ */
+export async function storeDeduplicationResult(
+  input: DeduplicationResultInput
+): Promise<DeduplicationResultOutput> {
+  const group = await createDuplicateGroup({
+    issueId: input.issueId,
+    primaryPostId: input.primaryPostId,
+    topicSignature: input.topicSignature,
+  })
+
+  if (!group) {
+    return { group: null, storedDuplicates: 0 }
+  }
+
+  if (input.duplicates.length === 0) {
+    return { group, storedDuplicates: 0 }
+  }
+
+  try {
+    const rows = input.duplicates.map(dup => ({
+      group_id: group.id,
+      post_id: dup.postId,
+      similarity_score: dup.similarityScore,
+      detection_method: dup.detectionMethod ?? null,
+      actual_similarity_score: dup.similarityScore,
+    }))
+
+    const { error } = await supabaseAdmin
+      .from('duplicate_posts')
+      .insert(rows)
+
+    if (error) {
+      log.error(
+        { err: error, groupId: group.id, count: rows.length },
+        'storeDeduplicationResult bulk insert failed'
+      )
+      return { group, storedDuplicates: 0 }
+    }
+
+    return { group, storedDuplicates: rows.length }
+  } catch (err) {
+    log.error({ err, groupId: group.id }, 'storeDeduplicationResult exception')
+    return { group, storedDuplicates: 0 }
+  }
+}

--- a/src/lib/dal/paginate.ts
+++ b/src/lib/dal/paginate.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared Supabase pagination wrapper.
+ *
+ * Supabase silently truncates `.select()` at 1000 rows per request. This
+ * helper transparently pages past that limit by re-issuing the query with
+ * advancing `.range()` windows until a short page is returned.
+ *
+ * Pass a builder function — NOT a built query — because Supabase's fluent
+ * builders are mutable and cannot be reused across awaited calls.
+ */
+
+import type { PostgrestError } from '@supabase/supabase-js'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger({ module: 'dal:paginate' })
+
+const DEFAULT_PAGE_SIZE = 1000
+
+// Minimal shape we need from a Postgrest filter builder. Avoids tight
+// coupling to a specific @supabase/postgrest-js generic signature, which
+// changes across versions. The real builder returns this shape from .range().
+type AwaitableQuery<T> = PromiseLike<{ data: T[] | null; error: PostgrestError | null }>
+type RangeableQuery<T> = {
+  range: (from: number, to: number) => AwaitableQuery<T>
+}
+
+export interface FetchAllPaginatedOptions {
+  /** Rows per page. Default 1000 (Supabase's hard cap per request). */
+  pageSize?: number
+  /** Safety cap on number of pages. Throws if exceeded. Default 1000 (1M rows). */
+  maxPages?: number
+  /** Optional context tag for the log line. */
+  label?: string
+}
+
+/**
+ * Fetch every row from a Supabase query, paging past the 1000-row default.
+ *
+ * The builder MUST NOT call `.range()` or `.limit()` — this helper owns those.
+ * Errors propagate via `throw` so callers' try/catch can surface them.
+ *
+ * @example
+ *   const rows = await fetchAllPaginated<{ id: string }>(() =>
+ *     supabaseAdmin
+ *       .from('sparkloop_referrals')
+ *       .select('id')
+ *       .eq('publication_id', pubId),
+ *   )
+ */
+export async function fetchAllPaginated<T>(
+  buildQuery: () => RangeableQuery<T>,
+  options: FetchAllPaginatedOptions = {},
+): Promise<T[]> {
+  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE
+  const maxPages = options.maxPages ?? 1000
+  const startedAt = Date.now()
+
+  if (pageSize <= 0) throw new Error('fetchAllPaginated: pageSize must be > 0')
+  if (maxPages <= 0) throw new Error('fetchAllPaginated: maxPages must be > 0')
+
+  const all: T[] = []
+  let offset = 0
+  let page = 0
+
+  while (true) {
+    if (page >= maxPages) {
+      throw new Error(
+        `fetchAllPaginated: maxPages (${maxPages}) exceeded — query returned more than ${maxPages * pageSize} rows`,
+      )
+    }
+
+    const { data, error } = await buildQuery().range(offset, offset + pageSize - 1)
+
+    if (error) {
+      log.error({ err: error, label: options.label, page, offset }, 'fetchAllPaginated query failed')
+      throw error
+    }
+
+    const rows = data ?? []
+    all.push(...rows)
+    page += 1
+
+    if (rows.length < pageSize) break
+    offset += pageSize
+  }
+
+  log.info(
+    {
+      label: options.label,
+      pages: page,
+      rows: all.length,
+      durationMs: Date.now() - startedAt,
+    },
+    'fetchAllPaginated complete',
+  )
+
+  return all
+}

--- a/src/lib/dal/posts.ts
+++ b/src/lib/dal/posts.ts
@@ -1,0 +1,493 @@
+/**
+ * Data Access Layer — Posts Domain
+ *
+ * Centralizes queries against `rss_posts` and `post_ratings`. `post_ratings`
+ * is only ever joined (never directly read), so insert helpers live here too.
+ *
+ * Conventions match `dal/issues.ts`:
+ *  - Reads return `T | null` for single, `T[]` for list, never throw.
+ *  - Writes return `boolean` (or the inserted row when callers need the id).
+ *  - Errors are logged with structured pino fields and swallowed.
+ *  - Multi-tenant isolation: rss_posts is publication-scoped via feed_id.
+ *    Callers pass feed-id arrays they already filtered by publication.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { createLogger } from '@/lib/logger'
+import { fetchAllPaginated } from '@/lib/dal/paginate'
+import type { RssPost, PostRating, ExtractionStatus } from '@/types/database'
+
+const log = createLogger({ module: 'dal:posts' })
+
+// Column sets. Internal shapes stay private to the DAL; only the brief
+// rating-join shape is exported because external scoring callers select it.
+const POST_COLUMNS_FULL = `
+  id, feed_id, issue_id, article_module_id, external_id,
+  title, description, content, full_article_text,
+  author, publication_date, source_url, image_url, image_alt,
+  processed_at, extraction_status, extraction_error,
+  ticker, member_name, transaction_type
+` as const
+
+const POST_FOR_SCORING_COLUMNS = `
+  id, title, description, content, source_url, full_article_text,
+  article_module_id, feed_id, ticker, transaction_type
+` as const
+
+const POST_FOR_TITLE_GEN_COLUMNS = `
+  id, title, description, content, full_article_text,
+  source_url, image_url, image_alt, feed_id, issue_id,
+  article_module_id, ticker, member_name, transaction_type,
+  post_ratings(total_score, criteria_1_score, criteria_2_score, criteria_3_score, criteria_4_score, criteria_5_score)
+` as const
+
+export const POST_WITH_RATINGS_BRIEF = `
+  id, ticker,
+  post_ratings(total_score, criteria_1_score, criteria_2_score, criteria_3_score, criteria_4_score, criteria_5_score)
+` as const
+
+
+// ==================== READ OPERATIONS ====================
+
+/**
+ * Look up the IDs that already exist for a given (external_id, feed_id) pair.
+ * Returns a Set for fast `.has()` checks during ingestion.
+ */
+export async function getExistingExternalIds(
+  externalIds: string[],
+  feedIds: string[]
+): Promise<Set<string>> {
+  if (externalIds.length === 0 || feedIds.length === 0) return new Set()
+  try {
+    const rows = await fetchAllPaginated<{ external_id: string }>(
+      () =>
+        supabaseAdmin
+          .from('rss_posts')
+          .select('external_id')
+          .in('external_id', externalIds)
+          .in('feed_id', feedIds),
+      { label: 'dal:posts:getExistingExternalIds' }
+    )
+    return new Set(rows.map(r => r.external_id))
+  } catch (err) {
+    log.error({ err, externalIds: externalIds.length, feedIds: feedIds.length }, 'getExistingExternalIds failed')
+    return new Set()
+  }
+}
+
+/**
+ * List posts assigned to an issue. Returns full rows by default; pass
+ * `{ idsOnly: true }` for the lighter id-only shape used by unassignment.
+ *
+ * Overloads keep the return type honest so callers don't need to cast.
+ */
+export async function listPostsByIssue(
+  issueId: string,
+  opts: { idsOnly: true }
+): Promise<Array<Pick<RssPost, 'id'>>>
+export async function listPostsByIssue(
+  issueId: string,
+  opts?: { idsOnly?: false }
+): Promise<RssPost[]>
+export async function listPostsByIssue(
+  issueId: string,
+  opts: { idsOnly?: boolean } = {}
+): Promise<Array<Pick<RssPost, 'id'>> | RssPost[]> {
+  try {
+    const cols = opts.idsOnly ? 'id' : POST_COLUMNS_FULL
+    const { data, error } = await supabaseAdmin
+      .from('rss_posts')
+      .select(cols)
+      .eq('issue_id', issueId)
+
+    if (error) {
+      log.error({ err: error, issueId }, 'listPostsByIssue failed')
+      return []
+    }
+    return (data || []) as any
+  } catch (err) {
+    log.error({ err, issueId }, 'listPostsByIssue exception')
+    return []
+  }
+}
+
+/**
+ * List posts in a feed-set with their ratings. Used by both module-level
+ * scoring queries and the issue-level "top posts from pool" assignment.
+ */
+export async function listPostsForScoring(
+  feedIds: string[],
+  opts: {
+    unassignedOnly?: boolean
+    sinceTimestamp?: string
+    requireRating?: boolean
+    columns?: string
+  } = {}
+): Promise<any[]> {
+  if (feedIds.length === 0) return []
+  try {
+    let query = supabaseAdmin
+      .from('rss_posts')
+      .select(opts.columns ?? POST_WITH_RATINGS_BRIEF)
+      .in('feed_id', feedIds)
+
+    if (opts.unassignedOnly) query = query.is('issue_id', null)
+    if (opts.sinceTimestamp) query = query.gte('processed_at', opts.sinceTimestamp)
+    if (opts.requireRating) query = query.not('post_ratings', 'is', null)
+
+    const { data, error } = await query
+
+    if (error) {
+      log.error({ err: error, feedIds: feedIds.length }, 'listPostsForScoring failed')
+      return []
+    }
+    return data || []
+  } catch (err) {
+    log.error({ err, feedIds: feedIds.length }, 'listPostsForScoring exception')
+    return []
+  }
+}
+
+/**
+ * List posts already assigned to a (issue, module) for title generation.
+ * Includes the joined post_ratings shape needed by the generator.
+ */
+export async function listAssignedPostsForModule(
+  issueId: string,
+  moduleId: string,
+  feedIds: string[]
+): Promise<any[]> {
+  if (feedIds.length === 0) return []
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('rss_posts')
+      .select(POST_FOR_TITLE_GEN_COLUMNS)
+      .eq('issue_id', issueId)
+      .eq('article_module_id', moduleId)
+      .in('feed_id', feedIds)
+
+    if (error) {
+      log.error({ err: error, issueId, moduleId }, 'listAssignedPostsForModule failed')
+      return []
+    }
+    return data || []
+  } catch (err) {
+    log.error({ err, issueId, moduleId }, 'listAssignedPostsForModule exception')
+    return []
+  }
+}
+
+/**
+ * Fetch posts by id where extraction succeeded. Used during scoring when
+ * we want to skip posts whose extraction failed or is still pending.
+ */
+export async function listExtractedPostsByIds(
+  postIds: string[]
+): Promise<any[]> {
+  if (postIds.length === 0) return []
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('rss_posts')
+      .select(POST_FOR_SCORING_COLUMNS)
+      .in('id', postIds)
+      .eq('extraction_status', 'success')
+      .not('full_article_text', 'is', null)
+
+    if (error) {
+      log.error({ err: error, count: postIds.length }, 'listExtractedPostsByIds failed')
+      return []
+    }
+    return data || []
+  } catch (err) {
+    log.error({ err, count: postIds.length }, 'listExtractedPostsByIds exception')
+    return []
+  }
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Catch-up queue: oldest pending-extraction posts in a feed, optionally
+ * excluding a set of ids that we've just processed in this same run.
+ *
+ * `excludeIds` is interpolated directly into a Postgrest IN clause for
+ * `.not('id', 'in', ...)`. Non-UUID values are filtered out and logged as
+ * a structural guard against accidental injection.
+ */
+export async function listPendingExtractionPosts(
+  feedId: string,
+  opts: { limit?: number; excludeIds?: string[] } = {}
+): Promise<Array<{ id: string; source_url: string | null }>> {
+  try {
+    let query = supabaseAdmin
+      .from('rss_posts')
+      .select('id, source_url')
+      .eq('feed_id', feedId)
+      .eq('extraction_status', 'pending')
+
+    if (opts.excludeIds && opts.excludeIds.length > 0) {
+      const safe = opts.excludeIds.filter(id => UUID_RE.test(id))
+      if (safe.length !== opts.excludeIds.length) {
+        log.error(
+          { feedId, dropped: opts.excludeIds.length - safe.length },
+          'listPendingExtractionPosts: non-UUID excludeIds filtered out',
+        )
+      }
+      if (safe.length > 0) {
+        query = query.not('id', 'in', `(${safe.join(',')})`)
+      }
+    }
+
+    const { data, error } = await query
+      .order('processed_at', { ascending: true })
+      .limit(opts.limit ?? 20)
+
+    if (error) {
+      log.error({ err: error, feedId }, 'listPendingExtractionPosts failed')
+      return []
+    }
+    return data || []
+  } catch (err) {
+    log.error({ err, feedId }, 'listPendingExtractionPosts exception')
+    return []
+  }
+}
+
+/**
+ * List posts on an issue that need full-text extraction. Optional `sinceHours`
+ * restricts to recently processed posts (used for fast warm-cache enrichment).
+ */
+export async function listPostsForExtractionByIssue(
+  issueId: string,
+  opts: { sinceHours?: number } = {}
+): Promise<Array<Pick<RssPost, 'id' | 'source_url' | 'title' | 'full_article_text' | 'processed_at'>>> {
+  try {
+    let query = supabaseAdmin
+      .from('rss_posts')
+      .select('id, source_url, title, full_article_text, processed_at')
+      .eq('issue_id', issueId)
+      .not('source_url', 'is', null)
+
+    if (opts.sinceHours !== undefined) {
+      const since = new Date(Date.now() - opts.sinceHours * 60 * 60 * 1000).toISOString()
+      query = query.gte('processed_at', since)
+    }
+
+    const { data, error } = await query
+
+    if (error) {
+      log.error({ err: error, issueId }, 'listPostsForExtractionByIssue failed')
+      return []
+    }
+    return (data || []) as any
+  } catch (err) {
+    log.error({ err, issueId }, 'listPostsForExtractionByIssue exception')
+    return []
+  }
+}
+
+/**
+ * Filter a set of post ids down to those that already have a post_ratings row.
+ * Used for catch-up scoring to avoid double-rating.
+ */
+export async function getRatedPostIds(postIds: string[]): Promise<Set<string>> {
+  if (postIds.length === 0) return new Set()
+  try {
+    const rows = await fetchAllPaginated<{ post_id: string }>(
+      () =>
+        supabaseAdmin
+          .from('post_ratings')
+          .select('post_id')
+          .in('post_id', postIds),
+      { label: 'dal:posts:getRatedPostIds' }
+    )
+    return new Set(rows.map(r => r.post_id))
+  } catch (err) {
+    log.error({ err, count: postIds.length }, 'getRatedPostIds failed')
+    return new Set()
+  }
+}
+
+// ==================== WRITE OPERATIONS ====================
+
+/**
+ * Insert a single new RSS post. Returns the inserted id + source_url, the
+ * shape feed-ingestion needs to seed full-text extraction. The type is
+ * intentionally loose (extra columns like `ticker`, `member_name`,
+ * `transaction_type` exist on the table but aren't in the stale `RssPost`
+ * interface; fixing database.ts is out of scope for this DAL).
+ */
+export async function insertPost(
+  post: { feed_id: string; external_id: string; title: string } & Record<string, any>
+): Promise<{ id: string; source_url: string | null } | null> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('rss_posts')
+      .insert([post])
+      .select('id, source_url')
+      .single()
+
+    if (error || !data) {
+      log.error({ err: error, feedId: post.feed_id, externalId: post.external_id }, 'insertPost failed')
+      return null
+    }
+    return data
+  } catch (err) {
+    log.error({ err, feedId: post.feed_id }, 'insertPost exception')
+    return null
+  }
+}
+
+/**
+ * Update extraction status + (optionally) full text on a single post.
+ *
+ * On a `success` status the function ALWAYS clears `extraction_error`,
+ * regardless of what the caller passes. This prevents stale error text
+ * lingering on rows that subsequently extract successfully.
+ */
+export async function updatePostExtraction(
+  postId: string,
+  patch: {
+    fullArticleText?: string
+    extractionStatus: ExtractionStatus
+    extractionError?: string | null
+  }
+): Promise<boolean> {
+  try {
+    const updateData: Record<string, any> = {
+      extraction_status: patch.extractionStatus,
+    }
+    if (patch.fullArticleText !== undefined) updateData.full_article_text = patch.fullArticleText
+    if (patch.extractionStatus === 'success') {
+      updateData.extraction_error = null
+    } else if (patch.extractionError !== undefined) {
+      updateData.extraction_error = patch.extractionError
+    }
+
+    const { error } = await supabaseAdmin
+      .from('rss_posts')
+      .update(updateData)
+      .eq('id', postId)
+
+    if (error) {
+      log.error({ err: error, postId }, 'updatePostExtraction failed')
+      return false
+    }
+    return true
+  } catch (err) {
+    log.error({ err, postId }, 'updatePostExtraction exception')
+    return false
+  }
+}
+
+/**
+ * Bulk-assign posts to an issue. Optionally also stamp `article_module_id`.
+ */
+export async function assignPostsToIssue(
+  postIds: string[],
+  issueId: string,
+  opts: { moduleId?: string } = {}
+): Promise<boolean> {
+  if (postIds.length === 0) return true
+  try {
+    const updateData: Record<string, any> = { issue_id: issueId }
+    if (opts.moduleId) updateData.article_module_id = opts.moduleId
+
+    const { error } = await supabaseAdmin
+      .from('rss_posts')
+      .update(updateData)
+      .in('id', postIds)
+
+    if (error) {
+      log.error({ err: error, issueId, count: postIds.length }, 'assignPostsToIssue failed')
+      return false
+    }
+    return true
+  } catch (err) {
+    log.error({ err, issueId }, 'assignPostsToIssue exception')
+    return false
+  }
+}
+
+/**
+ * Bulk-unassign a set of posts back to the pool (issue_id = null).
+ * Used by Stage 1 unassignment after generation drops some posts.
+ */
+export async function unassignPosts(postIds: string[]): Promise<boolean> {
+  if (postIds.length === 0) return true
+  try {
+    const { error } = await supabaseAdmin
+      .from('rss_posts')
+      .update({ issue_id: null })
+      .in('id', postIds)
+
+    if (error) {
+      log.error({ err: error, count: postIds.length }, 'unassignPosts failed')
+      return false
+    }
+    return true
+  } catch (err) {
+    log.error({ err }, 'unassignPosts exception')
+    return false
+  }
+}
+
+/**
+ * Common pattern at every extraction site: a `result` object from the
+ * extractor reports either `{ success: true, fullText }` or a failure with
+ * `status` + `error`. This helper handles both branches and returns enough
+ * information for the caller to drive its own counters.
+ *
+ * Returns `{ updated, status }` — `status` is `'skipped'` when result is
+ * undefined (no extraction attempted for this URL), otherwise the status
+ * that was written to the DB.
+ */
+export async function applyExtractionResult(
+  postId: string,
+  result: { success: boolean; fullText?: string; status?: ExtractionStatus; error?: string } | undefined
+): Promise<{ updated: boolean; status: ExtractionStatus }> {
+  if (!result) return { updated: false, status: 'skipped' }
+
+  if (result.success && result.fullText) {
+    const ok = await updatePostExtraction(postId, {
+      fullArticleText: result.fullText,
+      extractionStatus: 'success',
+    })
+    return { updated: ok, status: 'success' }
+  }
+
+  const status = result.status || 'failed'
+  const ok = await updatePostExtraction(postId, {
+    extractionStatus: status,
+    extractionError: result.error?.substring(0, 500) || null,
+  })
+  return { updated: ok, status }
+}
+
+/**
+ * Insert a post_ratings row. The table is insert-only; updates use the
+ * scoring re-run pattern (insert a new rating row).
+ *
+ * Returns the Postgrest error message on failure so the caller can include
+ * it in any thrown exception (the structured pino log captures the full
+ * error object; this lets callers surface useful context in stack traces).
+ */
+export async function insertPostRating(
+  rating: Partial<PostRating> & { post_id: string }
+): Promise<{ ok: boolean; errorMessage?: string }> {
+  try {
+    const { error } = await supabaseAdmin
+      .from('post_ratings')
+      .insert([rating])
+
+    if (error) {
+      log.error({ err: error, postId: rating.post_id }, 'insertPostRating failed')
+      return { ok: false, errorMessage: error.message }
+    }
+    return { ok: true }
+  } catch (err) {
+    log.error({ err, postId: rating.post_id }, 'insertPostRating exception')
+    const message = err instanceof Error ? err.message : 'unknown error'
+    return { ok: false, errorMessage: message }
+  }
+}

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -96,3 +96,17 @@ export function getDaysAgoStr(days: number, tz: SupportedTz): string {
   }
   return tzDateFormatter.format(shifted)
 }
+
+/**
+ * Get tomorrow's date string in the given timezone. DST-safe: derives "today"
+ * via the timezone-aware path so the returned date is calendar-tomorrow in
+ * that zone, not "now + 24h" (which is wrong on spring-forward days).
+ */
+export function getTomorrowStr(tz: SupportedTz): string {
+  const todayStr = getTodayStr(tz)
+  const [y, m, d] = todayStr.split('-').map(Number)
+  // Construct UTC noon to avoid DST/midnight edge cases, advance one day,
+  // then format back to YYYY-MM-DD using local date parts.
+  const tomorrow = new Date(Date.UTC(y, m - 1, d + 1, 12, 0, 0))
+  return `${tomorrow.getUTCFullYear()}-${String(tomorrow.getUTCMonth() + 1).padStart(2, '0')}-${String(tomorrow.getUTCDate()).padStart(2, '0')}`
+}

--- a/src/lib/mailerlite/mailerlite-service.ts
+++ b/src/lib/mailerlite/mailerlite-service.ts
@@ -6,6 +6,7 @@ import { generateFullNewsletterHtml } from '../newsletter-templates'
 import { getEmailSettings, getScheduleSettings, getPublicationSetting, getPublicationSettings } from '../publication-settings'
 import { getEnvironment, isProduction } from '../env-guard'
 import { isCircuitOpen, recordRateLimitHit } from '../remediation/circuit-breaker'
+import { getTodayStr } from '../date-utils'
 
 const MAILERLITE_API_BASE = 'https://connect.mailerlite.com/api'
 
@@ -233,9 +234,7 @@ United States
         try {
           // Schedule review for TODAY at scheduled send time
           // issue is created at issue Creation Time (8:50pm) and scheduled to send same day at Scheduled Send Time
-          const nowCentral = new Date().toLocaleString("en-US", {timeZone: "America/Chicago"})
-          const centralDate = new Date(nowCentral)
-          const today = `${centralDate.getFullYear()}-${String(centralDate.getMonth() + 1).padStart(2, '0')}-${String(centralDate.getDate()).padStart(2, '0')}`
+          const today = getTodayStr('CST')
           scheduleData = await this.getReviewScheduleData(today, issue.publication_id)
           console.log('Scheduling review issue for today with data:', scheduleData)
 
@@ -780,9 +779,7 @@ United States
         // Schedule the final issue for TODAY at scheduled send time
         // issue is created at issue Creation Time and scheduled to send same day at Scheduled Send Time
         try {
-          const nowCentral = new Date().toLocaleString("en-US", {timeZone: "America/Chicago"})
-          const centralDate = new Date(nowCentral)
-          const today = `${centralDate.getFullYear()}-${String(centralDate.getMonth() + 1).padStart(2, '0')}-${String(centralDate.getDate()).padStart(2, '0')}`
+          const today = getTodayStr('CST')
           const finalScheduleData = isSecondary
             ? await this.getSecondaryScheduleData(today, issue.publication_id)
             : await this.getFinalScheduleData(today, issue.publication_id)

--- a/src/lib/rss-combiner.ts
+++ b/src/lib/rss-combiner.ts
@@ -1,5 +1,6 @@
 import { Feed } from 'feed'
 import { supabaseAdmin } from '@/lib/supabase'
+import { fetchAllPaginated } from '@/lib/dal/paginate'
 import { XMLParser } from 'fast-xml-parser'
 import { generateAndUploadTradeImage } from './trade-image-generator'
 import { normalizeTransactionType } from './transaction-type'
@@ -178,55 +179,6 @@ export function parseTradeSize(raw: string | null | undefined): number {
   return isNaN(num) ? 0 : num
 }
 
-/**
- * Fetch all rows from a Supabase table using pagination.
- * Supabase defaults to 1,000 rows per request.
- */
-async function fetchAllRows<T>(
-  table: string,
-  columns: string,
-  options?: {
-    order?: { column: string; ascending: boolean }
-    filters?: Array<{ column: string; op: 'eq' | 'neq'; value: any }>
-  }
-): Promise<T[]> {
-  const PAGE_SIZE = 1000
-  const allRows: T[] = []
-  let offset = 0
-
-  while (true) {
-    let query = supabaseAdmin
-      .from(table)
-      .select(columns)
-      .range(offset, offset + PAGE_SIZE - 1)
-
-    if (options?.order) {
-      query = query.order(options.order.column, { ascending: options.order.ascending })
-    }
-
-    if (options?.filters) {
-      for (const f of options.filters) {
-        query = query.eq(f.column, f.value)
-      }
-    }
-
-    const { data, error } = await query
-
-    if (error) {
-      console.error(`[RSS-Combiner] Failed to fetch ${table}:`, error.message)
-      break
-    }
-
-    if (!data || data.length === 0) break
-
-    allRows.push(...(data as T[]))
-
-    if (data.length < PAGE_SIZE) break
-    offset += PAGE_SIZE
-  }
-
-  return allRows
-}
 
 /**
  * Get top trades: deduplicate by ticker (keep largest trade_size_parsed),
@@ -243,10 +195,15 @@ export async function getTopTrades(maxTrades: number, tradeFreshnessDays?: numbe
   )
 
   // Fetch all trades with pagination, ordered by size desc
-  const trades = await fetchAllRows<CongressTrade>(
-    'congress_trades',
-    'id, ticker, ticker_type, company, traded, filed, transaction, trade_size_usd, trade_size_parsed, name, party, district, chamber, state, quiver_upload_time, image_url',
-    { order: { column: 'trade_size_parsed', ascending: false } }
+  const trades = await fetchAllPaginated<CongressTrade>(
+    () =>
+      supabaseAdmin
+        .from('congress_trades')
+        .select(
+          'id, ticker, ticker_type, company, traded, filed, transaction, trade_size_usd, trade_size_parsed, name, party, district, chamber, state, quiver_upload_time, image_url'
+        )
+        .order('trade_size_parsed', { ascending: false }),
+    { label: 'rss-combiner:congress_trades' }
   )
 
   // Helper: run dedup/exclusion/per-member logic on a set of trades

--- a/src/lib/rss-processor/article-extraction.ts
+++ b/src/lib/rss-processor/article-extraction.ts
@@ -1,6 +1,6 @@
-import { supabaseAdmin } from '../supabase'
 import type { RSSProcessorContext } from './shared-context'
 import { logInfo, logError } from './shared-context'
+import { listPostsForExtractionByIssue, applyExtractionResult } from '@/lib/dal/posts'
 
 /**
  * Article text extraction module.
@@ -19,22 +19,9 @@ export class ArticleExtraction {
    */
   async enrichRecentPostsWithFullContent(issueId: string) {
     try {
-      const yesterday = new Date()
-      yesterday.setHours(yesterday.getHours() - 24)
-      const yesterdayTimestamp = yesterday.toISOString()
+      const posts = await listPostsForExtractionByIssue(issueId, { sinceHours: 24 })
 
-      const { data: posts, error } = await supabaseAdmin
-        .from('rss_posts')
-        .select('id, source_url, title, full_article_text, processed_at')
-        .eq('issue_id', issueId)
-        .not('source_url', 'is', null)
-        .gte('processed_at', yesterdayTimestamp)
-
-      if (error) {
-        throw new Error(`Failed to fetch recent posts for extraction: ${error.message}`)
-      }
-
-      if (!posts || posts.length === 0) {
+      if (posts.length === 0) {
         return
       }
 
@@ -68,32 +55,10 @@ export class ArticleExtraction {
         const postId = urlToPostMap.get(url)
         if (!postId) continue
 
-        if (result.success && result.fullText) {
-          const { error: updateError } = await supabaseAdmin
-            .from('rss_posts')
-            .update({
-              full_article_text: result.fullText,
-              extraction_status: 'success',
-              extraction_error: null
-            })
-            .eq('id', postId)
-
-          if (!updateError) {
-            successCount++
-          }
-        } else {
-          const status = result.status || 'failed'
-          if (status === 'paywall') paywallCount++
-          if (status === 'login_required') loginCount++
-
-          await supabaseAdmin
-            .from('rss_posts')
-            .update({
-              extraction_status: status,
-              extraction_error: result.error?.substring(0, 500) || null
-            })
-            .eq('id', postId)
-        }
+        const { updated, status } = await applyExtractionResult(postId, result)
+        if (status === 'success' && updated) successCount++
+        if (status === 'paywall') paywallCount++
+        if (status === 'login_required') loginCount++
       }
 
       if (paywallCount > 0 || loginCount > 0) {
@@ -111,17 +76,9 @@ export class ArticleExtraction {
    */
   async enrichPostsWithFullContent(issueId: string) {
     try {
-      const { data: posts, error } = await supabaseAdmin
-        .from('rss_posts')
-        .select('id, source_url, title, full_article_text')
-        .eq('issue_id', issueId)
-        .not('source_url', 'is', null)
+      const posts = await listPostsForExtractionByIssue(issueId)
 
-      if (error) {
-        throw new Error(`Failed to fetch posts for extraction: ${error.message}`)
-      }
-
-      if (!posts || posts.length === 0) {
+      if (posts.length === 0) {
         return
       }
 
@@ -158,35 +115,14 @@ export class ArticleExtraction {
         const postId = urlToPostMap.get(url)
         if (!postId) continue
 
-        if (result.success && result.fullText) {
-          const { error: updateError } = await supabaseAdmin
-            .from('rss_posts')
-            .update({
-              full_article_text: result.fullText,
-              extraction_status: 'success',
-              extraction_error: null
-            })
-            .eq('id', postId)
-
-          if (!updateError) {
-            successCount++
-          } else {
-            failureCount++
-          }
+        const { updated, status } = await applyExtractionResult(postId, result)
+        if (status === 'success' && updated) {
+          successCount++
         } else {
-          const status = result.status || 'failed'
+          failureCount++
           if (status === 'paywall') paywallCount++
           if (status === 'login_required') loginCount++
           if (status === 'blocked') blockedCount++
-          failureCount++
-
-          await supabaseAdmin
-            .from('rss_posts')
-            .update({
-              extraction_status: status,
-              extraction_error: result.error?.substring(0, 500) || null
-            })
-            .eq('id', postId)
         }
       }
 

--- a/src/lib/rss-processor/deduplication.ts
+++ b/src/lib/rss-processor/deduplication.ts
@@ -2,60 +2,69 @@ import { supabaseAdmin } from '../supabase'
 import { Deduplicator } from '../deduplicator'
 import type { RssPost } from '@/types/database'
 import { getNewsletterIdFromIssue } from './shared-context'
+import { listPostsByIssue } from '@/lib/dal/posts'
+import {
+  isIssueDeduplicated,
+  listDuplicateGroupIdsByIssue,
+  listDuplicatePostIdsByGroups,
+  storeDeduplicationResult,
+  type NewDuplicatePost,
+} from '@/lib/dal/dedup'
+
+/**
+ * A "historical match" is a duplicate group whose primary post was published
+ * in a prior issue — meaning the primary itself should also be flagged as a
+ * duplicate (so we don't re-run an article on it).
+ */
+function isHistoricalDedupGroup(group: {
+  detection_method?: string
+  explanation?: string
+  topic_signature?: string
+}): boolean {
+  if (group.detection_method === 'historical_match') return true
+  if (group.topic_signature?.startsWith('Historical AI match:')) return true
+  if (
+    (group.detection_method === 'title_similarity' || group.detection_method === 'ai_semantic') &&
+    group.explanation?.includes('previously published')
+  ) {
+    return true
+  }
+  return false
+}
 
 /**
  * Duplicate detection and handling module.
  */
 export class Deduplication {
   async handleDuplicatesForIssue(issueId: string) {
-    const { data: allPosts, error } = await supabaseAdmin
-      .from('rss_posts')
-      .select('*')
-      .eq('issue_id', issueId)
+    const allPosts = await listPostsByIssue(issueId)
 
-    if (error || !allPosts || allPosts.length === 0) {
+    if (allPosts.length === 0) {
       return { groups: 0, duplicates: 0 }
     }
 
     await this.handleDuplicates(allPosts, issueId)
 
-    const { data: duplicateGroups } = await supabaseAdmin
-      .from('duplicate_groups')
-      .select('id')
-      .eq('issue_id', issueId)
-
-    const { data: duplicatePosts } = await supabaseAdmin
-      .from('duplicate_posts')
-      .select('id')
-      .in('group_id', duplicateGroups?.map(g => g.id) || [])
+    const groupIds = await listDuplicateGroupIdsByIssue(issueId)
+    const duplicatePostIds = await listDuplicatePostIdsByGroups(groupIds)
 
     return {
-      groups: duplicateGroups ? duplicateGroups.length : 0,
-      duplicates: duplicatePosts ? duplicatePosts.length : 0
+      groups: groupIds.length,
+      duplicates: duplicatePostIds.size,
     }
   }
 
   async handleDuplicates(posts: RssPost[], issueId: string) {
     try {
       // Check if already deduplicated for this issue
-      const { data: existingGroups } = await supabaseAdmin
-        .from('duplicate_groups')
-        .select('id')
-        .eq('issue_id', issueId)
-        .limit(1)
-
-      if (existingGroups && existingGroups.length > 0) {
+      if (await isIssueDeduplicated(issueId)) {
         return
       }
 
-      const { data: allPosts, error } = await supabaseAdmin
-        .from('rss_posts')
-        .select('*')
-        .eq('issue_id', issueId)
-
-      if (error || !allPosts || allPosts.length === 0) {
+      if (posts.length === 0) {
         return
       }
+      const allPosts = posts
 
       // Get publication_id from issue for multi-tenant filtering
       const newsletterId = await getNewsletterIdFromIssue(issueId)
@@ -98,58 +107,31 @@ export class Deduplication {
 
         console.log(`[Dedup] Storing group: "${group.topic_signature?.substring(0, 50)}..." - Primary: ${group.primary_post_id}`)
 
-        // Create duplicate group
-        const { data: duplicateGroup, error: groupError } = await supabaseAdmin
-          .from('duplicate_groups')
-          .insert([{
-            issue_id: issueId,
-            primary_post_id: group.primary_post_id,
-            topic_signature: group.topic_signature
-          }])
-          .select('id')
-          .single()
+        const isHistoricalMatch = isHistoricalDedupGroup(group)
 
-        if (groupError) {
-          console.error(`[Dedup] Failed to create group:`, groupError.message)
+        const duplicates: NewDuplicatePost[] = group.duplicate_post_ids
+          .filter((postId: string) => isHistoricalMatch || postId !== group.primary_post_id)
+          .map((postId: string) => ({
+            postId,
+            similarityScore: group.similarity_score,
+            detectionMethod: group.detection_method,
+          }))
+
+        const { group: created, storedDuplicates: insertedCount } = await storeDeduplicationResult({
+          issueId,
+          primaryPostId: group.primary_post_id,
+          topicSignature: group.topic_signature,
+          duplicates,
+        })
+
+        if (!created) {
+          console.error(`[Dedup] Failed to create group for primary ${group.primary_post_id}`)
           continue
         }
 
         storedGroups++
-
-        if (duplicateGroup) {
-          console.log(`[Dedup] Marking ${group.duplicate_post_ids.length} posts as duplicates`)
-
-          const isHistoricalMatch = group.detection_method === 'historical_match' ||
-                                   (group.detection_method === 'title_similarity' &&
-                                    group.explanation?.includes('previously published')) ||
-                                   (group.detection_method === 'ai_semantic' &&
-                                    group.explanation?.includes('previously published')) ||
-                                   group.topic_signature?.startsWith('Historical AI match:')
-
-          for (const postId of group.duplicate_post_ids) {
-            if (postId === group.primary_post_id && !isHistoricalMatch) {
-              console.log(`[Dedup] Skipping primary post ${postId} from duplicate list`)
-              continue
-            }
-
-            const { error: dupError } = await supabaseAdmin
-              .from('duplicate_posts')
-              .insert([{
-                group_id: duplicateGroup.id,
-                post_id: postId,
-                similarity_score: group.similarity_score,
-                detection_method: group.detection_method,
-                actual_similarity_score: group.similarity_score
-              }])
-
-            if (dupError) {
-              console.error(`[Dedup] Failed to mark post ${postId} as duplicate:`, dupError.message)
-            } else {
-              console.log(`[Dedup] Marked post ${postId} as duplicate (${group.detection_method})`)
-              storedDuplicates++
-            }
-          }
-        }
+        storedDuplicates += insertedCount
+        console.log(`[Dedup] Stored group ${created.id}: ${insertedCount}/${duplicates.length} duplicate rows inserted`)
       }
 
       console.log(`[Dedup] Stored ${storedGroups} groups with ${storedDuplicates} duplicate posts total`)

--- a/src/lib/rss-processor/feed-ingestion.ts
+++ b/src/lib/rss-processor/feed-ingestion.ts
@@ -5,6 +5,15 @@ import { alertOnFirecrawl402 } from '../monitoring/firecrawl-monitor'
 import type { RSSProcessorContext } from './shared-context'
 import { isFbcdnUrl } from './shared-context'
 import { Scoring } from './scoring'
+import {
+  getExistingExternalIds,
+  insertPost,
+  applyExtractionResult,
+  listExtractedPostsByIds,
+  listPendingExtractionPosts,
+  getRatedPostIds,
+  insertPostRating,
+} from '@/lib/dal/posts'
 
 const parser = new Parser({
   customFields: {
@@ -113,6 +122,9 @@ export class FeedIngestion {
 
       const blockedDomains = await getBlockedDomains(newsletterId)
 
+      // Pre-filter blocked domains and batch-check which externalIds already exist
+      const candidateItems: typeof recentPosts = []
+      const candidateExternalIds: string[] = []
       for (const item of recentPosts) {
         const externalId = item.guid || item.link || ''
         const sourceUrl = item.link || ''
@@ -123,23 +135,21 @@ export class FeedIngestion {
             const isBlocked = blockedDomains.some(domain =>
               hostname === domain || hostname.endsWith('.' + domain)
             )
-            if (isBlocked) {
-              continue
-            }
+            if (isBlocked) continue
           } catch {
             // Invalid URL, continue processing
           }
         }
+        candidateItems.push(item)
+        candidateExternalIds.push(externalId)
+      }
 
-        const { data: existing } = await supabaseAdmin
-          .from('rss_posts')
-          .select('id')
-          .eq('external_id', externalId)
-          .in('feed_id', publicationFeedIds)
-          .limit(1)
-          .maybeSingle()
+      const existingExternalIds = await getExistingExternalIds(candidateExternalIds, publicationFeedIds)
 
-        if (existing) continue
+      for (const item of candidateItems) {
+        const externalId = item.guid || item.link || ''
+
+        if (existingExternalIds.has(externalId)) continue
 
         const excludedSources = await getExcludedRssSources(newsletterId)
         const author = item.creator || (item as any)['dc:creator'] || null
@@ -170,28 +180,24 @@ export class FeedIngestion {
         const memberName = extractField((item as any).member)
         const transactionType = extractField((item as any).transaction)
 
-        const { data: newPost, error: insertError } = await supabaseAdmin
-          .from('rss_posts')
-          .insert([{
-            feed_id: feed.id,
-            issue_id: null,
-            article_module_id: feed.article_module_id || null,
-            external_id: externalId,
-            title: item.title || '',
-            description: item.contentSnippet || item.content || '',
-            content: item.content || '',
-            author,
-            publication_date: item.pubDate,
-            source_url: item.link,
-            image_url: imageUrl,
-            ticker,
-            member_name: memberName,
-            transaction_type: transactionType,
-          }])
-          .select('id, source_url')
-          .single()
+        const newPost = await insertPost({
+          feed_id: feed.id,
+          issue_id: null,
+          article_module_id: feed.article_module_id || null,
+          external_id: externalId,
+          title: item.title || '',
+          description: item.contentSnippet || item.content || '',
+          content: item.content || '',
+          author,
+          publication_date: item.pubDate,
+          source_url: item.link,
+          image_url: imageUrl,
+          ticker,
+          member_name: memberName,
+          transaction_type: transactionType,
+        })
 
-        if (insertError || !newPost) continue
+        if (!newPost) continue
 
         newPosts.push(newPost)
       }
@@ -208,26 +214,7 @@ export class FeedIngestion {
 
           for (const post of newPosts) {
             if (!post.source_url) continue
-
-            const result = extractionResults.get(post.source_url)
-            if (result?.success && result.fullText) {
-              await supabaseAdmin
-                .from('rss_posts')
-                .update({
-                  full_article_text: result.fullText,
-                  extraction_status: 'success',
-                  extraction_error: null
-                })
-                .eq('id', post.id)
-            } else if (result) {
-              await supabaseAdmin
-                .from('rss_posts')
-                .update({
-                  extraction_status: result.status || 'failed',
-                  extraction_error: result.error?.substring(0, 500) || null
-                })
-                .eq('id', post.id)
-            }
+            await applyExtractionResult(post.id, extractionResults.get(post.source_url))
           }
         } catch (error) {
           console.error('[Ingest] Extraction failed:', error instanceof Error ? error.message : 'Unknown')
@@ -240,12 +227,7 @@ export class FeedIngestion {
       let scoredCount = 0
 
       if (newPosts.length > 0) {
-        const { data: fullPosts } = await supabaseAdmin
-          .from('rss_posts')
-          .select('id, title, description, content, source_url, full_article_text, article_module_id, feed_id, ticker, transaction_type')
-          .in('id', newPosts.map(p => p.id))
-          .eq('extraction_status', 'success')
-          .not('full_article_text', 'is', null)
+        const fullPosts = await listExtractedPostsByIds(newPosts.map(p => p.id))
 
         if (fullPosts && fullPosts.length > 0) {
           console.log(`[Ingest] Scoring ${fullPosts.length}/${newPosts.length} posts (${newPosts.length - fullPosts.length} skipped — extraction not successful)`)
@@ -272,71 +254,32 @@ export class FeedIngestion {
       // from prior runs that timed out before finishing. Caps at 20 per run
       // so we chip away at the backlog without blowing the timeout.
       const CATCHUP_LIMIT = 20
-      let pendingQuery = supabaseAdmin
-        .from('rss_posts')
-        .select('id, source_url')
-        .eq('feed_id', feed.id)
-        .eq('extraction_status', 'pending')
-
-      // Exclude posts from this run (avoid double-processing)
-      if (newPosts.length > 0) {
-        pendingQuery = pendingQuery.not('id', 'in', `(${newPosts.map(p => p.id).join(',')})`)
-      }
-
-      // Process oldest first so the backlog clears from the bottom up
-      const { data: pendingPosts } = await pendingQuery
-        .order('processed_at', { ascending: true })
-        .limit(CATCHUP_LIMIT)
+      const pendingPosts = await listPendingExtractionPosts(feed.id, {
+        limit: CATCHUP_LIMIT,
+        excludeIds: newPosts.length > 0 ? newPosts.map(p => p.id) : undefined,
+      })
 
       if (pendingPosts && pendingPosts.length > 0) {
         console.log(`[Ingest] Catch-up: extracting ${pendingPosts.length} pending posts from prior runs`)
 
-        const pendingUrls = pendingPosts.filter(p => p.source_url).map(p => p.source_url)
+        const pendingUrls = pendingPosts.map(p => p.source_url).filter((u): u is string => !!u)
         try {
           const catchupResults = await this.ctx.articleExtractor.extractBatch(pendingUrls, 3)
           await alertOnFirecrawl402(catchupResults, { feedName: feed.name })
 
           for (const post of pendingPosts) {
             if (!post.source_url) continue
-            const result = catchupResults.get(post.source_url)
-            if (result?.success && result.fullText) {
-              await supabaseAdmin
-                .from('rss_posts')
-                .update({
-                  full_article_text: result.fullText,
-                  extraction_status: 'success',
-                  extraction_error: null
-                })
-                .eq('id', post.id)
-            } else if (result) {
-              await supabaseAdmin
-                .from('rss_posts')
-                .update({
-                  extraction_status: result.status || 'failed',
-                  extraction_error: result.error?.substring(0, 500) || null
-                })
-                .eq('id', post.id)
-            }
+            await applyExtractionResult(post.id, catchupResults.get(post.source_url))
           }
 
           // Score successfully extracted catch-up posts
-          const { data: catchupExtracted } = await supabaseAdmin
-            .from('rss_posts')
-            .select('id, title, description, content, source_url, full_article_text, article_module_id, feed_id, ticker, transaction_type')
-            .in('id', pendingPosts.map(p => p.id))
-            .eq('extraction_status', 'success')
-            .not('full_article_text', 'is', null)
+          const catchupExtracted = await listExtractedPostsByIds(pendingPosts.map(p => p.id))
 
           if (catchupExtracted && catchupExtracted.length > 0) {
             // Filter to only posts without existing ratings
-            const postIds = catchupExtracted.map(p => p.id)
-            const { data: existingRatings } = await supabaseAdmin
-              .from('post_ratings')
-              .select('post_id')
-              .in('post_id', postIds)
-
-            const ratedIds = new Set((existingRatings || []).map(r => r.post_id))
-            const unratedPosts = catchupExtracted.filter(p => !ratedIds.has(p.id))
+            const postIds = catchupExtracted.map((p: any) => p.id)
+            const ratedIds = await getRatedPostIds(postIds)
+            const unratedPosts = catchupExtracted.filter((p: any) => !ratedIds.has(p.id))
 
             if (unratedPosts.length > 0) {
               console.log(`[Ingest] Catch-up: scoring ${unratedPosts.length} newly extracted posts`)
@@ -429,12 +372,9 @@ export class FeedIngestion {
       }
     }
 
-    const { error } = await supabaseAdmin
-      .from('post_ratings')
-      .insert([ratingRecord])
-
-    if (error) {
-      throw new Error(`Rating insert failed: ${error.message}`)
+    const result = await insertPostRating(ratingRecord)
+    if (!result.ok) {
+      throw new Error(`Rating insert failed${result.errorMessage ? `: ${result.errorMessage}` : ''}`)
     }
   }
 

--- a/src/lib/rss-processor/issue-lifecycle.ts
+++ b/src/lib/rss-processor/issue-lifecycle.ts
@@ -1,5 +1,9 @@
 import { supabaseAdmin } from '../supabase'
 import { getArticleSettings } from '../publication-settings'
+import { getTomorrowStr } from '../date-utils'
+import { listPostsForScoring, assignPostsToIssue, listPostsByIssue, unassignPosts } from '@/lib/dal/posts'
+import { listModuleArticlesByIssue } from '@/lib/dal/articles'
+import { listDuplicateGroupIdsByIssue } from '@/lib/dal/dedup'
 import type { RSSProcessorContext } from './shared-context'
 import { getNewsletterIdFromIssue, formatError } from './shared-context'
 import type { Deduplication } from './deduplication'
@@ -66,13 +70,7 @@ export class IssueLifecycle {
       // STEP 1: Create NEW issue
       console.log('[Step 1/10] Creating new issue...')
 
-      const ctParts = new Intl.DateTimeFormat('en-CA', {
-        timeZone: 'America/Chicago',
-        year: 'numeric', month: '2-digit', day: '2-digit'
-      }).format(new Date())
-      const [ctYear, ctMonth, ctDay] = ctParts.split('-').map(Number)
-      const tomorrowDate = new Date(ctYear, ctMonth - 1, ctDay + 1)
-      const issueDate = `${tomorrowDate.getFullYear()}-${String(tomorrowDate.getMonth() + 1).padStart(2, '0')}-${String(tomorrowDate.getDate()).padStart(2, '0')}`
+      const issueDate = getTomorrowStr('CST')
 
       const { data: newissue, error: createError } = await supabaseAdmin
         .from('publication_issues')
@@ -110,30 +108,19 @@ export class IssueLifecycle {
       // STEP 4: Run deduplication
       console.log('[Step 4/10] Deduplicating posts...')
       await this.deduplication.handleDuplicatesForIssue(issueId)
-      const { data: duplicateGroups } = await supabaseAdmin
-        .from('duplicate_groups')
-        .select('id')
-        .eq('issue_id', issueId)
-      const groupsCount = duplicateGroups ? duplicateGroups.length : 0
+      const groupsCount = (await listDuplicateGroupIdsByIssue(issueId)).length
       console.log(`[Step 4/10] ✓ Deduplicated: ${groupsCount} duplicate groups`)
 
       // STEP 5: Article generation now handled by process-rss-workflow.ts -> module-articles.ts
       console.log('[Step 5/10] Counting module articles (generation handled by workflow)...')
-      const { data: generatedArticles } = await supabaseAdmin
-        .from('module_articles')
-        .select('id')
-        .eq('issue_id', issueId)
-      console.log(`[Step 5/10] ✓ Generated ${generatedArticles?.length || 0} module articles`)
+      const generatedArticles = await listModuleArticlesByIssue(issueId, { idsOnly: true })
+      console.log(`[Step 5/10] ✓ Generated ${generatedArticles.length} module articles`)
 
       // STEP 6: Article selection now handled by module pipeline (ArticleModuleSelector)
       console.log('[Step 6/10] Counting active module articles (selection handled by workflow)...')
       await this.articleSelector.selectTopArticlesForIssue(issueId)
-      const { data: activeModuleArticles } = await supabaseAdmin
-        .from('module_articles')
-        .select('id')
-        .eq('issue_id', issueId)
-        .eq('is_active', true)
-      console.log(`[Step 6/10] ✓ Selected ${activeModuleArticles?.length || 0} active module articles`)
+      const activeModuleArticles = await listModuleArticlesByIssue(issueId, { idsOnly: true, activeOnly: true })
+      console.log(`[Step 6/10] ✓ Selected ${activeModuleArticles.length} active module articles`)
 
       // STEP 7: Initialize and generate text box modules
       console.log('[Step 7/10] Generating text box modules...')
@@ -314,59 +301,46 @@ export class IssueLifecycle {
 
     const secondaryFeedIds = secondaryFeeds?.map(f => f.id) || []
 
-    const { data: allPrimaryPosts } = await supabaseAdmin
-      .from('rss_posts')
-      .select(`
-        id,
-        post_ratings(total_score)
-      `)
-      .in('feed_id', primaryFeedIds)
-      .is('issue_id', null)
-      .gte('processed_at', lookbackTimestamp)
-      .not('post_ratings', 'is', null)
+    const allPrimaryPosts = await listPostsForScoring(primaryFeedIds, {
+      unassignedOnly: true,
+      sinceTimestamp: lookbackTimestamp,
+      requireRating: true,
+      columns: 'id, post_ratings(total_score)',
+    })
 
     const topPrimary = allPrimaryPosts
-      ?.sort((a: any, b: any) => {
+      .sort((a: any, b: any) => {
         const scoreA = a.post_ratings?.[0]?.total_score || 0
         const scoreB = b.post_ratings?.[0]?.total_score || 0
         return scoreB - scoreA
       })
-      .slice(0, 12) || []
+      .slice(0, 12)
 
-    const { data: allSecondaryPosts } = await supabaseAdmin
-      .from('rss_posts')
-      .select(`
-        id,
-        post_ratings(total_score)
-      `)
-      .in('feed_id', secondaryFeedIds)
-      .is('issue_id', null)
-      .gte('processed_at', lookbackTimestamp)
-      .not('post_ratings', 'is', null)
+    const allSecondaryPosts = await listPostsForScoring(secondaryFeedIds, {
+      unassignedOnly: true,
+      sinceTimestamp: lookbackTimestamp,
+      requireRating: true,
+      columns: 'id, post_ratings(total_score)',
+    })
 
     const topSecondary = allSecondaryPosts
-      ?.sort((a: any, b: any) => {
+      .sort((a: any, b: any) => {
         const scoreA = a.post_ratings?.[0]?.total_score || 0
         const scoreB = b.post_ratings?.[0]?.total_score || 0
         return scoreB - scoreA
       })
-      .slice(0, 12) || []
+      .slice(0, 12)
 
-    const primaryIds = topPrimary?.map(p => p.id) || []
-    const secondaryIds = topSecondary?.map(p => p.id) || []
+    const primaryIds = topPrimary.map((p: any) => p.id)
+    const secondaryIds = topSecondary.map((p: any) => p.id)
 
-    if (primaryIds.length > 0) {
-      await supabaseAdmin
-        .from('rss_posts')
-        .update({ issue_id: issueId })
-        .in('id', primaryIds)
+    const primaryOk = await assignPostsToIssue(primaryIds, issueId)
+    if (!primaryOk && primaryIds.length > 0) {
+      console.warn(`[Step 3/10] ⚠️ Failed to assign ${primaryIds.length} primary posts to issue ${issueId}`)
     }
-
-    if (secondaryIds.length > 0) {
-      await supabaseAdmin
-        .from('rss_posts')
-        .update({ issue_id: issueId })
-        .in('id', secondaryIds)
+    const secondaryOk = await assignPostsToIssue(secondaryIds, issueId)
+    if (!secondaryOk && secondaryIds.length > 0) {
+      console.warn(`[Step 3/10] ⚠️ Failed to assign ${secondaryIds.length} secondary posts to issue ${issueId}`)
     }
 
     return { primary: primaryIds.length, secondary: secondaryIds.length }
@@ -376,25 +350,15 @@ export class IssueLifecycle {
    * Stage 1 Unassignment: Unassign posts that were assigned but no articles generated
    */
   async unassignUnusedPosts(issueId: string): Promise<{ unassigned: number }> {
-    const { data: assignedPosts } = await supabaseAdmin
-      .from('rss_posts')
-      .select('id')
-      .eq('issue_id', issueId)
-
-    const assignedPostIds = assignedPosts?.map(p => p.id) || []
+    const assignedPosts = await listPostsByIssue(issueId, { idsOnly: true })
+    const assignedPostIds = assignedPosts.map(p => p.id)
 
     if (assignedPostIds.length === 0) {
       return { unassigned: 0 }
     }
 
-    const { data: moduleArticlesUsed } = await supabaseAdmin
-      .from('module_articles')
-      .select('post_id')
-      .eq('issue_id', issueId)
-
-    const usedPostIds = [
-      ...(moduleArticlesUsed?.map(a => a.post_id).filter(Boolean) || [])
-    ]
+    const moduleArticlesUsed = await listModuleArticlesByIssue(issueId, { postIdsOnly: true })
+    const usedPostIds = moduleArticlesUsed.map(a => a.post_id).filter((id): id is string => !!id)
 
     const unusedPostIds = assignedPostIds.filter(id => !usedPostIds.includes(id))
 
@@ -402,10 +366,7 @@ export class IssueLifecycle {
       return { unassigned: 0 }
     }
 
-    await supabaseAdmin
-      .from('rss_posts')
-      .update({ issue_id: null })
-      .in('id', unusedPostIds)
+    await unassignPosts(unusedPostIds)
 
     return { unassigned: unusedPostIds.length }
   }

--- a/src/lib/rss-processor/module-articles.ts
+++ b/src/lib/rss-processor/module-articles.ts
@@ -2,6 +2,24 @@ import { supabaseAdmin } from '../supabase'
 import { AI_CALL, callOpenAI } from '../openai'
 import { normalizeTransactionType } from '../transaction-type'
 import { detectAIRefusal, getNewsletterIdFromIssue } from './shared-context'
+import {
+  listPostsForScoring,
+  assignPostsToIssue,
+  listAssignedPostsForModule,
+  POST_WITH_RATINGS_BRIEF,
+} from '@/lib/dal/posts'
+import {
+  moduleArticleExists,
+  insertModuleArticle,
+  listArticlesNeedingBody,
+  listArticlesNeedingFactCheck,
+  updateModuleArticleContent,
+  updateModuleArticleFactCheck,
+} from '@/lib/dal/articles'
+import {
+  listDuplicateGroupIdsByIssue,
+  listDuplicatePostIdsByGroups,
+} from '@/lib/dal/dedup'
 import type { ArticleGenerator } from './article-generator'
 
 /**
@@ -65,40 +83,22 @@ export class ModuleArticles {
 
     console.log(`[Module] Querying posts: feedIds=${JSON.stringify(feedIds)}, lookback=${lookbackTimestamp}, postsToAssign=${postsToAssign}`)
 
-    const { data: topPosts, error: postsError } = await supabaseAdmin
-      .from('rss_posts')
-      .select(`
-        id,
-        ticker,
-        post_ratings(
-          total_score,
-          criteria_1_score,
-          criteria_2_score,
-          criteria_3_score,
-          criteria_4_score,
-          criteria_5_score
-        )
-      `)
-      .in('feed_id', feedIds)
-      .is('issue_id', null)
-      .gte('processed_at', lookbackTimestamp)
-      .not('post_ratings', 'is', null)
-
-    if (postsError) {
-      console.error(`[Module] Query error for mod ${mod.name}:`, postsError.message)
-      return { assigned: 0 }
-    }
+    const topPosts = await listPostsForScoring(feedIds, {
+      unassignedOnly: true,
+      sinceTimestamp: lookbackTimestamp,
+      requireRating: true,
+      columns: POST_WITH_RATINGS_BRIEF,
+    })
 
     if (!topPosts || topPosts.length === 0) {
       // Debug: check without the post_ratings filter
-      const { data: unfilteredPosts, error: unfilteredError } = await supabaseAdmin
-        .from('rss_posts')
-        .select('id')
-        .in('feed_id', feedIds)
-        .is('issue_id', null)
-        .gte('processed_at', lookbackTimestamp)
+      const unfilteredPosts = await listPostsForScoring(feedIds, {
+        unassignedOnly: true,
+        sinceTimestamp: lookbackTimestamp,
+        columns: 'id',
+      })
 
-      console.log(`[Module] No available posts for mod ${mod.name} (unfiltered count: ${unfilteredPosts?.length || 0}, error: ${unfilteredError?.message || 'none'})`)
+      console.log(`[Module] No available posts for mod ${mod.name} (unfiltered count: ${unfilteredPosts.length})`)
       return { assigned: 0 }
     }
 
@@ -169,13 +169,14 @@ export class ModuleArticles {
     }
 
     if (selectedPosts.length > 0) {
-      await supabaseAdmin
-        .from('rss_posts')
-        .update({
-          issue_id: issueId,
-          article_module_id: moduleId
-        })
-        .in('id', selectedPosts.map((p: any) => p.id))
+      const ok = await assignPostsToIssue(
+        selectedPosts.map((p: any) => p.id),
+        issueId,
+        { moduleId }
+      )
+      if (!ok) {
+        console.warn(`[Module] ⚠️ Failed to assign ${selectedPosts.length} posts for mod ${mod.name} (issue ${issueId})`)
+      }
     }
 
     console.log(`[Module] Assigned ${selectedPosts.length} posts to mod ${mod.name}${filteredCount > 0 ? ` (${filteredCount} filtered by minimum scores)` : ''}`)
@@ -201,15 +202,7 @@ export class ModuleArticles {
       return
     }
 
-    const { data: posts } = await supabaseAdmin
-      .from('rss_posts')
-      .select(`
-        id, title, description, content, full_article_text, source_url, image_url, image_alt, feed_id, issue_id, article_module_id, ticker, member_name, transaction_type,
-        post_ratings(total_score, criteria_1_score, criteria_2_score, criteria_3_score, criteria_4_score, criteria_5_score)
-      `)
-      .eq('issue_id', issueId)
-      .eq('article_module_id', moduleId)
-      .in('feed_id', feedIds)
+    const posts = await listAssignedPostsForModule(issueId, moduleId, feedIds)
 
     if (!posts || posts.length === 0) {
       console.log(`[Module Titles] No posts assigned to mod ${mod.name}`)
@@ -217,21 +210,8 @@ export class ModuleArticles {
     }
 
     // Get duplicate post IDs to exclude
-    const { data: duplicateGroups } = await supabaseAdmin
-      .from('duplicate_groups')
-      .select('id')
-      .eq('issue_id', issueId)
-
-    const groupIds = duplicateGroups?.map(g => g.id) || []
-    let duplicatePostIds = new Set<string>()
-
-    if (groupIds.length > 0) {
-      const { data: duplicatePosts } = await supabaseAdmin
-        .from('duplicate_posts')
-        .select('post_id')
-        .in('group_id', groupIds)
-      duplicatePostIds = new Set(duplicatePosts?.map(d => d.post_id) || [])
-    }
+    const groupIds = await listDuplicateGroupIdsByIssue(issueId)
+    const duplicatePostIds = await listDuplicatePostIdsByGroups(groupIds)
 
     const { prompts } = await ArticleModuleSelector.getModulePrompts(moduleId)
     const titlePrompt = prompts.find(p => p.prompt_type === 'article_title')
@@ -256,17 +236,9 @@ export class ModuleArticles {
     for (let i = 0; i < postsWithRatings.length; i += BATCH_SIZE) {
       const batch = postsWithRatings.slice(i, i + BATCH_SIZE)
 
-      await Promise.all(batch.map(async (post) => {
+      await Promise.all(batch.map(async (post: any) => {
         try {
-          const { data: existing } = await supabaseAdmin
-            .from('module_articles')
-            .select('id')
-            .eq('post_id', post.id)
-            .eq('issue_id', issueId)
-            .eq('article_module_id', moduleId)
-            .maybeSingle()
-
-          if (existing) {
+          if (await moduleArticleExists(post.id, issueId, moduleId)) {
             console.log(`[Module Titles] Article already exists for post ${post.id}`)
             return
           }
@@ -312,29 +284,27 @@ export class ModuleArticles {
             return
           }
 
-          const { error: insertError } = await supabaseAdmin
-            .from('module_articles')
-            .insert([{
-              post_id: post.id,
-              issue_id: issueId,
-              article_module_id: moduleId,
-              headline: headline,
-              content: '',
-              rank: null,
-              is_active: false,
-              skipped: false,
-              fact_check_score: null,
-              fact_check_details: null,
-              word_count: 0,
-              ticker: (post as any).ticker || null,
-              member_name: (post as any).member_name || null,
-              transaction_type: (post as any).transaction_type || null,
-              trade_image_url: (post as any).image_url || null,
-              trade_image_alt: (post as any).image_alt || (post as any).ticker || null
-            }])
+          const insertResult = await insertModuleArticle({
+            post_id: post.id,
+            issue_id: issueId,
+            article_module_id: moduleId,
+            headline: headline,
+            content: '',
+            rank: null,
+            is_active: false,
+            skipped: false,
+            fact_check_score: null,
+            fact_check_details: null,
+            word_count: 0,
+            ticker: (post as any).ticker || null,
+            member_name: (post as any).member_name || null,
+            transaction_type: (post as any).transaction_type || null,
+            trade_image_url: (post as any).image_url || null,
+            trade_image_alt: (post as any).image_alt || (post as any).ticker || null,
+          })
 
-          if (insertError && insertError.code !== '23505') {
-            console.error(`[Module Titles] Insert failed for post ${post.id}:`, insertError.message)
+          if (!insertResult.ok && !insertResult.duplicate) {
+            console.error(`[Module Titles] Insert failed for post ${post.id}`)
           }
 
           console.log(`[Module Titles] Generated: "${headline.substring(0, 50)}..."`)
@@ -368,18 +338,7 @@ export class ModuleArticles {
     const { prompts } = await ArticleModuleSelector.getModulePrompts(moduleId)
     const bodyPrompt = prompts.find(p => p.prompt_type === 'article_body')
 
-    const { data: articles } = await supabaseAdmin
-      .from('module_articles')
-      .select(`
-        id, headline, content, post_id,
-        rss_posts(id, title, description, content, full_article_text, source_url, transaction_type)
-      `)
-      .eq('issue_id', issueId)
-      .eq('article_module_id', moduleId)
-      .eq('content', '')
-      .not('headline', 'is', null)
-      .order('post_id', { ascending: true })
-      .limit(limit)
+    const articles = await listArticlesNeedingBody(issueId, moduleId, limit)
 
     if (!articles || articles.length === 0) {
       console.log(`[Module Bodies] No articles awaiting body generation for ${mod.name}`)
@@ -474,13 +433,10 @@ export class ModuleArticles {
             return
           }
 
-          await supabaseAdmin
-            .from('module_articles')
-            .update({
-              content: bodyResult.content,
-              word_count: bodyResult.word_count
-            })
-            .eq('id', article.id)
+          await updateModuleArticleContent(article.id, {
+            content: bodyResult.content,
+            wordCount: bodyResult.word_count,
+          })
 
           console.log(`[Module Bodies] Generated body for article ${article.id} (${bodyResult.word_count} words)`)
 
@@ -510,17 +466,7 @@ export class ModuleArticles {
       return
     }
 
-    const { data: articles } = await supabaseAdmin
-      .from('module_articles')
-      .select(`
-        id, content, fact_check_score,
-        rss_posts(id, content, description)
-      `)
-      .eq('issue_id', issueId)
-      .eq('article_module_id', moduleId)
-      .neq('content', '')
-      .not('content', 'is', null)
-      .is('fact_check_score', null)
+    const articles = await listArticlesNeedingFactCheck(issueId, moduleId)
 
     if (!articles || articles.length === 0) {
       console.log(`[Module Fact-Check] No articles awaiting fact-check for ${mod.name}`)
@@ -544,26 +490,20 @@ export class ModuleArticles {
           const originalContent = post.content || post.description || ''
           const factCheck = await this.articleGenerator.factCheckContent(article.content, originalContent, newsletterId)
 
-          await supabaseAdmin
-            .from('module_articles')
-            .update({
-              fact_check_score: factCheck.score,
-              fact_check_details: factCheck.details
-            })
-            .eq('id', article.id)
+          await updateModuleArticleFactCheck(article.id, {
+            score: factCheck.score,
+            details: factCheck.details,
+          })
 
           console.log(`[Module Fact-Check] Article ${article.id}: Score ${factCheck.score}/10`)
 
         } catch (error) {
           console.error(`[Module Fact-Check] Failed for article ${article.id}:`, error instanceof Error ? error.message : 'Unknown')
 
-          await supabaseAdmin
-            .from('module_articles')
-            .update({
-              fact_check_score: 0,
-              fact_check_details: `Fact-check failed: ${error instanceof Error ? error.message : 'Unknown error'}`
-            })
-            .eq('id', article.id)
+          await updateModuleArticleFactCheck(article.id, {
+            score: 0,
+            details: `Fact-check failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          })
         }
       }))
 

--- a/src/lib/schedule-checker.ts
+++ b/src/lib/schedule-checker.ts
@@ -1,5 +1,6 @@
 import { supabaseAdmin } from './supabase'
 import { getScheduleConfig } from './settings/schedule-settings'
+import { getTodayStr, getTomorrowStr } from './date-utils'
 
 interface ScheduleSettings {
   reviewScheduleEnabled: boolean
@@ -63,9 +64,7 @@ export class ScheduleChecker {
       // Allow running multiple times per day for testing purposes
       // Only check if time window matches, don't prevent multiple runs per day
       try {
-        const nowCentral = new Date().toLocaleString("en-US", {timeZone: "America/Chicago"})
-        const centralDate = new Date(nowCentral)
-        const today = centralDate.toISOString().split('T')[0]
+        const today = getTodayStr('CST')
 
         // Update the last run date to today (for logging/tracking purposes only)
         await supabaseAdmin
@@ -158,14 +157,7 @@ export class ScheduleChecker {
       if (minutesAfter < 5 || minutesAfter > 30) return false
 
       // Check if there's a draft issue for tomorrow with no review_sent_at
-      // Use Intl.DateTimeFormat to avoid timezone conversion bugs with toISOString()
-      const ctParts = new Intl.DateTimeFormat('en-CA', {
-        timeZone: 'America/Chicago',
-        year: 'numeric', month: '2-digit', day: '2-digit'
-      }).format(new Date())
-      const [ctYear, ctMonth, ctDay] = ctParts.split('-').map(Number)
-      const tomorrowDate = new Date(ctYear, ctMonth - 1, ctDay + 1)
-      const issueDate = `${tomorrowDate.getFullYear()}-${String(tomorrowDate.getMonth() + 1).padStart(2, '0')}-${String(tomorrowDate.getDate()).padStart(2, '0')}`
+      const issueDate = getTomorrowStr('CST')
 
       const { data: draftIssue } = await supabaseAdmin
         .from('publication_issues')

--- a/src/lib/sendgrid.ts
+++ b/src/lib/sendgrid.ts
@@ -22,6 +22,7 @@ import {
   generateWelcomeSection
 } from './newsletter-templates'
 import { getEmailSettings, getScheduleSettings, getPublicationSetting, getPublicationSettings } from './publication-settings'
+import { getTodayStr } from './date-utils'
 
 // Initialize SendGrid clients
 const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY || ''
@@ -183,9 +184,7 @@ export class SendGridService {
 
       // Schedule the campaign for today at review send time
       try {
-        const nowCentral = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' })
-        const centralDate = new Date(nowCentral)
-        const today = centralDate.toISOString().split('T')[0]
+        const today = getTodayStr('CST')
 
         const scheduleSettings = await getScheduleSettings(issue.publication_id)
         const sendAt = toSendGridSchedule(today, scheduleSettings.review_send_time)
@@ -317,9 +316,7 @@ export class SendGridService {
 
       // Schedule the campaign
       try {
-        const nowCentral = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' })
-        const centralDate = new Date(nowCentral)
-        const today = centralDate.toISOString().split('T')[0]
+        const today = getTodayStr('CST')
 
         let sendTime: string
         if (isSecondary) {

--- a/src/lib/sparkloop-client/sparkloop-client.ts
+++ b/src/lib/sparkloop-client/sparkloop-client.ts
@@ -15,6 +15,7 @@ import type {
   StoredSparkLoopRecommendation,
 } from '@/types/sparkloop'
 import { supabaseAdmin } from '@/lib/supabase'
+import { fetchAllPaginated } from '@/lib/dal/paginate'
 import { getPublicationSettings, getSparkLoopCredentials } from '@/lib/publication-settings'
 import { toLocalDateStr as toDateString } from '@/lib/date-utils'
 
@@ -994,23 +995,17 @@ export class SparkLoopService {
     snapLowerDate.setDate(snapLowerDate.getDate() - (maxScreeningForFetch + windowDays + 7))
     const snapLowerStr = toDateString(snapLowerDate)
 
-    const allSnaps: Array<{ ref_code: string; sparkloop_confirmed: number; sparkloop_rejected: number; snapshot_date: string }> = []
-    let snapOffset = 0
-    const SNAP_PAGE = 1000
-    while (true) {
-      const { data: page } = await supabaseAdmin
-        .from('sparkloop_daily_snapshots')
-        .select('ref_code, sparkloop_confirmed, sparkloop_rejected, snapshot_date')
-        .eq('publication_id', publicationId)
-        .gte('snapshot_date', snapLowerStr)
-        .lte('snapshot_date', todayStr)
-        .order('snapshot_date', { ascending: false })
-        .range(snapOffset, snapOffset + SNAP_PAGE - 1)
-      if (!page || page.length === 0) break
-      allSnaps.push(...page)
-      if (page.length < SNAP_PAGE) break
-      snapOffset += SNAP_PAGE
-    }
+    const allSnaps = await fetchAllPaginated<{ ref_code: string; sparkloop_confirmed: number; sparkloop_rejected: number; snapshot_date: string }>(
+      () =>
+        supabaseAdmin
+          .from('sparkloop_daily_snapshots')
+          .select('ref_code, sparkloop_confirmed, sparkloop_rejected, snapshot_date')
+          .eq('publication_id', publicationId)
+          .gte('snapshot_date', snapLowerStr)
+          .lte('snapshot_date', todayStr)
+          .order('snapshot_date', { ascending: false }),
+      { label: 'sparkloop:daily_snapshots' }
+    )
 
     // Group snapshots by ref_code, sorted by date descending (most recent first).
     // Exclude each rec's very first snapshot — it captured all-time cumulative totals
@@ -1044,22 +1039,15 @@ export class SparkLoopService {
     sendsRangeEnd.setDate(sendsRangeEnd.getDate() - 1)
 
     // Fetch all referrals in the broadest date range (for sends counting).
-    // Paginate to avoid Supabase's default 1000-row limit.
-    const allReferrals: Array<{ ref_code: string; subscribed_at: string }> = []
-    let refOffset = 0
-    const REF_PAGE = 1000
-    while (true) {
-      const { data: page } = await supabaseAdmin
-        .from('sparkloop_referrals')
-        .select('ref_code, subscribed_at')
-        .eq('publication_id', publicationId)
-        .gte('subscribed_at', toDateString(sendsRangeStart))
-        .range(refOffset, refOffset + REF_PAGE - 1)
-      if (!page || page.length === 0) break
-      allReferrals.push(...page)
-      if (page.length < REF_PAGE) break
-      refOffset += REF_PAGE
-    }
+    const allReferrals = await fetchAllPaginated<{ ref_code: string; subscribed_at: string }>(
+      () =>
+        supabaseAdmin
+          .from('sparkloop_referrals')
+          .select('ref_code, subscribed_at')
+          .eq('publication_id', publicationId)
+          .gte('subscribed_at', toDateString(sendsRangeStart)),
+      { label: 'sparkloop:referrals_for_sends' }
+    )
 
     // Group referrals by ref_code with their dates, and build send date sets for attribution filtering
     const referralsByRefCode = new Map<string, Date[]>()

--- a/src/lib/workflows/process-rss-workflow.ts
+++ b/src/lib/workflows/process-rss-workflow.ts
@@ -3,6 +3,7 @@ import { RSSProcessor } from '@/lib/rss-processor'
 import { ModuleAdSelector } from '@/lib/ad-modules'
 import { PollModuleSelector } from '@/lib/poll-modules'
 import { ArticleModuleSelector } from '@/lib/article-modules'
+import { getTomorrowStr } from '@/lib/date-utils'
 
 /**
  * RSS Processing Workflow (DYNAMIC ARTICLE MODULES)
@@ -117,13 +118,7 @@ async function setupIssue(newsletterId: string): Promise<{ issueId: string; modu
       console.log(`[Workflow Step 1] Using newsletter: ${newsletter.name} (${newsletter.id})`)
 
       // Always target tomorrow in Central Time (matches send-review logic)
-      const ctParts = new Intl.DateTimeFormat('en-CA', {
-        timeZone: 'America/Chicago',
-        year: 'numeric', month: '2-digit', day: '2-digit'
-      }).format(new Date())
-      const [ctYear, ctMonth, ctDay] = ctParts.split('-').map(Number)
-      const tomorrowDate = new Date(ctYear, ctMonth - 1, ctDay + 1)
-      const issueDate = `${tomorrowDate.getFullYear()}-${String(tomorrowDate.getMonth() + 1).padStart(2, '0')}-${String(tomorrowDate.getDate()).padStart(2, '0')}`
+      const issueDate = getTomorrowStr('CST')
 
       // Create new issue via DAL (dynamic import: pino uses Node.js modules not available in workflow context)
       const { createIssue } = await import('@/lib/dal')


### PR DESCRIPTION
## Summary

Two-commit DAL refactor addressing tech-debt issues #66 and #77.

### `7ddd9c2c` — Pagination wrapper + CT-date migrations + 1 bug fix
- New `src/lib/dal/paginate.ts` — `fetchAllPaginated<T>()` defeats Supabase's silent 1000-row truncation. Callback-style API preserves Supabase's fluent operators without per-operator wrappers.
- `src/lib/date-utils.ts` — adds `getTomorrowStr(tz)` (was reimplemented in 3 files). DST-safe via `getTodayStr` + UTC noon advance.
- Migrations (lib only): `sendgrid`, `mailerlite-service`, `schedule-checker`, `process-rss-workflow`, `issue-lifecycle`, `rss-combiner`, `sparkloop-client` — replaces `toLocaleString → toISOString` anti-pattern with `getTodayStr('CST')` / `getTomorrowStr('CST')` and the 3 inline pagination loops with `fetchAllPaginated`.
- **Bug fix**: `api/cron/process-mailerlite-updates/route.ts:163` was running an unbounded `.select()` on `subscriber_real_click_status` that silently truncated past 1000 rows per publication, causing every sync to redundantly resend the same MailerLite updates. Now paginated.
- Tests: 9 paginate tests + 20 date-utils tests including DST spring-forward + fall-back boundaries.

### `e5d8aa02` — Posts/articles/dedup DAL modules + 5 rss-processor migrations
- New `src/lib/dal/posts.ts` (rss_posts + post_ratings, includes `applyExtractionResult` composite that consolidates 5 copy-pasted blocks), `dal/articles.ts` (module_articles + manual_articles, single-LIKE `findNextAvailableSlug`), `dal/dedup.ts` (bulk-insert `storeDeduplicationResult`).
- Migrations in `src/lib/rss-processor/`: `feed-ingestion.ts` (per-item dedup check now batched — perf win), `issue-lifecycle.ts` (assignment, unassignment, dedup count via DAL + warning logs on failures), `module-articles.ts` (3 workflow stages + scoring), `deduplication.ts` (composite write + extracted `isHistoricalDedupGroup` predicate + fixed dead `posts` parameter), `article-extraction.ts` (both extraction paths use `applyExtractionResult`).
- Type-safety polish: overloads on `listPostsByIssue`/`listModuleArticlesByIssue`, UUID-regex validation on `listPendingExtractionPosts.excludeIds`, `updatePostExtraction` always clears `extraction_error` on success.
- `src/lib/CLAUDE.md` documents the 4 DAL modules and notes `src/lib/*-modules/` selectors are the canonical pattern for module-type domains (do not migrate to `dal/`).
- 74 new DAL unit tests; suite now 738/738 passing.

## Out of scope (follow-ups)
- Settings DAL — needs its own pass: 50+ API routes reimplement UPSERT loops, `prompt-loaders.ts` skips fallback. Standalone refactor.
- 14 API-route pagination sites in `src/app/api/sparkloop/**`, `excluded-ips/export`, etc. — functional today, just duplicated.
- Atomic dedup writes via Postgres RPC — current composite is non-atomic across two tables; failure mode preserved from pre-existing code.

## Verification

- [x] `npm run type-check` passes
- [x] `npm run test:run` passes (738/738; +74 new DAL tests)
- [x] `npm run lint` 331 warnings (under 360 ceiling), 0 errors
- [x] `npm run build` passes
- [x] `node scripts/check-bug-patterns.mjs --all` 305 vs 303 baseline (+2 acceptable false positives in `dal/posts.ts` where the script doesn't recognize transitive `feed_id`-scoped tenancy; −3 real violations removed elsewhere via CT-date migrations)
- [x] Pre-push gate review (security, junior-dev, dba, ops) — all critical findings addressed
- [x] Pre-push hook bug-pattern check passed

## Test plan (post-merge to staging)

- [ ] Watch `aiprodaily-staging` Vercel deployment land
- [ ] Behavior-parity check on next nightly RSS workflow — sample-run against a publication and SQL-diff `module_articles`, `post_ratings`, `duplicate_groups` rows against the prior run's snapshot. The 5 migrated files are nightly hot paths.
- [ ] `process-mailerlite-updates` cron in staging — confirm a publication with >1000 `subscriber_real_click_status` rows now picks them all up
- [ ] `schedule-checker` near 23:55 CT — verify `getTomorrowStr('CST')` rolls over correctly
- [ ] Rolling staging soak (24h+) before promotion to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed MailerLite real-click status synchronization issue that was causing repeated or incorrect updates for publications with large subscriber lists.

## Tests
* Added comprehensive test coverage for core data operations including articles, deduplication, post management, and pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->