### PR TITLE
DAL/AI-prompts hardening: pub-scoped prompts, pagination, perf cache

### DIFF
--- a/src/app/api/ai/load-prompt-template/route.ts
+++ b/src/app/api/ai/load-prompt-template/route.ts
@@ -1,20 +1,19 @@
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
 import { withApiHandler } from '@/lib/api-handler'
 import { AI_PROMPTS } from '@/lib/openai/prompt-loaders'
 import { supabaseAdmin } from '@/lib/supabase'
 
-export const POST = withApiHandler(
-  { authTier: 'authenticated', logContext: 'ai/load-prompt-template' },
-  async ({ request, logger }) => {
-    const body = await request.json()
-    const { promptType } = body
+const inputSchema = z.object({
+  promptType: z.string().min(1),
+  publicationId: z.string().uuid().optional(),
+})
 
-    if (!promptType) {
-      return NextResponse.json(
-        { error: 'Missing required field: promptType' },
-        { status: 400 }
-      )
-    }
+export const POST = withApiHandler(
+  { authTier: 'authenticated', logContext: 'ai/load-prompt-template', inputSchema },
+  async ({ input, logger }) => {
+    const { promptType, publicationId } = input
+    const pubId = publicationId
 
     // Check if this is a module-based prompt type (e.g., "module-{uuid}-title" or "module-{uuid}-body")
     const moduleMatch = promptType.match(/^module-(.+)-(title|body)$/)
@@ -63,33 +62,33 @@ export const POST = withApiHandler(
         title: '{{title}}',
         description: '{{description}}',
         content: '{{content}}'
-      })
+      }, pubId)
     } else if (promptType === 'primary-body') {
       templatePrompt = await AI_PROMPTS.primaryArticleBody({
         title: '{{title}}',
         description: '{{description}}',
         content: '{{content}}',
         source_url: '{{url}}'
-      }, '{{headline}}')
+      }, '{{headline}}', pubId)
     } else if (promptType === 'secondary-title') {
       templatePrompt = await AI_PROMPTS.secondaryArticleTitle({
         title: '{{title}}',
         description: '{{description}}',
         content: '{{content}}'
-      })
+      }, pubId)
     } else if (promptType === 'secondary-body') {
       templatePrompt = await AI_PROMPTS.secondaryArticleBody({
         title: '{{title}}',
         description: '{{description}}',
         content: '{{content}}',
         source_url: '{{url}}'
-      }, '{{headline}}')
+      }, '{{headline}}', pubId)
     } else if (promptType === 'post-scorer') {
       templatePrompt = await AI_PROMPTS.criteria1Evaluator({
         title: '{{title}}',
         description: '{{description}}',
         content: '{{content}}'
-      })
+      }, pubId)
     } else if (promptType === 'subject-line') {
       templatePrompt = await AI_PROMPTS.subjectLineGenerator({
         headline: '{{headline}}',

--- a/src/app/api/cron/process-mailerlite-updates/route.ts
+++ b/src/app/api/cron/process-mailerlite-updates/route.ts
@@ -1,8 +1,8 @@
 import { withApiHandler } from '@/lib/api-handler'
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
-import { fetchAllPaginated } from '@/lib/dal/paginate'
-import { isIPExcluded, IPExclusion } from '@/lib/ip-utils'
+import { fetchAllPaginated, getExcludedIPs } from '@/lib/dal'
+import { isIPExcluded } from '@/lib/ip-utils'
 import { getEmailProviderSettings } from '@/lib/publication-settings'
 import { updateBeehiivSubscriberField } from '@/lib/beehiiv'
 import type { Logger } from '@/lib/logger'
@@ -117,33 +117,12 @@ async function syncRealClickStatus(log: Logger): Promise<{
 
   for (const publication of publications) {
     try {
-      // Get excluded IPs for this publication. Paginated past Supabase's
-      // 1000-row default — truncation here causes false positive clicker
-      // detection and re-sends the same MailerLite field updates indefinitely.
-      let exclusions: IPExclusion[] = []
-      try {
-        const excludedIpsData = await fetchAllPaginated<{
-          ip_address: string
-          is_range: boolean | null
-          cidr_prefix: number | null
-        }>(
-          () =>
-            supabaseAdmin
-              .from('excluded_ips')
-              .select('ip_address, is_range, cidr_prefix')
-              .eq('publication_id', publication.id),
-          { label: `process-mailerlite-updates:excluded_ips:${publication.slug}` },
-        )
-
-        exclusions = excludedIpsData.map(e => ({
-          ip_address: e.ip_address,
-          is_range: e.is_range || false,
-          cidr_prefix: e.cidr_prefix
-        }))
-      } catch (err) {
-        errors.push(`[${publication.slug}] Failed to fetch excluded IPs: ${err instanceof Error ? err.message : 'unknown'}`)
-        continue
-      }
+      // Without exclusions, bot clicks count as real clickers and re-send
+      // the same MailerLite field updates indefinitely.
+      const exclusions = await getExcludedIPs(
+        publication.id,
+        `process-mailerlite-updates:excluded_ips:${publication.slug}`,
+      )
 
       // Get ALL link clicks for this publication (paginated)
       const FETCH_BATCH = 1000

--- a/src/app/api/cron/process-mailerlite-updates/route.ts
+++ b/src/app/api/cron/process-mailerlite-updates/route.ts
@@ -2,7 +2,7 @@ import { withApiHandler } from '@/lib/api-handler'
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { fetchAllPaginated, getExcludedIPs } from '@/lib/dal'
-import { isIPExcluded } from '@/lib/ip-utils'
+import { isIPExcluded, type IPExclusion } from '@/lib/ip-utils'
 import { getEmailProviderSettings } from '@/lib/publication-settings'
 import { updateBeehiivSubscriberField } from '@/lib/beehiiv'
 import type { Logger } from '@/lib/logger'
@@ -117,12 +117,23 @@ async function syncRealClickStatus(log: Logger): Promise<{
 
   for (const publication of publications) {
     try {
-      // Without exclusions, bot clicks count as real clickers and re-send
-      // the same MailerLite field updates indefinitely.
-      const exclusions = await getExcludedIPs(
-        publication.id,
-        `process-mailerlite-updates:excluded_ips:${publication.slug}`,
-      )
+      // Without exclusions, bot clicks count as real clickers and trigger
+      // MailerLite/Beehiiv field writes. On a DB error we MUST skip the
+      // publication rather than degrade to empty exclusions — see the
+      // throwOnError docstring.
+      let exclusions: IPExclusion[]
+      try {
+        exclusions = await getExcludedIPs(
+          publication.id,
+          `process-mailerlite-updates:excluded_ips:${publication.slug}`,
+          { throwOnError: true },
+        )
+      } catch (err) {
+        errors.push(
+          `[${publication.slug}] Skipping — failed to fetch excluded IPs: ${err instanceof Error ? err.message : 'unknown'}`,
+        )
+        continue
+      }
 
       // Get ALL link clicks for this publication (paginated)
       const FETCH_BATCH = 1000

--- a/src/app/api/cron/process-mailerlite-updates/route.ts
+++ b/src/app/api/cron/process-mailerlite-updates/route.ts
@@ -117,17 +117,33 @@ async function syncRealClickStatus(log: Logger): Promise<{
 
   for (const publication of publications) {
     try {
-      // Get excluded IPs for this publication
-      const { data: excludedIpsData } = await supabaseAdmin
-        .from('excluded_ips')
-        .select('ip_address, is_range, cidr_prefix')
-        .eq('publication_id', publication.id)
+      // Get excluded IPs for this publication. Paginated past Supabase's
+      // 1000-row default — truncation here causes false positive clicker
+      // detection and re-sends the same MailerLite field updates indefinitely.
+      let exclusions: IPExclusion[] = []
+      try {
+        const excludedIpsData = await fetchAllPaginated<{
+          ip_address: string
+          is_range: boolean | null
+          cidr_prefix: number | null
+        }>(
+          () =>
+            supabaseAdmin
+              .from('excluded_ips')
+              .select('ip_address, is_range, cidr_prefix')
+              .eq('publication_id', publication.id),
+          { label: `process-mailerlite-updates:excluded_ips:${publication.slug}` },
+        )
 
-      const exclusions: IPExclusion[] = (excludedIpsData || []).map(e => ({
-        ip_address: e.ip_address,
-        is_range: e.is_range || false,
-        cidr_prefix: e.cidr_prefix
-      }))
+        exclusions = excludedIpsData.map(e => ({
+          ip_address: e.ip_address,
+          is_range: e.is_range || false,
+          cidr_prefix: e.cidr_prefix
+        }))
+      } catch (err) {
+        errors.push(`[${publication.slug}] Failed to fetch excluded IPs: ${err instanceof Error ? err.message : 'unknown'}`)
+        continue
+      }
 
       // Get ALL link clicks for this publication (paginated)
       const FETCH_BATCH = 1000

--- a/src/app/api/feedback/analytics/route.ts
+++ b/src/app/api/feedback/analytics/route.ts
@@ -55,6 +55,9 @@ export const GET = withApiHandler(
       shouldExcludeIps
         ? getExcludedIPs(publicationId, 'feedback/analytics:excluded_ips')
         : Promise.resolve<IPExclusion[]>([]),
+      // No .order() in the builder — Supabase paginates via offset, and
+      // ORDER BY + concurrent inserts can shift rows across page boundaries
+      // (duplicates or skips). Sort in-memory after fetch instead.
       fetchAllPaginated<FeedbackResponseRow>(
         () =>
           supabaseAdmin
@@ -62,8 +65,7 @@ export const GET = withApiHandler(
             .select('id, publication_id, campaign_date, section_choice, ip_address, mailerlite_updated, created_at')
             .eq('publication_id', publicationId!)
             .gte('campaign_date', startDateStr)
-            .lte('campaign_date', endDateStr)
-            .order('created_at', { ascending: false }),
+            .lte('campaign_date', endDateStr),
         { label: 'feedback/analytics:feedback_responses' },
       ),
     ])
@@ -103,7 +105,11 @@ export const GET = withApiHandler(
       return NextResponse.json({ error: err?.message ?? 'unknown error' }, { status: 500 })
     }
 
+    // Sort by created_at desc in-memory — see the .order() comment on the
+    // paginated query above for why we don't sort at the DB layer.
     const responsesRaw = responsesResult.value
+      .slice()
+      .sort((a, b) => b.created_at.localeCompare(a.created_at))
 
     // Filter out excluded IPs from analytics
     const responses = shouldExcludeIps && exclusions.length > 0
@@ -133,8 +139,15 @@ export const GET = withApiHandler(
     const successfulSyncs = responses.filter(r => r.mailerlite_updated).length
     const syncSuccessRate = totalResponses > 0 ? (successfulSyncs / totalResponses) * 100 : 0
 
-    // Get most recent responses
-    const recentResponses = responses.slice(0, 10)
+    // Get most recent responses. Project away ip_address (PII) and
+    // publication_id (already known to caller) before serializing.
+    const recentResponses = responses.slice(0, 10).map(r => ({
+      id: r.id,
+      campaign_date: r.campaign_date,
+      section_choice: r.section_choice,
+      mailerlite_updated: r.mailerlite_updated,
+      created_at: r.created_at,
+    }))
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/feedback/analytics/route.ts
+++ b/src/app/api/feedback/analytics/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
-import { isIPExcluded, IPExclusion } from '@/lib/ip-utils'
+import { isIPExcluded, type IPExclusion } from '@/lib/ip-utils'
 import { withApiHandler } from '@/lib/api-handler'
-import { fetchAllPaginated } from '@/lib/dal/paginate'
+import { fetchAllPaginated, getExcludedIPs } from '@/lib/dal'
 
 export const GET = withApiHandler(
   { authTier: 'authenticated', logContext: 'feedback/analytics' },
@@ -38,41 +38,10 @@ export const GET = withApiHandler(
 
     console.log(`[Feedback Analytics] Fetching for last ${days} days (${startDateStr} to ${endDateStr})`)
 
-    // Fetch excluded IPs if publication_id provided
-    let exclusions: IPExclusion[] = []
-    let excludedIpCount = 0
-
-    if (publicationId && shouldExcludeIps) {
-      try {
-        const excludedIpsData = await fetchAllPaginated<{
-          ip_address: string
-          is_range: boolean | null
-          cidr_prefix: number | null
-        }>(
-          () =>
-            supabaseAdmin
-              .from('excluded_ips')
-              .select('ip_address, is_range, cidr_prefix')
-              .eq('publication_id', publicationId!),
-          { label: 'feedback/analytics:excluded_ips' },
-        )
-
-        exclusions = excludedIpsData.map(e => ({
-          ip_address: e.ip_address,
-          is_range: e.is_range || false,
-          cidr_prefix: e.cidr_prefix
-        }))
-        excludedIpCount = exclusions.length
-      } catch (err) {
-        console.error('[Feedback Analytics] Failed to fetch excluded IPs:', err)
-        // Continue with empty exclusions — analytics still useful, just not IP-filtered
-      }
-    }
-
-    // Fetch feedback responses within date range, scoped to publication.
-    // Paginated past Supabase's 1000-row default — section/daily aggregates
-    // depend on the full set; truncation silently corrupts those metrics.
-    let responsesRaw: Array<{
+    // Both reads are independent — only depend on publicationId + date range.
+    // Run in parallel: feedback_responses dominates latency on a hot dashboard
+    // refresh, no point waiting for it sequentially after exclusions.
+    type FeedbackResponseRow = {
       id: string
       publication_id: string
       campaign_date: string
@@ -80,10 +49,13 @@ export const GET = withApiHandler(
       ip_address: string
       mailerlite_updated: boolean | null
       created_at: string
-    }> = []
+    }
 
-    try {
-      responsesRaw = await fetchAllPaginated<typeof responsesRaw[number]>(
+    const [exclusionsResult, responsesResult] = await Promise.allSettled([
+      shouldExcludeIps
+        ? getExcludedIPs(publicationId, 'feedback/analytics:excluded_ips')
+        : Promise.resolve<IPExclusion[]>([]),
+      fetchAllPaginated<FeedbackResponseRow>(
         () =>
           supabaseAdmin
             .from('feedback_responses')
@@ -93,8 +65,16 @@ export const GET = withApiHandler(
             .lte('campaign_date', endDateStr)
             .order('created_at', { ascending: false }),
         { label: 'feedback/analytics:feedback_responses' },
-      )
-    } catch (err: any) {
+      ),
+    ])
+
+    // getExcludedIPs swallows its own errors, so this branch is defensive only.
+    const exclusions: IPExclusion[] =
+      exclusionsResult.status === 'fulfilled' ? exclusionsResult.value : []
+    const excludedIpCount = exclusions.length
+
+    if (responsesResult.status === 'rejected') {
+      const err = responsesResult.reason as any
       console.error('[Feedback Analytics] Error fetching responses:', err)
       // If table doesn't exist or other DB error, return empty analytics
       const isMissingTable =
@@ -122,6 +102,8 @@ export const GET = withApiHandler(
       }
       return NextResponse.json({ error: err?.message ?? 'unknown error' }, { status: 500 })
     }
+
+    const responsesRaw = responsesResult.value
 
     // Filter out excluded IPs from analytics
     const responses = shouldExcludeIps && exclusions.length > 0

--- a/src/app/api/feedback/analytics/route.ts
+++ b/src/app/api/feedback/analytics/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { isIPExcluded, IPExclusion } from '@/lib/ip-utils'
 import { withApiHandler } from '@/lib/api-handler'
+import { fetchAllPaginated } from '@/lib/dal/paginate'
 
 export const GET = withApiHandler(
   { authTier: 'authenticated', logContext: 'feedback/analytics' },
@@ -42,37 +43,66 @@ export const GET = withApiHandler(
     let excludedIpCount = 0
 
     if (publicationId && shouldExcludeIps) {
-      const { data: excludedIpsData } = await supabaseAdmin
-        .from('excluded_ips')
-        .select('ip_address, is_range, cidr_prefix')
-        .eq('publication_id', publicationId)
+      try {
+        const excludedIpsData = await fetchAllPaginated<{
+          ip_address: string
+          is_range: boolean | null
+          cidr_prefix: number | null
+        }>(
+          () =>
+            supabaseAdmin
+              .from('excluded_ips')
+              .select('ip_address, is_range, cidr_prefix')
+              .eq('publication_id', publicationId!),
+          { label: 'feedback/analytics:excluded_ips' },
+        )
 
-      exclusions = (excludedIpsData || []).map(e => ({
-        ip_address: e.ip_address,
-        is_range: e.is_range || false,
-        cidr_prefix: e.cidr_prefix
-      }))
-      excludedIpCount = exclusions.length
+        exclusions = excludedIpsData.map(e => ({
+          ip_address: e.ip_address,
+          is_range: e.is_range || false,
+          cidr_prefix: e.cidr_prefix
+        }))
+        excludedIpCount = exclusions.length
+      } catch (err) {
+        console.error('[Feedback Analytics] Failed to fetch excluded IPs:', err)
+        // Continue with empty exclusions — analytics still useful, just not IP-filtered
+      }
     }
 
-    // Fetch feedback responses within date range, scoped to publication
-    const { data: responsesRaw, error } = await supabaseAdmin
-      .from('feedback_responses')
-      .select('id, publication_id, campaign_date, section_choice, ip_address, mailerlite_updated, created_at')
-      .eq('publication_id', publicationId)
-      .gte('campaign_date', startDateStr)
-      .lte('campaign_date', endDateStr)
-      .order('created_at', { ascending: false })
+    // Fetch feedback responses within date range, scoped to publication.
+    // Paginated past Supabase's 1000-row default — section/daily aggregates
+    // depend on the full set; truncation silently corrupts those metrics.
+    let responsesRaw: Array<{
+      id: string
+      publication_id: string
+      campaign_date: string
+      section_choice: string
+      ip_address: string
+      mailerlite_updated: boolean | null
+      created_at: string
+    }> = []
 
-    if (error) {
-      console.error('[Feedback Analytics] Error fetching responses:', error)
+    try {
+      responsesRaw = await fetchAllPaginated<typeof responsesRaw[number]>(
+        () =>
+          supabaseAdmin
+            .from('feedback_responses')
+            .select('id, publication_id, campaign_date, section_choice, ip_address, mailerlite_updated, created_at')
+            .eq('publication_id', publicationId!)
+            .gte('campaign_date', startDateStr)
+            .lte('campaign_date', endDateStr)
+            .order('created_at', { ascending: false }),
+        { label: 'feedback/analytics:feedback_responses' },
+      )
+    } catch (err: any) {
+      console.error('[Feedback Analytics] Error fetching responses:', err)
       // If table doesn't exist or other DB error, return empty analytics
       const isMissingTable =
-        error.code === 'PGRST116' ||
-        error.code === '42P01' ||
-        error.message?.includes('relation') ||
-        error.message?.includes('does not exist') ||
-        error.message?.includes('feedback_responses')
+        err?.code === 'PGRST116' ||
+        err?.code === '42P01' ||
+        err?.message?.includes('relation') ||
+        err?.message?.includes('does not exist') ||
+        err?.message?.includes('feedback_responses')
 
       if (isMissingTable) {
         console.log('[Feedback Analytics] Table not found - returning empty analytics')
@@ -90,14 +120,14 @@ export const GET = withApiHandler(
           }
         })
       }
-      return NextResponse.json({ error: error.message }, { status: 500 })
+      return NextResponse.json({ error: err?.message ?? 'unknown error' }, { status: 500 })
     }
 
     // Filter out excluded IPs from analytics
     const responses = shouldExcludeIps && exclusions.length > 0
-      ? (responsesRaw || []).filter(r => !isIPExcluded(r.ip_address, exclusions))
-      : (responsesRaw || [])
-    const excludedResponseCount = (responsesRaw?.length || 0) - responses.length
+      ? responsesRaw.filter(r => !isIPExcluded(r.ip_address, exclusions))
+      : responsesRaw
+    const excludedResponseCount = responsesRaw.length - responses.length
 
     if (excludedResponseCount > 0) {
       console.log(`[Feedback Analytics] Filtered ${excludedResponseCount} responses from ${excludedIpCount} excluded IP(s)`)

--- a/src/app/api/images/ingest/route.ts
+++ b/src/app/api/images/ingest/route.ts
@@ -24,7 +24,7 @@ export const POST = withApiHandler(
     // Get image record from database
     const { data: image, error: fetchError } = await supabaseAdmin
       .from('images')
-      .select('*')
+      .select('id, cdn_url, variant_16x9_url')
       .eq('id', image_id)
       .single()
 

--- a/src/app/api/images/ingest/route.ts
+++ b/src/app/api/images/ingest/route.ts
@@ -16,8 +16,8 @@ interface IngestRequest {
 }
 
 export const POST = withApiHandler(
-  { authTier: 'authenticated', logContext: 'images/ingest' },
-  async ({ request }) => {
+  { authTier: 'authenticated', logContext: 'images/ingest', requirePublicationId: true },
+  async ({ request, publicationId }) => {
     const body: IngestRequest = await request.json()
     const { image_id, source_url, license, credit, location } = body
 
@@ -39,8 +39,8 @@ export const POST = withApiHandler(
     const imageUrl = image.cdn_url
 
     try {
-      // Get image analyzer prompt from database
-      const imageAnalyzerPrompt = await AI_PROMPTS.imageAnalyzer()
+      // Get image analyzer prompt from database (publication-scoped with app_settings fallback)
+      const imageAnalyzerPrompt = await AI_PROMPTS.imageAnalyzer(publicationId!)
 
       // Analyze image with OpenAI Vision using Responses API
       const response = await (openai as any).responses.create({

--- a/src/app/api/link-tracking/analytics/route.ts
+++ b/src/app/api/link-tracking/analytics/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { isIPExcluded, IPExclusion } from '@/lib/ip-utils'
 import { withApiHandler } from '@/lib/api-handler'
+import { fetchAllPaginated } from '@/lib/dal/paginate'
 
 /**
  * Link Click Analytics Endpoint
@@ -40,19 +41,34 @@ export const GET = withApiHandler(
       publicationId = newsletter.id
     }
 
-    // Fetch excluded IPs for this publication (if we have a publication_id)
+    // Fetch excluded IPs for this publication (if we have a publication_id).
+    // Paginated past Supabase's 1000-row default — without this, missing
+    // exclusions cause bot clicks to be counted as real, inflating CTR.
     let exclusions: IPExclusion[] = []
     if (publicationId) {
-      const { data: excludedIpsData } = await supabaseAdmin
-        .from('excluded_ips')
-        .select('ip_address, is_range, cidr_prefix')
-        .eq('publication_id', publicationId)
+      try {
+        const excludedIpsData = await fetchAllPaginated<{
+          ip_address: string
+          is_range: boolean | null
+          cidr_prefix: number | null
+        }>(
+          () =>
+            supabaseAdmin
+              .from('excluded_ips')
+              .select('ip_address, is_range, cidr_prefix')
+              .eq('publication_id', publicationId!),
+          { label: 'link-tracking/analytics:excluded_ips' },
+        )
 
-      exclusions = (excludedIpsData || []).map(e => ({
-        ip_address: e.ip_address,
-        is_range: e.is_range || false,
-        cidr_prefix: e.cidr_prefix
-      }))
+        exclusions = excludedIpsData.map(e => ({
+          ip_address: e.ip_address,
+          is_range: e.is_range || false,
+          cidr_prefix: e.cidr_prefix
+        }))
+      } catch (err) {
+        console.error('[Link Analytics] Failed to fetch excluded IPs:', err)
+        // Continue with empty exclusions — analytics still works, just unfiltered
+      }
     }
 
     // Calculate date range using local timezone

--- a/src/app/api/link-tracking/analytics/route.ts
+++ b/src/app/api/link-tracking/analytics/route.ts
@@ -67,7 +67,7 @@ export const GET = withApiHandler(
     while (hasMore) {
       let query = supabaseAdmin
         .from('link_clicks')
-        .select('*')
+        .select('id, ip_address, link_section, link_url, subscriber_email, issue_date, clicked_at')
         .gte('issue_date', startDateStr)
         .lte('issue_date', endDateStr)
         .order('clicked_at', { ascending: false })

--- a/src/app/api/link-tracking/analytics/route.ts
+++ b/src/app/api/link-tracking/analytics/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
-import { isIPExcluded, IPExclusion } from '@/lib/ip-utils'
+import { isIPExcluded } from '@/lib/ip-utils'
 import { withApiHandler } from '@/lib/api-handler'
-import { fetchAllPaginated } from '@/lib/dal/paginate'
+import { getExcludedIPs } from '@/lib/dal'
 
 /**
  * Link Click Analytics Endpoint
@@ -41,35 +41,11 @@ export const GET = withApiHandler(
       publicationId = newsletter.id
     }
 
-    // Fetch excluded IPs for this publication (if we have a publication_id).
-    // Paginated past Supabase's 1000-row default — without this, missing
-    // exclusions cause bot clicks to be counted as real, inflating CTR.
-    let exclusions: IPExclusion[] = []
-    if (publicationId) {
-      try {
-        const excludedIpsData = await fetchAllPaginated<{
-          ip_address: string
-          is_range: boolean | null
-          cidr_prefix: number | null
-        }>(
-          () =>
-            supabaseAdmin
-              .from('excluded_ips')
-              .select('ip_address, is_range, cidr_prefix')
-              .eq('publication_id', publicationId!),
-          { label: 'link-tracking/analytics:excluded_ips' },
-        )
-
-        exclusions = excludedIpsData.map(e => ({
-          ip_address: e.ip_address,
-          is_range: e.is_range || false,
-          cidr_prefix: e.cidr_prefix
-        }))
-      } catch (err) {
-        console.error('[Link Analytics] Failed to fetch excluded IPs:', err)
-        // Continue with empty exclusions — analytics still works, just unfiltered
-      }
-    }
+    // Without exclusions, bot clicks count as real and inflate CTR. The DAL
+    // helper paginates past the 1000-row default and swallows errors.
+    const exclusions = publicationId
+      ? await getExcludedIPs(publicationId, 'link-tracking/analytics:excluded_ips')
+      : []
 
     // Calculate date range using local timezone
     const endDate = new Date()

--- a/src/lib/__tests__/publication-settings-typed.test.ts
+++ b/src/lib/__tests__/publication-settings-typed.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// vi.hoisted runs before the hoisted vi.mock factory, so symbols declared
+// here are available at mock-construction time.
+const mocks = vi.hoisted(() => {
+  let chainResult: { data: any; error: any } = { data: null, error: null }
+  const mockChain: any = {}
+  mockChain.select = (..._args: any[]) => mockChain
+  mockChain.eq = (..._args: any[]) => mockChain
+  mockChain.in = (..._args: any[]) => mockChain
+  mockChain.then = (onFulfilled: any) => Promise.resolve(chainResult).then(onFulfilled)
+
+  return {
+    setResult(r: { data: any; error: any }) { chainResult = r },
+    reset() { chainResult = { data: null, error: null } },
+    mockChain,
+    mockFrom: vi.fn(() => mockChain),
+  }
+})
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: mocks.mockFrom },
+}))
+
+vi.mock('../env-guard', () => ({
+  shouldApplySendGuards: vi.fn().mockReturnValue(false),
+}))
+
+import { getAIAppSettings, getDirectorySettings, getSlackSettings } from '../publication-settings'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.reset()
+})
+
+// ---------------------------------------------------------------------------
+describe('getAIAppSettings', () => {
+  it('returns parsed numeric values from publication_settings', async () => {
+    mocks.setResult({
+      data: [
+        { key: 'ai_apps_per_newsletter', value: '8' },
+        { key: 'ai_apps_max_per_category', value: '4' },
+        { key: 'affiliate_cooldown_days', value: '14' },
+      ],
+      error: null,
+    })
+    const result = await getAIAppSettings('pub-1')
+    expect(result).toEqual({
+      totalApps: 8,
+      maxPerCategory: 4,
+      affiliateCooldownDays: 14,
+    })
+  })
+
+  it('returns hardcoded defaults when settings are missing', async () => {
+    mocks.setResult({ data: [], error: null })
+    const result = await getAIAppSettings('pub-1')
+    expect(result).toEqual({
+      totalApps: 6,
+      maxPerCategory: 3,
+      affiliateCooldownDays: 7,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('getDirectorySettings', () => {
+  it('returns parsed numeric values from publication_settings', async () => {
+    mocks.setResult({
+      data: [
+        { key: 'directory_paid_placement_price', value: '49.99' },
+        { key: 'directory_featured_price', value: '99.50' },
+        { key: 'directory_yearly_discount_months', value: '3' },
+      ],
+      error: null,
+    })
+    const result = await getDirectorySettings('pub-1')
+    expect(result).toEqual({
+      paidPlacementPrice: 49.99,
+      featuredPrice: 99.5,
+      yearlyDiscountMonths: 3,
+    })
+  })
+
+  it('returns hardcoded defaults matching the prior DEFAULT_PRICING', async () => {
+    mocks.setResult({ data: [], error: null })
+    const result = await getDirectorySettings('pub-1')
+    expect(result).toEqual({
+      paidPlacementPrice: 30,
+      featuredPrice: 60,
+      yearlyDiscountMonths: 2,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('getSlackSettings null-publication path', () => {
+  it('skips publication_settings query when publicationId is null', async () => {
+    mocks.setResult({
+      data: [
+        { key: 'slack_webhook_url', value: 'https://hooks.example.com/abc' },
+        { key: 'slack_low_article_count_enabled', value: 'true' },
+        { key: 'slack_rss_processing_updates_enabled', value: 'false' },
+      ],
+      error: null,
+    })
+    const result = await getSlackSettings(null)
+    expect(result.webhook_url).toBe('https://hooks.example.com/abc')
+    expect(result.low_article_count_enabled).toBe(true)
+    expect(result.rss_processing_updates_enabled).toBe(false)
+
+    expect(mocks.mockFrom.mock.calls.some((c: any[]) => c[0] === 'publication_settings')).toBe(false)
+    expect(mocks.mockFrom.mock.calls.some((c: any[]) => c[0] === 'app_settings')).toBe(true)
+  })
+
+  it('uses publication→app fallback when a publicationId is provided', async () => {
+    mocks.setResult({
+      data: [{ key: 'slack_webhook_url', value: 'https://pub.example.com/xyz' }],
+      error: null,
+    })
+    const result = await getSlackSettings('pub-1')
+    expect(result.webhook_url).toBe('https://pub.example.com/xyz')
+
+    expect(mocks.mockFrom.mock.calls.some((c: any[]) => c[0] === 'publication_settings')).toBe(true)
+  })
+})

--- a/src/lib/app-selector.ts
+++ b/src/lib/app-selector.ts
@@ -88,10 +88,21 @@ export class AppSelector {
       const { totalApps, maxPerCategory, affiliateCooldownDays } = await this.getAppSettings(newsletterId)
       console.log(`[AppSelector] Settings: totalApps=${totalApps}, maxPerCategory=${maxPerCategory}, cooldown=${affiliateCooldownDays} days`)
 
-      // Get all active apps for this newsletter
+      // Get all active apps for this newsletter. AIApplication has ~40
+      // columns and downstream callers spread the full row; explicit list.
       const { data: allApps, error: appsError } = await supabaseAdmin
         .from('ai_applications')
-        .select('*')
+        .select(`
+          id, publication_id, app_name, tagline, description, category, app_url,
+          tracked_link, logo_url, logo_alt, screenshot_url, screenshot_alt, tool_type,
+          category_priority, is_featured, is_paid_placement, is_affiliate, is_active,
+          display_order, last_used_date, times_used, created_at, updated_at,
+          clerk_user_id, submitter_email, submitter_name, submitter_image_url,
+          submission_status, rejection_reason, approved_by, approved_at,
+          plan, stripe_payment_id, stripe_subscription_id, stripe_customer_id,
+          sponsor_start_date, sponsor_end_date, view_count, click_count,
+          ai_app_module_id, priority, pinned_position, button_text
+        `)
         .eq('publication_id', newsletterId)
         .eq('is_active', true)
 

--- a/src/lib/app-selector.ts
+++ b/src/lib/app-selector.ts
@@ -1,9 +1,10 @@
 import { supabaseAdmin } from './supabase'
+import { getAIAppSettings } from './publication-settings'
 import type { AIApplication } from '@/types/database'
 
 export class AppSelector {
   /**
-   * Get app selection settings from publication_settings table
+   * Get app selection settings via the typed DAL helper (publication→app fallback).
    */
   private static async getAppSettings(newsletterId: string): Promise<{
     totalApps: number
@@ -11,26 +12,13 @@ export class AppSelector {
     affiliateCooldownDays: number
   }> {
     try {
-      const { data: settings } = await supabaseAdmin
-        .from('publication_settings')
-        .select('key, value')
-        .eq('publication_id', newsletterId)
-        .in('key', ['ai_apps_per_newsletter', 'ai_apps_max_per_category', 'affiliate_cooldown_days'])
-
-      const settingsMap = new Map(settings?.map(s => [s.key, parseInt(s.value || '0')]) || [])
-
-      return {
-        totalApps: settingsMap.get('ai_apps_per_newsletter') || 6,
-        maxPerCategory: settingsMap.get('ai_apps_max_per_category') || 3,
-        affiliateCooldownDays: settingsMap.get('affiliate_cooldown_days') || 7
-      }
+      return await getAIAppSettings(newsletterId)
     } catch (error) {
       console.error('Error fetching app settings:', error)
-      // Return defaults
       return {
         totalApps: 6,
         maxPerCategory: 3,
-        affiliateCooldownDays: 7
+        affiliateCooldownDays: 7,
       }
     }
   }

--- a/src/lib/breaking-news-processor.ts
+++ b/src/lib/breaking-news-processor.ts
@@ -3,6 +3,7 @@ import { supabaseAdmin } from './supabase'
 import { callOpenAI } from './openai'
 import { AI_PROMPTS } from './openai/prompt-loaders'
 import { ErrorHandler, SlackNotificationService } from './slack'
+import { getIssuePublicationId } from './dal/issues'
 import type { RssFeed, RssPost } from '@/types/database'
 
 const parser = new Parser({
@@ -192,6 +193,14 @@ export class BreakingNewsProcessor {
   private async scoreAndCategorizeArticles(issueId: string) {
     console.log('Starting Breaking News scoring and categorization...')
 
+    // Resolve publication once so per-publication prompt overrides apply
+    const publicationId = await getIssuePublicationId(issueId)
+    if (!publicationId) {
+      console.error(
+        `[BreakingNews] Could not resolve publicationId for issue ${issueId} — scoring will use app-wide / fallback prompts`,
+      )
+    }
+
     // Get all posts for this issue that haven't been scored yet
     const { data: posts, error } = await supabaseAdmin
       .from('rss_posts')
@@ -223,7 +232,7 @@ export class BreakingNewsProcessor {
           console.log(`Scoring post ${overallIndex}/${posts.length}: ${post.title}`)
 
           // Score the article
-          const score = await this.scoreArticle(post)
+          const score = await this.scoreArticle(post, publicationId ?? undefined)
 
           // Generate summary and title
           const summary = await this.generateSummaryAndTitle(post)
@@ -285,12 +294,12 @@ export class BreakingNewsProcessor {
     })
   }
 
-  private async scoreArticle(post: RssPost): Promise<BreakingNewsScore> {
+  private async scoreArticle(post: RssPost, publicationId?: string): Promise<BreakingNewsScore> {
     const prompt = await AI_PROMPTS.breakingNewsScorer({
       title: post.title,
       description: post.description || '',
       content: post.content || ''
-    })
+    }, publicationId)
 
     const result = await callOpenAI(prompt, 1000, 0.3)
 

--- a/src/lib/breaking-news-processor.ts
+++ b/src/lib/breaking-news-processor.ts
@@ -44,10 +44,15 @@ export class BreakingNewsProcessor {
     console.log('Starting Breaking News RSS processing for issue:', issueId)
 
     try {
-      // Get active Breaking News RSS feeds
+      // Get active Breaking News RSS feeds. processFeed() consumes the full
+      // RssFeed shape, hence the explicit column list.
       const { data: feeds, error: feedsError } = await supabaseAdmin
         .from('rss_feeds')
-        .select('*')
+        .select(`
+          id, publication_id, url, name, description, active,
+          use_for_primary_section, use_for_secondary_section, article_module_id,
+          last_processed, last_error, processing_errors, created_at, updated_at
+        `)
         .eq('active', true)
         .not('publication_id', 'is', null) // Only feeds associated with a newsletter
 
@@ -201,10 +206,19 @@ export class BreakingNewsProcessor {
       )
     }
 
-    // Get all posts for this issue that haven't been scored yet
+    // Get all posts for this issue that haven't been scored yet.
+    // scoreArticle/generateSummaryAndTitle take the full RssPost shape.
     const { data: posts, error } = await supabaseAdmin
       .from('rss_posts')
-      .select('*')
+      .select(`
+        id, feed_id, issue_id, article_module_id, external_id, title, description,
+        content, full_article_text, author, publication_date, source_url, image_url,
+        image_alt, processed_at, breaking_news_score, breaking_news_category,
+        ai_summary, ai_title, extraction_status, extraction_error,
+        criteria_1_score, criteria_1_reason, criteria_2_score, criteria_2_reason,
+        criteria_3_score, criteria_3_reason, criteria_4_score, criteria_4_reason,
+        criteria_5_score, criteria_5_reason, final_priority_score, criteria_enabled
+      `)
       .eq('issue_id', issueId)
       .is('breaking_news_score', null) // Only score unscored posts
 

--- a/src/lib/dal/__tests__/excluded-ips.test.ts
+++ b/src/lib/dal/__tests__/excluded-ips.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports that use them
+// ---------------------------------------------------------------------------
+let mockChainResult: { data: any; error: any } = { data: null, error: null }
+
+const mockChain: Record<string, any> = {
+  select: vi.fn(function () { return mockChain }),
+  eq: vi.fn(function () { return mockChain }),
+  range: vi.fn(function () { return Promise.resolve(mockChainResult) }),
+}
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: vi.fn(() => mockChain) },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    correlationId: 'test-id',
+  })),
+}))
+
+import { getExcludedIPs } from '../excluded-ips'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockChainResult = { data: null, error: null }
+  mockChain.select.mockReturnValue(mockChain)
+  mockChain.eq.mockReturnValue(mockChain)
+})
+
+describe('getExcludedIPs', () => {
+  it('returns normalized IPExclusion[] with is_range coerced to boolean', async () => {
+    mockChainResult = {
+      data: [
+        { ip_address: '1.2.3.4', is_range: false, cidr_prefix: null },
+        { ip_address: '10.0.0.0', is_range: true, cidr_prefix: 24 },
+        { ip_address: '5.6.7.8', is_range: null, cidr_prefix: null }, // null → false
+      ],
+      error: null,
+    }
+
+    const result = await getExcludedIPs('pub-1')
+
+    expect(result).toEqual([
+      { ip_address: '1.2.3.4', is_range: false, cidr_prefix: null },
+      { ip_address: '10.0.0.0', is_range: true, cidr_prefix: 24 },
+      { ip_address: '5.6.7.8', is_range: false, cidr_prefix: null },
+    ])
+  })
+
+  it('returns empty array when publicationId is empty (defensive guard)', async () => {
+    const result = await getExcludedIPs('')
+    expect(result).toEqual([])
+    // Did NOT issue a query
+    expect(mockChain.range).not.toHaveBeenCalled()
+  })
+
+  it('returns empty array on DB error (errors swallowed, not thrown)', async () => {
+    mockChainResult = { data: null, error: { message: 'connection reset' } }
+
+    const result = await getExcludedIPs('pub-1')
+    expect(result).toEqual([])
+  })
+
+  it('uses the provided label for pagination logging', async () => {
+    mockChainResult = { data: [], error: null }
+
+    await getExcludedIPs('pub-1', 'custom-label')
+    // Range was called (i.e. fetchAllPaginated ran)
+    expect(mockChain.range).toHaveBeenCalled()
+  })
+})

--- a/src/lib/dal/__tests__/excluded-ips.test.ts
+++ b/src/lib/dal/__tests__/excluded-ips.test.ts
@@ -8,6 +8,7 @@ let mockChainResult: { data: any; error: any } = { data: null, error: null }
 const mockChain: Record<string, any> = {
   select: vi.fn(function () { return mockChain }),
   eq: vi.fn(function () { return mockChain }),
+  order: vi.fn(function () { return mockChain }),
   range: vi.fn(function () { return Promise.resolve(mockChainResult) }),
 }
 
@@ -32,6 +33,7 @@ beforeEach(() => {
   mockChainResult = { data: null, error: null }
   mockChain.select.mockReturnValue(mockChain)
   mockChain.eq.mockReturnValue(mockChain)
+  mockChain.order.mockReturnValue(mockChain)
 })
 
 describe('getExcludedIPs', () => {
@@ -74,5 +76,27 @@ describe('getExcludedIPs', () => {
     await getExcludedIPs('pub-1', 'custom-label')
     // Range was called (i.e. fetchAllPaginated ran)
     expect(mockChain.range).toHaveBeenCalled()
+  })
+
+  it('orders by id for stable offset pagination', async () => {
+    mockChainResult = { data: [], error: null }
+
+    await getExcludedIPs('pub-1')
+    expect(mockChain.order).toHaveBeenCalledWith('id')
+  })
+
+  it('throws on DB error when throwOnError: true is passed', async () => {
+    mockChainResult = { data: null, error: { message: 'connection reset' } }
+
+    await expect(
+      getExcludedIPs('pub-1', 'cron-label', { throwOnError: true }),
+    ).rejects.toBeDefined()
+  })
+
+  it('still swallows on DB error when throwOnError is false (default)', async () => {
+    mockChainResult = { data: null, error: { message: 'connection reset' } }
+
+    const result = await getExcludedIPs('pub-1', 'analytics-label')
+    expect(result).toEqual([])
   })
 })

--- a/src/lib/dal/excluded-ips.ts
+++ b/src/lib/dal/excluded-ips.ts
@@ -11,9 +11,11 @@
  * truncation causes false-positive clicker detection.
  *
  * Conventions match `dal/posts.ts`:
- *  - Returns `IPExclusion[]` (never null); empty array on error or no rows.
- *  - Errors are logged and swallowed — analytics still works without
- *    exclusions, just unfiltered.
+ *  - Default returns `IPExclusion[]` (never null); empty array on error
+ *    or no rows. Errors are logged via pino and swallowed.
+ *  - Pass `{ throwOnError: true }` for callers (e.g. crons writing to
+ *    external systems) where empty-on-error would cause incorrect downstream
+ *    writes. The error then propagates to the caller's try/catch.
  */
 
 import { supabaseAdmin } from '@/lib/supabase'
@@ -23,16 +25,31 @@ import type { IPExclusion } from '@/lib/ip-utils'
 
 const log = createLogger({ module: 'dal:excluded-ips' })
 
+export interface GetExcludedIPsOptions {
+  /**
+   * When true, DB errors propagate to the caller instead of being swallowed.
+   * Use for callers that drive external writes (e.g. MailerLite cron) where
+   * an empty exclusion list silently promotes bot clicks to real ones.
+   * Default: false (swallow + return []).
+   */
+  throwOnError?: boolean
+}
+
 /**
  * Fetch all excluded IPs for a publication, normalized to the `IPExclusion`
  * shape used by `isIPExcluded()`.
  *
+ * Pagination order is keyed on `id` (PK) so offset windows are stable —
+ * concurrent inserts can't shift rows across page boundaries.
+ *
  * @param publicationId - Tenant scope. Must be non-empty.
  * @param label - Optional context tag for the pagination log line.
+ * @param options - See `GetExcludedIPsOptions`.
  */
 export async function getExcludedIPs(
   publicationId: string,
   label?: string,
+  options: GetExcludedIPsOptions = {},
 ): Promise<IPExclusion[]> {
   if (!publicationId) return []
 
@@ -46,7 +63,8 @@ export async function getExcludedIPs(
         supabaseAdmin
           .from('excluded_ips')
           .select('ip_address, is_range, cidr_prefix')
-          .eq('publication_id', publicationId),
+          .eq('publication_id', publicationId)
+          .order('id'),
       { label: label ?? `dal:excluded-ips:${publicationId}` },
     )
 
@@ -57,6 +75,7 @@ export async function getExcludedIPs(
     }))
   } catch (err) {
     log.error({ err, publicationId, label }, 'getExcludedIPs failed')
+    if (options.throwOnError) throw err
     return []
   }
 }

--- a/src/lib/dal/excluded-ips.ts
+++ b/src/lib/dal/excluded-ips.ts
@@ -1,0 +1,62 @@
+/**
+ * Data Access Layer — Excluded IPs Domain
+ *
+ * Centralizes the `excluded_ips` fetch+normalize that's needed by every
+ * analytics endpoint and cron that filters bot/honeypot traffic. The shape
+ * mirrors `IPExclusion` from `ip-utils.ts` so callers can pass the result
+ * directly into `isIPExcluded()`.
+ *
+ * The query is paginated past Supabase's 1000-row default — bot-detection
+ * lists for long-running publications can grow past that, and silent
+ * truncation causes false-positive clicker detection.
+ *
+ * Conventions match `dal/posts.ts`:
+ *  - Returns `IPExclusion[]` (never null); empty array on error or no rows.
+ *  - Errors are logged and swallowed — analytics still works without
+ *    exclusions, just unfiltered.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { createLogger } from '@/lib/logger'
+import { fetchAllPaginated } from '@/lib/dal/paginate'
+import type { IPExclusion } from '@/lib/ip-utils'
+
+const log = createLogger({ module: 'dal:excluded-ips' })
+
+/**
+ * Fetch all excluded IPs for a publication, normalized to the `IPExclusion`
+ * shape used by `isIPExcluded()`.
+ *
+ * @param publicationId - Tenant scope. Must be non-empty.
+ * @param label - Optional context tag for the pagination log line.
+ */
+export async function getExcludedIPs(
+  publicationId: string,
+  label?: string,
+): Promise<IPExclusion[]> {
+  if (!publicationId) return []
+
+  try {
+    const rows = await fetchAllPaginated<{
+      ip_address: string
+      is_range: boolean | null
+      cidr_prefix: number | null
+    }>(
+      () =>
+        supabaseAdmin
+          .from('excluded_ips')
+          .select('ip_address, is_range, cidr_prefix')
+          .eq('publication_id', publicationId),
+      { label: label ?? `dal:excluded-ips:${publicationId}` },
+    )
+
+    return rows.map(e => ({
+      ip_address: e.ip_address,
+      is_range: e.is_range || false,
+      cidr_prefix: e.cidr_prefix,
+    }))
+  } catch (err) {
+    log.error({ err, publicationId, label }, 'getExcludedIPs failed')
+    return []
+  }
+}

--- a/src/lib/dal/index.ts
+++ b/src/lib/dal/index.ts
@@ -82,6 +82,9 @@ export {
 } from './dedup'
 export type { NewDuplicatePost, DeduplicationResultInput, DeduplicationResultOutput } from './dedup'
 
+// Excluded IPs DAL — bot/honeypot exclusion list
+export { getExcludedIPs } from './excluded-ips'
+
 // Pagination helper — most callers want fetchAllPaginated directly
 export { fetchAllPaginated } from './paginate'
 export type { FetchAllPaginatedOptions } from './paginate'

--- a/src/lib/dal/index.ts
+++ b/src/lib/dal/index.ts
@@ -5,6 +5,7 @@
  *   import { getIssueById, createIssue } from '@/lib/dal'
  */
 
+// Issues DAL
 export {
   getIssueById,
   getIssueByDate,
@@ -27,3 +28,60 @@ export {
   getIssueEngagement,
   getModuleEngagement,
 } from './analytics'
+
+// Posts DAL — rss_posts + post_ratings
+export {
+  POST_WITH_RATINGS_BRIEF,
+  getExistingExternalIds,
+  listPostsByIssue,
+  listPostsForScoring,
+  listAssignedPostsForModule,
+  listExtractedPostsByIds,
+  listPendingExtractionPosts,
+  listPostsForExtractionByIssue,
+  getRatedPostIds,
+  insertPost,
+  updatePostExtraction,
+  assignPostsToIssue,
+  unassignPosts,
+  applyExtractionResult,
+  insertPostRating,
+} from './posts'
+
+// Articles DAL — module_articles + manual_articles
+export {
+  MODULE_ARTICLE_COLUMNS,
+  MODULE_ARTICLE_BODY_GEN_SELECT,
+  MODULE_ARTICLE_FACT_CHECK_SELECT,
+  MANUAL_ARTICLE_COLUMNS,
+  MANUAL_ARTICLE_WITH_CATEGORY_SELECT,
+  listModuleArticlesByIssue,
+  moduleArticleExists,
+  listArticlesNeedingBody,
+  listArticlesNeedingFactCheck,
+  insertModuleArticle,
+  updateModuleArticleContent,
+  updateModuleArticleFactCheck,
+  listManualArticlesByPublication,
+  findNextAvailableSlug,
+  insertManualArticle,
+  updateManualArticle,
+  deleteManualArticle,
+} from './articles'
+export type { NewModuleArticle, ManualArticleRow, NewManualArticle } from './articles'
+
+// Dedup DAL — duplicate_groups + duplicate_posts
+export {
+  isIssueDeduplicated,
+  listDuplicateGroupIdsByIssue,
+  listDuplicatePostIdsByGroups,
+  listDuplicatePostsForGroup,
+  createDuplicateGroup,
+  addDuplicatePostToGroup,
+  storeDeduplicationResult,
+} from './dedup'
+export type { NewDuplicatePost, DeduplicationResultInput, DeduplicationResultOutput } from './dedup'
+
+// Pagination helper — most callers want fetchAllPaginated directly
+export { fetchAllPaginated } from './paginate'
+export type { FetchAllPaginatedOptions } from './paginate'

--- a/src/lib/directory.ts
+++ b/src/lib/directory.ts
@@ -3,6 +3,20 @@ import { PUBLICATION_ID } from './config'
 import { getDirectorySettings } from './publication-settings'
 import type { AIApplication, AIAppCategory } from '@/types/database'
 
+// Full ai_applications column list. transformApp() spreads the entire row,
+// so every consumer of getApprovedTools/getToolById/etc. needs all columns.
+const AI_APPLICATION_COLUMNS = `
+  id, publication_id, app_name, tagline, description, category, app_url,
+  tracked_link, logo_url, logo_alt, screenshot_url, screenshot_alt, tool_type,
+  category_priority, is_featured, is_paid_placement, is_affiliate, is_active,
+  display_order, last_used_date, times_used, created_at, updated_at,
+  clerk_user_id, submitter_email, submitter_name, submitter_image_url,
+  submission_status, rejection_reason, approved_by, approved_at,
+  plan, stripe_payment_id, stripe_subscription_id, stripe_customer_id,
+  sponsor_start_date, sponsor_end_date, view_count, click_count,
+  ai_app_module_id, priority, pinned_position, button_text
+` as const
+
 // Categories derived from AIAppCategory type
 const CATEGORIES: { id: string; name: AIAppCategory; slug: string; description: string }[] = [
   { id: 'accounting-bookkeeping', name: 'Accounting & Bookkeeping', slug: 'accounting-bookkeeping', description: 'Discover top AI accounting software and bookkeeping tools that automate journal entries, reconciliations, and financial reporting for accountants and firms.' },
@@ -71,7 +85,7 @@ export async function getApprovedTools(publicationId?: string): Promise<Director
   // Get apps: either no module (backwards compatible) or in a visible module
   const { data: apps, error } = await supabaseAdmin
     .from('ai_applications')
-    .select('*')
+    .select(AI_APPLICATION_COLUMNS)
     .eq('publication_id', pubId)
     .eq('is_active', true)
     .or(`ai_app_module_id.is.null,ai_app_module_id.in.(${visibleModuleIds.join(',')})`)
@@ -138,7 +152,7 @@ export async function getToolById(toolId: string, publicationId?: string): Promi
   const pubId = publicationId || PUBLICATION_ID
   const { data: app, error } = await supabaseAdmin
     .from('ai_applications')
-    .select('*')
+    .select(AI_APPLICATION_COLUMNS)
     .eq('id', toolId)
     .eq('publication_id', pubId)
     .single()
@@ -178,7 +192,7 @@ export async function getToolsByCategory(categorySlug: string, publicationId?: s
   // Get tools in this category (filtered by directory visibility)
   const { data: apps, error } = await supabaseAdmin
     .from('ai_applications')
-    .select('*')
+    .select(AI_APPLICATION_COLUMNS)
     .eq('publication_id', pubId)
     .eq('is_active', true)
     .eq('category', category.name)
@@ -216,7 +230,7 @@ export async function searchTools(query: string, publicationId?: string): Promis
   // Search by name or description
   const { data: apps, error } = await supabaseAdmin
     .from('ai_applications')
-    .select('*')
+    .select(AI_APPLICATION_COLUMNS)
     .eq('publication_id', pubId)
     .eq('is_active', true)
     .or(`app_name.ilike.%${query}%,description.ilike.%${query}%`)
@@ -246,7 +260,7 @@ export async function getPendingTools(publicationId?: string): Promise<Directory
   const pubId = publicationId || PUBLICATION_ID
   const { data: apps, error } = await supabaseAdmin
     .from('ai_applications')
-    .select('*')
+    .select(AI_APPLICATION_COLUMNS)
     .eq('publication_id', pubId)
     .eq('is_active', false)
     .order('created_at', { ascending: false })

--- a/src/lib/directory.ts
+++ b/src/lib/directory.ts
@@ -1,5 +1,6 @@
 import { supabaseAdmin } from './supabase'
 import { PUBLICATION_ID } from './config'
+import { getDirectorySettings } from './publication-settings'
 import type { AIApplication, AIAppCategory } from '@/types/database'
 
 // Categories derived from AIAppCategory type
@@ -319,44 +320,14 @@ export interface DirectoryPricing {
 }
 
 /**
- * Get directory pricing from publication_settings
- * Falls back to defaults if settings are not configured
+ * Get directory pricing via the typed DAL helper (publication→app fallback).
+ * Falls back to hardcoded defaults if the helper throws.
  */
 export async function getDirectoryPricing(publicationId?: string): Promise<DirectoryPricing> {
   const pubId = publicationId || PUBLICATION_ID
   try {
-    const { data: settings, error } = await supabaseAdmin
-      .from('publication_settings')
-      .select('key, value')
-      .eq('publication_id', pubId)
-      .in('key', ['directory_paid_placement_price', 'directory_featured_price', 'directory_yearly_discount_months'])
-
-    if (error) {
-      console.error('[Directory] Error fetching pricing settings:', error)
-      return computePricing(DEFAULT_PRICING)
-    }
-
-    // Build settings map from database
-    const settingsMap: Record<string, string> = {}
-    settings?.forEach(s => {
-      if (s.value !== null) {
-        settingsMap[s.key] = s.value
-      }
-    })
-
-    const pricing = {
-      paidPlacementPrice: settingsMap.directory_paid_placement_price
-        ? parseFloat(settingsMap.directory_paid_placement_price)
-        : DEFAULT_PRICING.paidPlacementPrice,
-      featuredPrice: settingsMap.directory_featured_price
-        ? parseFloat(settingsMap.directory_featured_price)
-        : DEFAULT_PRICING.featuredPrice,
-      yearlyDiscountMonths: settingsMap.directory_yearly_discount_months
-        ? parseInt(settingsMap.directory_yearly_discount_months)
-        : DEFAULT_PRICING.yearlyDiscountMonths
-    }
-
-    return computePricing(pricing)
+    const base = await getDirectorySettings(pubId)
+    return computePricing(base)
   } catch (error) {
     console.error('[Directory] Unexpected error fetching pricing:', error)
     return computePricing(DEFAULT_PRICING)

--- a/src/lib/openai/__tests__/prompt-loaders.test.ts
+++ b/src/lib/openai/__tests__/prompt-loaders.test.ts
@@ -32,10 +32,13 @@ vi.mock('../core', () => ({
   callWithStructuredPrompt: mocks.mockCallStructured,
 }))
 
-import { AI_PROMPTS } from '../prompt-loaders'
+import { AI_PROMPTS, clearPromptCache } from '../prompt-loaders'
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Cache is module-scoped; reset between tests so mockResolvedValueOnce
+  // sequencing isn't short-circuited by hits from prior tests.
+  clearPromptCache()
 })
 
 // ---------------------------------------------------------------------------
@@ -101,6 +104,114 @@ describe('AI_PROMPTS.contentEvaluator (plain-text via fetchPromptRow)', () => {
     expect(result).toBe('App: Z')
     expect(mocks.mockFrom).toHaveBeenCalledWith('app_settings')
     expect(mocks.mockFrom).not.toHaveBeenCalledWith('publication_settings')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('fetchPromptRow caching behavior', () => {
+  it('second call with same key+publicationId is a cache hit (no DB roundtrip)', async () => {
+    mocks.mockMaybeSingle.mockResolvedValueOnce({
+      data: { value: 'Cached: {{title}}' },
+      error: null,
+    })
+
+    const a = await AI_PROMPTS.contentEvaluator(
+      { title: 'First', description: '', hasImage: false },
+      'pub-cache',
+    )
+    const b = await AI_PROMPTS.contentEvaluator(
+      { title: 'Second', description: '', hasImage: false },
+      'pub-cache',
+    )
+
+    expect(a).toContain('Cached: First')
+    expect(b).toContain('Cached: Second')
+    // Only one DB call across both AI_PROMPTS invocations
+    expect(mocks.mockMaybeSingle).toHaveBeenCalledTimes(1)
+  })
+
+  it('different publicationIds do not collide in the cache', async () => {
+    mocks.mockMaybeSingle
+      .mockResolvedValueOnce({ data: { value: 'Pub A: {{title}}' }, error: null })
+      .mockResolvedValueOnce({ data: { value: 'Pub B: {{title}}' }, error: null })
+
+    const a = await AI_PROMPTS.contentEvaluator(
+      { title: 'X', description: '', hasImage: false },
+      'pub-A',
+    )
+    const b = await AI_PROMPTS.contentEvaluator(
+      { title: 'X', description: '', hasImage: false },
+      'pub-B',
+    )
+
+    expect(a).toContain('Pub A: X')
+    expect(b).toContain('Pub B: X')
+    expect(mocks.mockMaybeSingle).toHaveBeenCalledTimes(2)
+  })
+
+  it('caches the "no row" result so double-misses are not repeated', async () => {
+    // Both publication and app reads return null on the first call
+    mocks.mockMaybeSingle
+      .mockResolvedValueOnce({ data: null, error: null })
+      .mockResolvedValueOnce({ data: null, error: null })
+
+    await AI_PROMPTS.contentEvaluator(
+      { title: 'X', description: '', hasImage: false },
+      'pub-empty',
+    )
+    await AI_PROMPTS.contentEvaluator(
+      { title: 'Y', description: '', hasImage: false },
+      'pub-empty',
+    )
+
+    // Two DB queries on the first call (pub miss → app miss); zero on the second
+    expect(mocks.mockMaybeSingle).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT cache when the app_settings query errors (transient blip retries)', async () => {
+    // First call: pub miss, app errors
+    mocks.mockMaybeSingle
+      .mockResolvedValueOnce({ data: null, error: null })
+      .mockResolvedValueOnce({ data: null, error: { message: 'connection reset' } as any })
+      // Second call: pub miss, app returns a real row
+      .mockResolvedValueOnce({ data: null, error: null })
+      .mockResolvedValueOnce({ data: { value: 'Recovered: {{title}}', ai_provider: null }, error: null })
+
+    const first = await AI_PROMPTS.contentEvaluator(
+      { title: 'X', description: '', hasImage: false },
+      'pub-blip',
+    )
+    // Error → fell through to fallback
+    expect(first).toContain('Article Title: X')
+
+    const second = await AI_PROMPTS.contentEvaluator(
+      { title: 'Y', description: '', hasImage: false },
+      'pub-blip',
+    )
+    // Second call retried both queries (error wasn't cached) and got the recovered prompt
+    expect(second).toBe('Recovered: Y')
+    expect(mocks.mockMaybeSingle).toHaveBeenCalledTimes(4)
+  })
+
+  it('clearPromptCache() forces the next call to hit the DB', async () => {
+    mocks.mockMaybeSingle
+      .mockResolvedValueOnce({ data: { value: 'V1: {{title}}' }, error: null })
+      .mockResolvedValueOnce({ data: { value: 'V2: {{title}}' }, error: null })
+
+    const a = await AI_PROMPTS.contentEvaluator(
+      { title: 'X', description: '', hasImage: false },
+      'pub-clear',
+    )
+    expect(a).toContain('V1: X')
+
+    clearPromptCache()
+
+    const b = await AI_PROMPTS.contentEvaluator(
+      { title: 'X', description: '', hasImage: false },
+      'pub-clear',
+    )
+    expect(b).toContain('V2: X')
+    expect(mocks.mockMaybeSingle).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/lib/openai/__tests__/prompt-loaders.test.ts
+++ b/src/lib/openai/__tests__/prompt-loaders.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// vi.hoisted runs before the hoisted vi.mock factory, so the chain symbols
+// are available at mock-construction time.
+const mocks = vi.hoisted(() => {
+  const mockMaybeSingle = vi.fn()
+  const mockEq = vi.fn()
+  const mockChain: any = {}
+  mockChain.select = (..._args: any[]) => mockChain
+  mockChain.eq = (...args: any[]) => { mockEq(...args); return mockChain }
+  mockChain.maybeSingle = mockMaybeSingle
+
+  return {
+    mockChain,
+    mockMaybeSingle,
+    mockEq,
+    mockFrom: vi.fn(() => mockChain),
+    mockGetPrompt: vi.fn(),
+    mockCallStructured: vi.fn(),
+  }
+})
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: mocks.mockFrom },
+}))
+
+vi.mock('../prompt-repository', () => ({
+  getPrompt: mocks.mockGetPrompt,
+}))
+
+vi.mock('../core', () => ({
+  callWithStructuredPrompt: mocks.mockCallStructured,
+}))
+
+import { AI_PROMPTS } from '../prompt-loaders'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+describe('AI_PROMPTS.contentEvaluator (plain-text via fetchPromptRow)', () => {
+  it('returns DB template with substitutions when publication_settings has the key', async () => {
+    // First call (publication_settings) returns the override
+    mocks.mockMaybeSingle.mockResolvedValueOnce({
+      data: { value: 'Title is {{title}} and image: {{imagePenalty}}' },
+      error: null,
+    })
+
+    const result = await AI_PROMPTS.contentEvaluator(
+      { title: 'My Story', description: 'desc', hasImage: true },
+      'pub-123',
+    )
+
+    expect(result).toContain('Title is My Story')
+    expect(result).toContain('This post HAS an image.')
+    expect(mocks.mockFrom).toHaveBeenCalledWith('publication_settings')
+    // Guards against typos in the key string
+    expect(mocks.mockEq).toHaveBeenCalledWith('key', 'ai_prompt_content_evaluator')
+    expect(mocks.mockEq).toHaveBeenCalledWith('publication_id', 'pub-123')
+  })
+
+  it('falls back to app_settings when publication_settings has no row', async () => {
+    mocks.mockMaybeSingle
+      .mockResolvedValueOnce({ data: null, error: null })
+      .mockResolvedValueOnce({
+        data: { value: 'Global: {{title}}', ai_provider: null },
+        error: null,
+      })
+
+    const result = await AI_PROMPTS.contentEvaluator(
+      { title: 'X', description: '', hasImage: false },
+      'pub-123',
+    )
+    expect(result).toBe('Global: X')
+  })
+
+  it('returns FALLBACK when both publication and app settings miss', async () => {
+    mocks.mockMaybeSingle
+      .mockResolvedValueOnce({ data: null, error: null })
+      .mockResolvedValueOnce({ data: null, error: null })
+
+    const result = await AI_PROMPTS.contentEvaluator(
+      { title: 'X', description: '', hasImage: false },
+      'pub-123',
+    )
+    // Fallback already has values inlined (no {{title}} placeholders left)
+    expect(result).toContain('Article Title: X')
+    expect(result).not.toContain('{{title}}')
+  })
+
+  it('skips publication_settings query when no publicationId is provided (debug-handler path)', async () => {
+    mocks.mockMaybeSingle.mockResolvedValueOnce({
+      data: { value: 'App: {{title}}', ai_provider: null },
+      error: null,
+    })
+
+    const result = await AI_PROMPTS.contentEvaluator(
+      { title: 'Z', description: '', hasImage: false },
+    )
+    expect(result).toBe('App: Z')
+    expect(mocks.mockFrom).toHaveBeenCalledWith('app_settings')
+    expect(mocks.mockFrom).not.toHaveBeenCalledWith('publication_settings')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('AI_PROMPTS.imageAnalyzer (delegates to getPrompt)', () => {
+  it('forwards publicationId to getPrompt', async () => {
+    mocks.mockGetPrompt.mockResolvedValueOnce('analyze image content')
+    const result = await AI_PROMPTS.imageAnalyzer('pub-1')
+    expect(result).toBe('analyze image content')
+    expect(mocks.mockGetPrompt).toHaveBeenCalledWith(
+      'ai_prompt_image_analyzer',
+      expect.any(String),
+      'pub-1',
+    )
+  })
+
+  it('passes undefined publicationId through', async () => {
+    mocks.mockGetPrompt.mockResolvedValueOnce('analyze image content')
+    await AI_PROMPTS.imageAnalyzer()
+    expect(mocks.mockGetPrompt).toHaveBeenCalledWith(
+      'ai_prompt_image_analyzer',
+      expect.any(String),
+      undefined,
+    )
+  })
+})

--- a/src/lib/openai/prompt-loaders.ts
+++ b/src/lib/openai/prompt-loaders.ts
@@ -855,7 +855,8 @@ Respond with valid JSON in this exact format:
   "word_count": <exact word count>
 }`,
 
-  breakingNewsScorer: (article: { title: string; description: string; content?: string }) => `
+  breakingNewsScorer: (article: { title: string; description: string; content?: string }) => {
+    const template = `
 You are evaluating a news article for inclusion in the AI Accounting Professionals newsletter's "Breaking News" section.
 
 Your task is to score this article's RELEVANCE and IMPORTANCE to accounting professionals on a scale of 0-100.
@@ -919,33 +920,88 @@ Response format:
   "urgency": "<high|medium|low>",
   "actionable": <true|false>
 }`
+    return template
+      .replace(/\{\{title\}\}/g, article.title)
+      .replace(/\{\{description\}\}/g, article.description || 'No description available')
+      .replace(/\{\{content\}\}/g, article.content ? article.content.substring(0, 1500) + '...' : 'No content available')
+  },
 }
 
-// Dynamic AI Prompts - Uses database with fallbacks (Oct 7 2025 - Force cache bust)
-// WARNING: These legacy functions query app_settings WITHOUT publication_id filter.
-// For multi-tenant per-publication prompts, use callAIWithPrompt(key, newsletterId, vars)
-// which reads from publication_settings first. These functions should be migrated
-// to accept a publicationId parameter when their callers are updated.
-export const AI_PROMPTS = {
-  contentEvaluator: async (post: { title: string; description: string; content?: string; hasImage?: boolean }) => {
-    try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_content_evaluator')
-        .single()
+// Internal helper: fetch a prompt row with publication→app fallback.
+// `publication_settings` has no `ai_provider` column (only `app_settings` does),
+// so when a publication override exists the provider defaults to whatever the
+// caller's downstream auto-detect produces (typically openai unless the model
+// name says claude). Callers handle the value-shape variance (string vs JSONB).
+//
+// Empty/null publication values fall through to app_settings (via the
+// `pubData?.value` check). This intentionally diverges from
+// `prompt-repository.ts:getPrompt`, which treats an empty publication row as a
+// "win" and returns `''`. Falling through is safer because an accidentally-
+// blank override would otherwise feed an empty prompt to the AI. Aligning
+// `getPrompt` to match is tracked as a follow-up.
+async function fetchPromptRow(
+  key: string,
+  publicationId?: string,
+): Promise<{ value: any; ai_provider: string | null } | null> {
+  if (publicationId) {
+    const { data: pubData, error: pubError } = await supabaseAdmin
+      .from('publication_settings')
+      .select('value')
+      .eq('publication_id', publicationId)
+      .eq('key', key)
+      .maybeSingle()
+    if (!pubError && pubData?.value) {
+      return { value: pubData.value, ai_provider: null }
+    }
+  }
+  const { data, error } = await supabaseAdmin
+    .from('app_settings')
+    .select('value, ai_provider')
+    .eq('key', key)
+    .maybeSingle()
+  if (error || !data?.value) return null
+  return { value: data.value, ai_provider: (data as any).ai_provider ?? null }
+}
 
-      if (error || !data) {
-        console.log('Using code fallback for contentEvaluator prompt')
+// Shared loader for the 5 criteria evaluators — same shape, different key suffix.
+async function loadCriteriaPrompt(
+  n: 1 | 2 | 3 | 4 | 5,
+  post: { title: string; description: string; content?: string },
+  publicationId?: string,
+): Promise<string> {
+  const fallback = FALLBACK_PROMPTS[`criteria${n}Evaluator` as keyof typeof FALLBACK_PROMPTS] as
+    (p: typeof post) => string
+  try {
+    const row = await fetchPromptRow(`ai_prompt_criteria_${n}`, publicationId)
+    if (!row || !row.value) return fallback(post)
+    const valueStr = typeof row.value === 'string' ? row.value : JSON.stringify(row.value)
+    return valueStr
+      .replace(/\{\{title\}\}/g, post.title)
+      .replace(/\{\{description\}\}/g, post.description || 'No description available')
+      .replace(/\{\{content\}\}/g, post.content ? post.content.substring(0, 1000) + '...' : 'No content available')
+  } catch (error) {
+    console.error(`Error fetching criteria${n}Evaluator prompt, using fallback:`, error)
+    return fallback(post)
+  }
+}
+
+// Dynamic AI Prompts - publication→app_settings fallback via fetchPromptRow.
+// Each function accepts an optional `publicationId` for per-publication prompt
+// overrides. Callers without publication context (debug/admin tools) can omit
+// it for app-wide behavior.
+export const AI_PROMPTS = {
+  contentEvaluator: async (post: { title: string; description: string; content?: string; hasImage?: boolean }, publicationId?: string) => {
+    try {
+      const row = await fetchPromptRow('ai_prompt_content_evaluator', publicationId)
+      if (!row || typeof row.value !== 'string') {
         return FALLBACK_PROMPTS.contentEvaluator(post)
       }
 
-      // Database template uses {{}} placeholders
       const imagePenaltyText = post.hasImage
         ? 'This post HAS an image.'
         : 'This post has NO image - subtract 5 points from interest_level.'
 
-      return data.value
+      return row.value
         .replace(/\{\{title\}\}/g, post.title)
         .replace(/\{\{description\}\}/g, post.description || 'No description available')
         .replace(/\{\{content\}\}/g, post.content ? post.content.substring(0, 1000) + '...' : 'No content available')
@@ -956,20 +1012,13 @@ export const AI_PROMPTS = {
     }
   },
 
-  newsletterWriter: async (post: { title: string; description: string; content?: string; source_url?: string }) => {
+  newsletterWriter: async (post: { title: string; description: string; content?: string; source_url?: string }, publicationId?: string) => {
     try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_newsletter_writer')
-        .single()
-
-      if (error || !data) {
-        console.log('Using code fallback for newsletterWriter prompt')
+      const row = await fetchPromptRow('ai_prompt_newsletter_writer', publicationId)
+      if (!row || typeof row.value !== 'string') {
         return FALLBACK_PROMPTS.newsletterWriter(post)
       }
-
-      return data.value
+      return row.value
         .replace(/\{\{title\}\}/g, post.title)
         .replace(/\{\{description\}\}/g, post.description || 'No description available')
         .replace(/\{\{content\}\}/g, post.content ? post.content.substring(0, 1500) + '...' : 'No additional content')
@@ -980,20 +1029,13 @@ export const AI_PROMPTS = {
     }
   },
 
-  eventSummarizer: async (event: { title: string; description: string | null; venue?: string | null }) => {
+  eventSummarizer: async (event: { title: string; description: string | null; venue?: string | null }, publicationId?: string) => {
     try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_event_summary')
-        .single()
-
-      if (error || !data) {
-        console.log('Using code fallback for eventSummarizer prompt')
+      const row = await fetchPromptRow('ai_prompt_event_summary', publicationId)
+      if (!row || typeof row.value !== 'string') {
         return FALLBACK_PROMPTS.eventSummarizer(event)
       }
-
-      return data.value
+      return row.value
         .replace(/\{\{title\}\}/g, event.title)
         .replace(/\{\{description\}\}/g, event.description || 'No description available')
         .replace(/\{\{venue\}\}/g, event.venue || 'No venue specified')
@@ -1013,28 +1055,22 @@ export const AI_PROMPTS = {
     return FALLBACK_PROMPTS.roadWorkGenerator(issueDate)
   },
 
-  imageAnalyzer: async () => {
+  imageAnalyzer: async (publicationId?: string) => {
     return await getPrompt(
       'ai_prompt_image_analyzer',
-      FALLBACK_PROMPTS.imageAnalyzer()
+      FALLBACK_PROMPTS.imageAnalyzer(),
+      publicationId
     )
   },
 
-  topicDeduper: async (posts: Array<{ title: string; description: string; full_article_text: string }>) => {
+  topicDeduper: async (posts: Array<{ title: string; description: string; full_article_text: string }>, publicationId?: string) => {
     try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value, ai_provider')
-        .eq('key', 'ai_prompt_topic_deduper')
-        .single()
-
-      if (error || !data) {
-        console.log('[AI] Using fallback for topicDeduper prompt')
+      const row = await fetchPromptRow('ai_prompt_topic_deduper', publicationId)
+      if (!row) {
         return FALLBACK_PROMPTS.topicDeduper(posts)
       }
 
-      console.log('[AI] Using database prompt for topicDeduper')
-      const provider = (data.ai_provider === 'claude' ? 'claude' : 'openai') as 'openai' | 'claude'
+      const provider = (row.ai_provider === 'claude' ? 'claude' : 'openai') as 'openai' | 'claude'
 
       // Format articles list for the prompt with full article text
       const articlesText = posts.map((post, i) => `
@@ -1045,108 +1081,68 @@ ${i}. Title: ${post.title}
 
       // Check if value is already an object (JSONB auto-parsed) or needs parsing
       let promptConfig: any
-      if (typeof data.value === 'string') {
-        // String value - try to parse as JSON
+      if (typeof row.value === 'string') {
         try {
-          promptConfig = JSON.parse(data.value)
-        } catch (jsonError) {
-          // Not JSON, treat as plain text prompt
-          console.log('[AI] Using plain text prompt for topicDeduper')
-          return data.value.replace(/\{\{articles\}\}/g, articlesText)
+          promptConfig = JSON.parse(row.value)
+        } catch {
+          return row.value.replace(/\{\{articles\}\}/g, articlesText)
         }
-      } else if (typeof data.value === 'object' && data.value !== null) {
-        // Already an object (JSONB was auto-parsed)
-        promptConfig = data.value
+      } else if (typeof row.value === 'object' && row.value !== null) {
+        promptConfig = row.value
       } else {
-        console.log('[AI] Unknown value format for topicDeduper, treating as plain text')
-        return String(data.value).replace(/\{\{articles\}\}/g, articlesText)
+        return String(row.value).replace(/\{\{articles\}\}/g, articlesText)
       }
 
-      // Check if it's a structured prompt
       if (promptConfig.messages && Array.isArray(promptConfig.messages)) {
-        console.log('[AI] Using structured JSON prompt for topicDeduper with provider:', provider)
-        const placeholders = { articles: articlesText }
-        return await callWithStructuredPrompt(promptConfig, placeholders, provider)
+        return await callWithStructuredPrompt(promptConfig, { articles: articlesText }, provider)
       }
 
-      // Fallback to plain text
-      console.log('[AI] Using plain text format for topicDeduper')
       const promptText = typeof promptConfig === 'string' ? promptConfig : JSON.stringify(promptConfig)
       return promptText.replace(/\{\{articles\}\}/g, articlesText)
-
     } catch (error) {
       console.error('[AI] Error loading topicDeduper prompt:', error)
       return FALLBACK_PROMPTS.topicDeduper(posts)
     }
   },
-  factChecker: async (newsletterContent: string, originalContent: string) => {
+  factChecker: async (newsletterContent: string, originalContent: string, publicationId?: string) => {
     try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value, ai_provider')
-        .eq('key', 'ai_prompt_fact_checker')
-        .single()
-
-      if (error || !data) {
-        console.log('[AI] Using fallback for factChecker prompt')
+      const row = await fetchPromptRow('ai_prompt_fact_checker', publicationId)
+      if (!row) {
         return FALLBACK_PROMPTS.factChecker(newsletterContent, originalContent)
       }
 
-      console.log('[AI] Using database prompt for factChecker')
-      const provider = (data.ai_provider === 'claude' ? 'claude' : 'openai') as 'openai' | 'claude'
+      const provider = (row.ai_provider === 'claude' ? 'claude' : 'openai') as 'openai' | 'claude'
 
-      // Check if value is already an object (JSONB auto-parsed) or needs parsing
-      let promptConfig: any
-      if (typeof data.value === 'string') {
-        // String value - try to parse as JSON
-        try {
-          promptConfig = JSON.parse(data.value)
-        } catch (jsonError) {
-          // Not JSON, treat as plain text prompt
-          console.log('[AI] Using plain text prompt for factChecker')
-          return data.value
-            .replace(/\{\{newsletterContent\}\}/g, newsletterContent)
-            .replace(/\{\{newsletter_content\}\}/g, newsletterContent)
-            .replace(/\{\{originalContent\}\}/g, originalContent.substring(0, 2000))
-            .replace(/\{\{original_content\}\}/g, originalContent.substring(0, 2000))
-        }
-      } else if (typeof data.value === 'object' && data.value !== null) {
-        // Already an object (JSONB was auto-parsed)
-        promptConfig = data.value
-      } else {
-        // Unknown format, use as plain text
-        console.log('[AI] Unknown value format for factChecker, treating as plain text')
-        const valueStr = String(data.value)
-        return valueStr
-          .replace(/\{\{newsletterContent\}\}/g, newsletterContent)
-          .replace(/\{\{newsletter_content\}\}/g, newsletterContent)
-          .replace(/\{\{originalContent\}\}/g, originalContent.substring(0, 2000))
-          .replace(/\{\{original_content\}\}/g, originalContent.substring(0, 2000))
+      const placeholders = {
+        newsletterContent,
+        newsletter_content: newsletterContent,
+        originalContent: originalContent.substring(0, 2000),
+        original_content: originalContent.substring(0, 2000),
       }
 
-      // Check if it's a structured prompt
-      if (promptConfig.messages && Array.isArray(promptConfig.messages)) {
-        console.log('[AI] Detected structured JSON prompt for factChecker with provider:', provider)
-
-        // Support both camelCase and snake_case placeholders for backward compatibility
-        const placeholders = {
-          newsletterContent,
-          newsletter_content: newsletterContent,
-          originalContent: originalContent.substring(0, 2000),
-          original_content: originalContent.substring(0, 2000)
-        }
-
-        return await callWithStructuredPrompt(promptConfig, placeholders, provider)
-      }
-
-      // Plain text prompt - support both placeholder formats
-      console.log('[AI] Using plain text prompt for factChecker')
-      const configStr = String(promptConfig)
-      return configStr
+      const applyPlaceholders = (text: string) => text
         .replace(/\{\{newsletterContent\}\}/g, newsletterContent)
         .replace(/\{\{newsletter_content\}\}/g, newsletterContent)
         .replace(/\{\{originalContent\}\}/g, originalContent.substring(0, 2000))
         .replace(/\{\{original_content\}\}/g, originalContent.substring(0, 2000))
+
+      let promptConfig: any
+      if (typeof row.value === 'string') {
+        try {
+          promptConfig = JSON.parse(row.value)
+        } catch {
+          return applyPlaceholders(row.value)
+        }
+      } else if (typeof row.value === 'object' && row.value !== null) {
+        promptConfig = row.value
+      } else {
+        return applyPlaceholders(String(row.value))
+      }
+
+      if (promptConfig.messages && Array.isArray(promptConfig.messages)) {
+        return await callWithStructuredPrompt(promptConfig, placeholders, provider)
+      }
+      return applyPlaceholders(String(promptConfig))
     } catch (error) {
       console.error('[AI] Error fetching factChecker prompt, using fallback:', error)
       return FALLBACK_PROMPTS.factChecker(newsletterContent, originalContent)
@@ -1156,20 +1152,13 @@ ${i}. Title: ${post.title}
     return FALLBACK_PROMPTS.roadWorkValidator(roadWorkItems, date)
   },
 
-  breakingNewsScorer: async (article: { title: string; description: string; content?: string }) => {
+  breakingNewsScorer: async (article: { title: string; description: string; content?: string }, publicationId?: string) => {
     try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_breaking_news_scorer')
-        .single()
-
-      if (error || !data) {
-        console.log('Using code fallback for breakingNewsScorer prompt')
+      const row = await fetchPromptRow('ai_prompt_breaking_news_scorer', publicationId)
+      if (!row || typeof row.value !== 'string') {
         return FALLBACK_PROMPTS.breakingNewsScorer(article)
       }
-
-      return data.value
+      return row.value
         .replace(/\{\{title\}\}/g, article.title)
         .replace(/\{\{description\}\}/g, article.description || 'No description available')
         .replace(/\{\{content\}\}/g, article.content ? article.content.substring(0, 1500) + '...' : 'No content available')
@@ -1179,58 +1168,35 @@ ${i}. Title: ${post.title}
     }
   },
 
-  welcomeSection: async (articles: Array<{ headline: string; content: string }>) => {
+  welcomeSection: async (articles: Array<{ headline: string; content: string }>, publicationId?: string) => {
     try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value, ai_provider')
-        .eq('key', 'ai_prompt_welcome_section')
-        .single()
-
-      if (error || !data) {
-        console.log('[AI] Using fallback for welcomeSection prompt')
+      const row = await fetchPromptRow('ai_prompt_welcome_section', publicationId)
+      if (!row) {
         return FALLBACK_PROMPTS.welcomeSection(articles)
       }
 
-      console.log('[AI] Using database prompt for welcomeSection')
-      const provider = (data.ai_provider === 'claude' ? 'claude' : 'openai') as 'openai' | 'claude'
+      const provider = (row.ai_provider === 'claude' ? 'claude' : 'openai') as 'openai' | 'claude'
 
-      // Format articles for the prompt
       const articlesText = articles
         .map((article, index) => `${index + 1}. ${article.headline}\n   ${article.content.substring(0, 200)}...`)
         .join('\n\n')
 
-      // Check if value is already an object (JSONB auto-parsed) or needs parsing
       let promptConfig: any
-      if (typeof data.value === 'string') {
-        // String value - try to parse as JSON
+      if (typeof row.value === 'string') {
         try {
-          promptConfig = JSON.parse(data.value)
-        } catch (jsonError) {
-          // Not JSON, treat as plain text prompt
-          console.log('[AI] Using plain text prompt for welcomeSection')
-          return data.value.replace(/\{\{articles\}\}/g, articlesText)
+          promptConfig = JSON.parse(row.value)
+        } catch {
+          return row.value.replace(/\{\{articles\}\}/g, articlesText)
         }
-      } else if (typeof data.value === 'object' && data.value !== null) {
-        // Already an object (JSONB was auto-parsed)
-        promptConfig = data.value
+      } else if (typeof row.value === 'object' && row.value !== null) {
+        promptConfig = row.value
       } else {
-        // Unknown format, use as plain text
-        console.log('[AI] Unknown value format for welcomeSection, treating as plain text')
-        return String(data.value).replace(/\{\{articles\}\}/g, articlesText)
+        return String(row.value).replace(/\{\{articles\}\}/g, articlesText)
       }
 
-      // Check if it's a structured prompt
       if (promptConfig.messages && Array.isArray(promptConfig.messages)) {
-        console.log('[AI] Using structured JSON prompt for welcomeSection with provider:', provider)
-        const placeholders = {
-          articles: articlesText
-        }
-        return await callWithStructuredPrompt(promptConfig, placeholders, provider)
+        return await callWithStructuredPrompt(promptConfig, { articles: articlesText }, provider)
       }
-
-      // Plain text prompt
-      console.log('[AI] Using plain text prompt for welcomeSection')
       return String(promptConfig).replace(/\{\{articles\}\}/g, articlesText)
     } catch (error) {
       console.error('[AI] Error fetching welcomeSection prompt, using fallback:', error)
@@ -1238,151 +1204,27 @@ ${i}. Title: ${post.title}
     }
   },
 
-  // Multi-Criteria Evaluators (database-driven with fallbacks)
-  criteria1Evaluator: async (post: { title: string; description: string; content?: string }) => {
+  // Multi-Criteria Evaluators (database-driven with fallbacks).
+  // All five share the same shape: load the prompt template, substitute the
+  // post fields, return the rendered text.
+  criteria1Evaluator: async (post: { title: string; description: string; content?: string }, publicationId?: string) =>
+    loadCriteriaPrompt(1, post, publicationId),
+  criteria2Evaluator: async (post: { title: string; description: string; content?: string }, publicationId?: string) =>
+    loadCriteriaPrompt(2, post, publicationId),
+  criteria3Evaluator: async (post: { title: string; description: string; content?: string }, publicationId?: string) =>
+    loadCriteriaPrompt(3, post, publicationId),
+  criteria4Evaluator: async (post: { title: string; description: string; content?: string }, publicationId?: string) =>
+    loadCriteriaPrompt(4, post, publicationId),
+  criteria5Evaluator: async (post: { title: string; description: string; content?: string }, publicationId?: string) =>
+    loadCriteriaPrompt(5, post, publicationId),
+
+  articleWriter: async (post: { title: string; description: string; content?: string; source_url?: string }, publicationId?: string) => {
     try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_criteria_1')
-        .single()
-
-      if (error || !data || !data.value) {
-        console.log('Using code fallback for criteria1Evaluator prompt')
-        return FALLBACK_PROMPTS.criteria1Evaluator(post)
-      }
-
-      // Ensure value is a string (handle JSONB auto-parsing)
-      const valueStr = typeof data.value === 'string' ? data.value : JSON.stringify(data.value)
-
-      return valueStr
-        .replace(/\{\{title\}\}/g, post.title)
-        .replace(/\{\{description\}\}/g, post.description || 'No description available')
-        .replace(/\{\{content\}\}/g, post.content ? post.content.substring(0, 1000) + '...' : 'No content available')
-    } catch (error) {
-      console.error('Error fetching criteria1Evaluator prompt, using fallback:', error)
-      return FALLBACK_PROMPTS.criteria1Evaluator(post)
-    }
-  },
-
-  criteria2Evaluator: async (post: { title: string; description: string; content?: string }) => {
-    try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_criteria_2')
-        .single()
-
-      if (error || !data || !data.value) {
-        console.log('Using code fallback for criteria2Evaluator prompt')
-        return FALLBACK_PROMPTS.criteria2Evaluator(post)
-      }
-
-      // Ensure value is a string (handle JSONB auto-parsing)
-      const valueStr = typeof data.value === 'string' ? data.value : JSON.stringify(data.value)
-
-      return valueStr
-        .replace(/\{\{title\}\}/g, post.title)
-        .replace(/\{\{description\}\}/g, post.description || 'No description available')
-        .replace(/\{\{content\}\}/g, post.content ? post.content.substring(0, 1000) + '...' : 'No content available')
-    } catch (error) {
-      console.error('Error fetching criteria2Evaluator prompt, using fallback:', error)
-      return FALLBACK_PROMPTS.criteria2Evaluator(post)
-    }
-  },
-
-  criteria3Evaluator: async (post: { title: string; description: string; content?: string }) => {
-    try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_criteria_3')
-        .single()
-
-      if (error || !data || !data.value) {
-        console.log('Using code fallback for criteria3Evaluator prompt')
-        return FALLBACK_PROMPTS.criteria3Evaluator(post)
-      }
-
-      // Ensure value is a string (handle JSONB auto-parsing)
-      const valueStr = typeof data.value === 'string' ? data.value : JSON.stringify(data.value)
-
-      return valueStr
-        .replace(/\{\{title\}\}/g, post.title)
-        .replace(/\{\{description\}\}/g, post.description || 'No description available')
-        .replace(/\{\{content\}\}/g, post.content ? post.content.substring(0, 1000) + '...' : 'No content available')
-    } catch (error) {
-      console.error('Error fetching criteria3Evaluator prompt, using fallback:', error)
-      return FALLBACK_PROMPTS.criteria3Evaluator(post)
-    }
-  },
-
-  criteria4Evaluator: async (post: { title: string; description: string; content?: string }) => {
-    try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_criteria_4')
-        .single()
-
-      if (error || !data || !data.value) {
-        console.log('Using code fallback for criteria4Evaluator prompt')
-        return FALLBACK_PROMPTS.criteria4Evaluator(post)
-      }
-
-      // Ensure value is a string (handle JSONB auto-parsing)
-      const valueStr = typeof data.value === 'string' ? data.value : JSON.stringify(data.value)
-
-      return valueStr
-        .replace(/\{\{title\}\}/g, post.title)
-        .replace(/\{\{description\}\}/g, post.description || 'No description available')
-        .replace(/\{\{content\}\}/g, post.content ? post.content.substring(0, 1000) + '...' : 'No content available')
-    } catch (error) {
-      console.error('Error fetching criteria4Evaluator prompt, using fallback:', error)
-      return FALLBACK_PROMPTS.criteria4Evaluator(post)
-    }
-  },
-
-  criteria5Evaluator: async (post: { title: string; description: string; content?: string }) => {
-    try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_criteria_5')
-        .single()
-
-      if (error || !data || !data.value) {
-        console.log('Using code fallback for criteria5Evaluator prompt')
-        return FALLBACK_PROMPTS.criteria5Evaluator(post)
-      }
-
-      // Ensure value is a string (handle JSONB auto-parsing)
-      const valueStr = typeof data.value === 'string' ? data.value : JSON.stringify(data.value)
-
-      return valueStr
-        .replace(/\{\{title\}\}/g, post.title)
-        .replace(/\{\{description\}\}/g, post.description || 'No description available')
-        .replace(/\{\{content\}\}/g, post.content ? post.content.substring(0, 1000) + '...' : 'No content available')
-    } catch (error) {
-      console.error('Error fetching criteria5Evaluator prompt, using fallback:', error)
-      return FALLBACK_PROMPTS.criteria5Evaluator(post)
-    }
-  },
-
-  articleWriter: async (post: { title: string; description: string; content?: string; source_url?: string }) => {
-    try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_article_writer')
-        .single()
-
-      if (error || !data) {
-        console.log('Using code fallback for articleWriter prompt')
+      const row = await fetchPromptRow('ai_prompt_article_writer', publicationId)
+      if (!row || typeof row.value !== 'string') {
         return FALLBACK_PROMPTS.articleWriter(post)
       }
-
-      return data.value
+      return row.value
         .replace(/\{\{title\}\}/g, post.title)
         .replace(/\{\{description\}\}/g, post.description || 'No description available')
         .replace(/\{\{content\}\}/g, post.content ? post.content.substring(0, 1500) + '...' : 'No additional content')
@@ -1395,53 +1237,32 @@ ${i}. Title: ${post.title}
 ,
 
   // Primary Article Title Generator
-  primaryArticleTitle: async (post: { title: string; description: string; content?: string }) => {
+  primaryArticleTitle: async (post: { title: string; description: string; content?: string }, publicationId?: string) => {
     try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value, ai_provider')
-        .eq('key', 'ai_prompt_primary_article_title')
-        .single()
+      const row = await fetchPromptRow('ai_prompt_primary_article_title', publicationId)
+      if (!row || !row.value) return FALLBACK_PROMPTS.primaryArticleTitle(post)
 
-      if (error) {
-        console.log('[AI] Error fetching primaryArticleTitle prompt:', error.message)
-        console.log('[AI] Using code fallback for primaryArticleTitle prompt')
-        return FALLBACK_PROMPTS.primaryArticleTitle(post)
-      }
+      const provider = (row.ai_provider === 'claude' ? 'claude' : 'openai') as 'openai' | 'claude'
 
-      if (!data || !data.value) {
-        console.log('[AI] No database value found for primaryArticleTitle prompt')
-        console.log('[AI] Using code fallback for primaryArticleTitle prompt')
-        return FALLBACK_PROMPTS.primaryArticleTitle(post)
-      }
-
-      const provider = (data.ai_provider === 'claude' ? 'claude' : 'openai') as 'openai' | 'claude'
-
-      // Check if the prompt is JSON (structured format) or plain text
+      // Check if the prompt is structured JSON or plain text
+      const valueStr = typeof row.value === 'string' ? row.value : JSON.stringify(row.value)
       try {
-        const promptConfig = JSON.parse(data.value) as StructuredPromptConfig
-
-        // If it has a messages array, it's a structured prompt
+        const promptConfig = (typeof row.value === 'object' && row.value !== null
+          ? row.value
+          : JSON.parse(valueStr)) as StructuredPromptConfig
         if (promptConfig.messages && Array.isArray(promptConfig.messages)) {
-          console.log('[AI] Using structured database prompt for primaryArticleTitle with provider:', provider)
-
-          // Prepare placeholders
           const placeholders = {
             title: post.title,
             description: post.description || 'No description available',
-            content: post.content ? post.content.substring(0, 1000) + '...' : 'No content available'
+            content: post.content ? post.content.substring(0, 1000) + '...' : 'No content available',
           }
-
-          // Call with structured format
           return await callWithStructuredPrompt(promptConfig, placeholders, provider)
         }
-      } catch (jsonError) {
-        // Not JSON, treat as plain text prompt (fallthrough to below)
+      } catch {
+        // Fallthrough to plain text path
       }
 
-      // Plain text prompt - use old format
-      console.log('[AI] Using plain text database prompt for primaryArticleTitle (length:', data.value.length, 'chars)')
-      return data.value
+      return valueStr
         .replace(/\{\{title\}\}/g, post.title)
         .replace(/\{\{description\}\}/g, post.description || 'No description available')
         .replace(/\{\{content\}\}/g, post.content ? post.content.substring(0, 1000) + '...' : 'No content available')
@@ -1452,20 +1273,13 @@ ${i}. Title: ${post.title}
   },
 
   // Primary Article Body Generator
-  primaryArticleBody: async (post: { title: string; description: string; content?: string; source_url?: string }, headline: string) => {
+  primaryArticleBody: async (post: { title: string; description: string; content?: string; source_url?: string }, headline: string, publicationId?: string) => {
     try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_primary_article_body')
-        .single()
-
-      if (error || !data) {
-        console.log('Using code fallback for primaryArticleBody prompt')
+      const row = await fetchPromptRow('ai_prompt_primary_article_body', publicationId)
+      if (!row || typeof row.value !== 'string') {
         return FALLBACK_PROMPTS.primaryArticleBody(post, headline)
       }
-
-      return data.value
+      return row.value
         .replace(/\{\{headline\}\}/g, headline)
         .replace(/\{\{title\}\}/g, post.title)
         .replace(/\{\{description\}\}/g, post.description || 'No description available')
@@ -1478,20 +1292,13 @@ ${i}. Title: ${post.title}
   },
 
   // Secondary Article Title Generator
-  secondaryArticleTitle: async (post: { title: string; description: string; content?: string }) => {
+  secondaryArticleTitle: async (post: { title: string; description: string; content?: string }, publicationId?: string) => {
     try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_secondary_article_title')
-        .single()
-
-      if (error || !data) {
-        console.log('Using code fallback for secondaryArticleTitle prompt')
+      const row = await fetchPromptRow('ai_prompt_secondary_article_title', publicationId)
+      if (!row || typeof row.value !== 'string') {
         return FALLBACK_PROMPTS.secondaryArticleTitle(post)
       }
-
-      return data.value
+      return row.value
         .replace(/\{\{title\}\}/g, post.title)
         .replace(/\{\{description\}\}/g, post.description || 'No description available')
         .replace(/\{\{content\}\}/g, post.content ? post.content.substring(0, 1000) + '...' : 'No content available')
@@ -1502,20 +1309,13 @@ ${i}. Title: ${post.title}
   },
 
   // Secondary Article Body Generator
-  secondaryArticleBody: async (post: { title: string; description: string; content?: string; source_url?: string }, headline: string) => {
+  secondaryArticleBody: async (post: { title: string; description: string; content?: string; source_url?: string }, headline: string, publicationId?: string) => {
     try {
-      const { data, error } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'ai_prompt_secondary_article_body')
-        .single()
-
-      if (error || !data) {
-        console.log('Using code fallback for secondaryArticleBody prompt')
+      const row = await fetchPromptRow('ai_prompt_secondary_article_body', publicationId)
+      if (!row || typeof row.value !== 'string') {
         return FALLBACK_PROMPTS.secondaryArticleBody(post, headline)
       }
-
-      return data.value
+      return row.value
         .replace(/\{\{headline\}\}/g, headline)
         .replace(/\{\{title\}\}/g, post.title)
         .replace(/\{\{description\}\}/g, post.description || 'No description available')

--- a/src/lib/openai/prompt-loaders.ts
+++ b/src/lib/openai/prompt-loaders.ts
@@ -927,6 +927,63 @@ Response format:
   },
 }
 
+// In-process prompt cache. Hot scoring loops (breakingNewsScorer per-post,
+// criteria evaluators per-article) hit the same key+publicationId tens to
+// hundreds of times per workflow run. Without caching, each call is a 1-2
+// round-trip read against publication_settings + app_settings. The cache
+// short-circuits to a Map lookup after the first miss.
+//
+// TTL is short (60s) so prompt edits propagate quickly; correctness over
+// perf for editorial changes. Errors are NOT cached so a transient DB blip
+// won't poison the cache for the full TTL. Successful "no row" reads ARE
+// cached (most prompts have no per-publication override; cache prevents
+// repeated double-misses). The cache is per-process — Vercel Fluid Compute
+// reuses instances across requests, so this amortizes across invocations.
+type CachedPromptRow = { value: any; ai_provider: string | null } | null
+type CacheEntry = { row: CachedPromptRow; expiresAt: number }
+
+const PROMPT_CACHE_TTL_MS = 60_000
+const PROMPT_CACHE_MAX_SIZE = 500
+const promptRowCache = new Map<string, CacheEntry>()
+
+function buildCacheKey(key: string, publicationId?: string): string {
+  // Treat empty string and undefined the same (matches the `if (publicationId)`
+  // gate that skips the publication query).
+  return `${publicationId || '_app_'}::${key}`
+}
+
+function readCache(key: string, publicationId?: string): CacheEntry | null {
+  const entry = promptRowCache.get(buildCacheKey(key, publicationId))
+  if (!entry) return null
+  if (Date.now() > entry.expiresAt) {
+    promptRowCache.delete(buildCacheKey(key, publicationId))
+    return null
+  }
+  return entry
+}
+
+function writeCache(key: string, publicationId: string | undefined, row: CachedPromptRow): void {
+  // Crude size cap. The keyspace is small in practice (~14 prompt keys ×
+  // active publications), but bound it anyway to defend against pathological
+  // growth from one-off pubIds (e.g. tests, debug calls).
+  if (promptRowCache.size >= PROMPT_CACHE_MAX_SIZE) {
+    const firstKey = promptRowCache.keys().next().value
+    if (firstKey !== undefined) promptRowCache.delete(firstKey)
+  }
+  promptRowCache.set(buildCacheKey(key, publicationId), {
+    row,
+    expiresAt: Date.now() + PROMPT_CACHE_TTL_MS,
+  })
+}
+
+/**
+ * Drop all cached prompt rows. Call from settings-write paths (or tests) to
+ * force the next prompt read to hit the DB.
+ */
+export function clearPromptCache(): void {
+  promptRowCache.clear()
+}
+
 // Internal helper: fetch a prompt row with publication→app fallback.
 // `publication_settings` has no `ai_provider` column (only `app_settings` does),
 // so when a publication override exists the provider defaults to whatever the
@@ -942,7 +999,12 @@ Response format:
 async function fetchPromptRow(
   key: string,
   publicationId?: string,
-): Promise<{ value: any; ai_provider: string | null } | null> {
+): Promise<CachedPromptRow> {
+  const cached = readCache(key, publicationId)
+  if (cached) return cached.row
+
+  let hadError = false
+
   if (publicationId) {
     const { data: pubData, error: pubError } = await supabaseAdmin
       .from('publication_settings')
@@ -951,16 +1013,32 @@ async function fetchPromptRow(
       .eq('key', key)
       .maybeSingle()
     if (!pubError && pubData?.value) {
-      return { value: pubData.value, ai_provider: null }
+      const row: CachedPromptRow = { value: pubData.value, ai_provider: null }
+      writeCache(key, publicationId, row)
+      return row
     }
+    if (pubError) hadError = true
   }
+
   const { data, error } = await supabaseAdmin
     .from('app_settings')
     .select('value, ai_provider')
     .eq('key', key)
     .maybeSingle()
-  if (error || !data?.value) return null
-  return { value: data.value, ai_provider: (data as any).ai_provider ?? null }
+  if (error) hadError = true
+
+  const row: CachedPromptRow =
+    !error && data?.value
+      ? { value: data.value, ai_provider: (data as any).ai_provider ?? null }
+      : null
+
+  // Only cache when both reads completed without error. A transient DB blip
+  // shouldn't lock in `null` (which would force fallback prompts) for 60s.
+  if (!hadError) {
+    writeCache(key, publicationId, row)
+  }
+
+  return row
 }
 
 // Shared loader for the 5 criteria evaluators — same shape, different key suffix.

--- a/src/lib/openai/prompt-loaders.ts
+++ b/src/lib/openai/prompt-loaders.ts
@@ -927,50 +927,47 @@ Response format:
   },
 }
 
-// In-process prompt cache. Hot scoring loops (breakingNewsScorer per-post,
-// criteria evaluators per-article) hit the same key+publicationId tens to
-// hundreds of times per workflow run. Without caching, each call is a 1-2
-// round-trip read against publication_settings + app_settings. The cache
-// short-circuits to a Map lookup after the first miss.
-//
-// TTL is short (60s) so prompt edits propagate quickly; correctness over
-// perf for editorial changes. Errors are NOT cached so a transient DB blip
-// won't poison the cache for the full TTL. Successful "no row" reads ARE
-// cached (most prompts have no per-publication override; cache prevents
-// repeated double-misses). The cache is per-process — Vercel Fluid Compute
-// reuses instances across requests, so this amortizes across invocations.
+// In-process prompt cache for fetchPromptRow.
+// - Short TTL (60s) so editorial prompt edits propagate quickly.
+// - Errors NOT cached: a transient DB blip would otherwise lock in null
+//   and force fallback prompts for the full TTL.
+// - "No row" results ARE cached: most prompts have no per-publication
+//   override, so this prevents repeated publication-miss → app-miss
+//   double-roundtrips on every per-post call.
 type CachedPromptRow = { value: any; ai_provider: string | null } | null
 type CacheEntry = { row: CachedPromptRow; expiresAt: number }
 
 const PROMPT_CACHE_TTL_MS = 60_000
 const PROMPT_CACHE_MAX_SIZE = 500
+// Sentinel used in the cache key when no publicationId is provided. Treats
+// empty string and undefined the same (matches the `if (publicationId)`
+// gate in fetchPromptRow that skips the publication query).
+const APP_SCOPE_SENTINEL = '_app_'
 const promptRowCache = new Map<string, CacheEntry>()
 
 function buildCacheKey(key: string, publicationId?: string): string {
-  // Treat empty string and undefined the same (matches the `if (publicationId)`
-  // gate that skips the publication query).
-  return `${publicationId || '_app_'}::${key}`
+  return `${publicationId || APP_SCOPE_SENTINEL}::${key}`
 }
 
-function readCache(key: string, publicationId?: string): CacheEntry | null {
-  const entry = promptRowCache.get(buildCacheKey(key, publicationId))
+function readCache(cacheKey: string): CacheEntry | null {
+  const entry = promptRowCache.get(cacheKey)
   if (!entry) return null
   if (Date.now() > entry.expiresAt) {
-    promptRowCache.delete(buildCacheKey(key, publicationId))
+    promptRowCache.delete(cacheKey)
     return null
   }
   return entry
 }
 
-function writeCache(key: string, publicationId: string | undefined, row: CachedPromptRow): void {
-  // Crude size cap. The keyspace is small in practice (~14 prompt keys ×
-  // active publications), but bound it anyway to defend against pathological
-  // growth from one-off pubIds (e.g. tests, debug calls).
+function writeCache(cacheKey: string, row: CachedPromptRow): void {
+  // Bounded as defense-in-depth. Keyspace is small in practice (~14 prompt
+  // keys × active publications), but pathological pubIds from tests or
+  // debug calls could grow it unboundedly otherwise.
   if (promptRowCache.size >= PROMPT_CACHE_MAX_SIZE) {
     const firstKey = promptRowCache.keys().next().value
     if (firstKey !== undefined) promptRowCache.delete(firstKey)
   }
-  promptRowCache.set(buildCacheKey(key, publicationId), {
+  promptRowCache.set(cacheKey, {
     row,
     expiresAt: Date.now() + PROMPT_CACHE_TTL_MS,
   })
@@ -985,6 +982,8 @@ export function clearPromptCache(): void {
 }
 
 // Internal helper: fetch a prompt row with publication→app fallback.
+// Results are cached per (key, publicationId) for 60s; see `clearPromptCache`.
+//
 // `publication_settings` has no `ai_provider` column (only `app_settings` does),
 // so when a publication override exists the provider defaults to whatever the
 // caller's downstream auto-detect produces (typically openai unless the model
@@ -1000,7 +999,8 @@ async function fetchPromptRow(
   key: string,
   publicationId?: string,
 ): Promise<CachedPromptRow> {
-  const cached = readCache(key, publicationId)
+  const cacheKey = buildCacheKey(key, publicationId)
+  const cached = readCache(cacheKey)
   if (cached) return cached.row
 
   let hadError = false
@@ -1014,7 +1014,7 @@ async function fetchPromptRow(
       .maybeSingle()
     if (!pubError && pubData?.value) {
       const row: CachedPromptRow = { value: pubData.value, ai_provider: null }
-      writeCache(key, publicationId, row)
+      writeCache(cacheKey, row)
       return row
     }
     if (pubError) hadError = true
@@ -1032,10 +1032,9 @@ async function fetchPromptRow(
       ? { value: data.value, ai_provider: (data as any).ai_provider ?? null }
       : null
 
-  // Only cache when both reads completed without error. A transient DB blip
-  // shouldn't lock in `null` (which would force fallback prompts) for 60s.
+  // Don't cache when a query errored — see comment block above the cache.
   if (!hadError) {
-    writeCache(key, publicationId, row)
+    writeCache(cacheKey, row)
   }
 
   return row

--- a/src/lib/publication-settings.ts
+++ b/src/lib/publication-settings.ts
@@ -50,39 +50,44 @@ export async function getPublicationSetting(
 
 /**
  * Get multiple settings for a publication with fallback
- * Returns a map of key -> value
+ * Returns a map of key -> value.
+ *
+ * When `publicationId` is null, the publication_settings lookup is skipped
+ * and values are read directly from `app_settings`. Used by app-wide consumers
+ * (e.g., the Slack notification service) that don't have a publication context.
  */
 export async function getPublicationSettings(
-  publicationId: string,
+  publicationId: string | null,
   keys: string[]
 ): Promise<Record<string, string>> {
   const result: Record<string, string> = {}
-
-  // Try publication_settings first
-  const { data: pubSettings } = await supabaseAdmin
-    .from('publication_settings')
-    .select('key, value')
-    .eq('publication_id', publicationId)
-    .in('key', keys)
-
-  // Build map from publication_settings
   const foundKeys = new Set<string>()
-  pubSettings?.forEach((setting) => {
-    if (setting.value) {
-      // Strip extra quotes if value was JSON stringified (e.g., '"#1C293D"' -> '#1C293D')
-      let cleanValue = setting.value
-      if (cleanValue.startsWith('"') && cleanValue.endsWith('"') && cleanValue.length > 2) {
-        cleanValue = cleanValue.slice(1, -1)
+
+  // Try publication_settings first (skip when null)
+  if (publicationId !== null) {
+    const { data: pubSettings } = await supabaseAdmin
+      .from('publication_settings')
+      .select('key, value')
+      .eq('publication_id', publicationId)
+      .in('key', keys)
+
+    pubSettings?.forEach((setting) => {
+      if (setting.value) {
+        // Strip extra quotes if value was JSON stringified (e.g., '"#1C293D"' -> '#1C293D')
+        let cleanValue = setting.value
+        if (cleanValue.startsWith('"') && cleanValue.endsWith('"') && cleanValue.length > 2) {
+          cleanValue = cleanValue.slice(1, -1)
+        }
+        result[setting.key] = cleanValue
+        foundKeys.add(setting.key)
       }
-      result[setting.key] = cleanValue
-      foundKeys.add(setting.key)
-    }
-  })
+    })
+  }
 
   // Find missing keys
   const missingKeys = keys.filter((key) => !foundKeys.has(key))
 
-  // Fallback to app_settings for missing keys
+  // Fallback to app_settings for missing keys (or all keys when null)
   if (missingKeys.length > 0) {
     const { data: fallbackSettings } = await supabaseAdmin
       .from('app_settings')
@@ -91,9 +96,11 @@ export async function getPublicationSettings(
 
     fallbackSettings?.forEach((setting) => {
       if (setting.value) {
-        console.warn(
-          `[SETTINGS FALLBACK] Using app_settings for key="${setting.key}" (publication=${publicationId}). Migrate this setting!`
-        )
+        if (publicationId !== null) {
+          console.warn(
+            `[SETTINGS FALLBACK] Using app_settings for key="${setting.key}" (publication=${publicationId}). Migrate this setting!`
+          )
+        }
         result[setting.key] = setting.value
       }
     })
@@ -507,9 +514,13 @@ export async function getAIPrompt(
 }
 
 /**
- * Get Slack notification settings for a publication
+ * Get Slack notification settings.
+ *
+ * Pass a `publicationId` to read per-publication overrides with app_settings
+ * fallback. Pass `null` for the app-wide settings only (used by the legacy
+ * `SlackNotificationService` which lacks publication context).
  */
-export async function getSlackSettings(publicationId: string): Promise<{
+export async function getSlackSettings(publicationId: string | null = null): Promise<{
   webhook_url: string
   low_article_count_enabled: boolean
   rss_processing_updates_enabled: boolean
@@ -524,6 +535,50 @@ export async function getSlackSettings(publicationId: string): Promise<{
     webhook_url: settings.slack_webhook_url || '',
     low_article_count_enabled: settings.slack_low_article_count_enabled === 'true',
     rss_processing_updates_enabled: settings.slack_rss_processing_updates_enabled === 'true',
+  }
+}
+
+/**
+ * Get AI app rotation settings for a publication.
+ * Defaults match the historic hardcoded fallbacks in `app-selector.ts`.
+ */
+export async function getAIAppSettings(publicationId: string): Promise<{
+  totalApps: number
+  maxPerCategory: number
+  affiliateCooldownDays: number
+}> {
+  const settings = await getPublicationSettings(publicationId, [
+    'ai_apps_per_newsletter',
+    'ai_apps_max_per_category',
+    'affiliate_cooldown_days',
+  ])
+
+  return {
+    totalApps: parseInt(settings.ai_apps_per_newsletter || '6', 10),
+    maxPerCategory: parseInt(settings.ai_apps_max_per_category || '3', 10),
+    affiliateCooldownDays: parseInt(settings.affiliate_cooldown_days || '7', 10),
+  }
+}
+
+/**
+ * Get directory pricing settings for a publication.
+ * Defaults match the historic `DEFAULT_PRICING` in `directory.ts`.
+ */
+export async function getDirectorySettings(publicationId: string): Promise<{
+  paidPlacementPrice: number
+  featuredPrice: number
+  yearlyDiscountMonths: number
+}> {
+  const settings = await getPublicationSettings(publicationId, [
+    'directory_paid_placement_price',
+    'directory_featured_price',
+    'directory_yearly_discount_months',
+  ])
+
+  return {
+    paidPlacementPrice: parseFloat(settings.directory_paid_placement_price || '30'),
+    featuredPrice: parseFloat(settings.directory_featured_price || '60'),
+    yearlyDiscountMonths: parseInt(settings.directory_yearly_discount_months || '2', 10),
   }
 }
 

--- a/src/lib/rss-processor/article-extraction.ts
+++ b/src/lib/rss-processor/article-extraction.ts
@@ -1,6 +1,6 @@
 import type { RSSProcessorContext } from './shared-context'
 import { logInfo, logError } from './shared-context'
-import { listPostsForExtractionByIssue, applyExtractionResult } from '@/lib/dal/posts'
+import { listPostsForExtractionByIssue, applyExtractionResult } from '@/lib/dal'
 
 /**
  * Article text extraction module.

--- a/src/lib/rss-processor/deduplication.ts
+++ b/src/lib/rss-processor/deduplication.ts
@@ -1,5 +1,5 @@
-import { supabaseAdmin } from '../supabase'
 import { Deduplicator } from '../deduplicator'
+import { getPublicationSettings } from '../publication-settings'
 import type { RssPost } from '@/types/database'
 import { getNewsletterIdFromIssue } from './shared-context'
 import { listPostsByIssue } from '@/lib/dal/posts'
@@ -69,16 +69,12 @@ export class Deduplication {
       // Get publication_id from issue for multi-tenant filtering
       const newsletterId = await getNewsletterIdFromIssue(issueId)
 
-      // Load deduplication settings
-      const { data: settings } = await supabaseAdmin
-        .from('publication_settings')
-        .select('key, value')
-        .eq('publication_id', newsletterId)
-        .in('key', ['dedup_historical_lookback_days', 'dedup_strictness_threshold'])
-
-      const settingsMap = new Map(settings?.map(s => [s.key, s.value]) || [])
-      const historicalLookbackDays = parseInt(settingsMap.get('dedup_historical_lookback_days') || '3')
-      const strictnessThreshold = parseFloat(settingsMap.get('dedup_strictness_threshold') || '0.80')
+      const settings = await getPublicationSettings(newsletterId, [
+        'dedup_historical_lookback_days',
+        'dedup_strictness_threshold',
+      ])
+      const historicalLookbackDays = parseInt(settings.dedup_historical_lookback_days || '3', 10)
+      const strictnessThreshold = parseFloat(settings.dedup_strictness_threshold || '0.80')
 
       // Run 4-stage deduplication with config
       const deduplicator = new Deduplicator({

--- a/src/lib/rss-processor/deduplication.ts
+++ b/src/lib/rss-processor/deduplication.ts
@@ -2,14 +2,14 @@ import { Deduplicator } from '../deduplicator'
 import { getPublicationSettings } from '../publication-settings'
 import type { RssPost } from '@/types/database'
 import { getNewsletterIdFromIssue } from './shared-context'
-import { listPostsByIssue } from '@/lib/dal/posts'
 import {
+  listPostsByIssue,
   isIssueDeduplicated,
   listDuplicateGroupIdsByIssue,
   listDuplicatePostIdsByGroups,
   storeDeduplicationResult,
   type NewDuplicatePost,
-} from '@/lib/dal/dedup'
+} from '@/lib/dal'
 
 /**
  * A "historical match" is a duplicate group whose primary post was published

--- a/src/lib/rss-processor/feed-ingestion.ts
+++ b/src/lib/rss-processor/feed-ingestion.ts
@@ -13,7 +13,7 @@ import {
   listPendingExtractionPosts,
   getRatedPostIds,
   insertPostRating,
-} from '@/lib/dal/posts'
+} from '@/lib/dal'
 
 const parser = new Parser({
   customFields: {

--- a/src/lib/rss-processor/issue-lifecycle.ts
+++ b/src/lib/rss-processor/issue-lifecycle.ts
@@ -1,9 +1,14 @@
 import { supabaseAdmin } from '../supabase'
 import { getArticleSettings } from '../publication-settings'
 import { getTomorrowStr } from '../date-utils'
-import { listPostsForScoring, assignPostsToIssue, listPostsByIssue, unassignPosts } from '@/lib/dal/posts'
-import { listModuleArticlesByIssue } from '@/lib/dal/articles'
-import { listDuplicateGroupIdsByIssue } from '@/lib/dal/dedup'
+import {
+  listPostsForScoring,
+  assignPostsToIssue,
+  listPostsByIssue,
+  unassignPosts,
+  listModuleArticlesByIssue,
+  listDuplicateGroupIdsByIssue,
+} from '@/lib/dal'
 import type { RSSProcessorContext } from './shared-context'
 import { getNewsletterIdFromIssue, formatError } from './shared-context'
 import type { Deduplication } from './deduplication'

--- a/src/lib/rss-processor/module-articles.ts
+++ b/src/lib/rss-processor/module-articles.ts
@@ -7,19 +7,15 @@ import {
   assignPostsToIssue,
   listAssignedPostsForModule,
   POST_WITH_RATINGS_BRIEF,
-} from '@/lib/dal/posts'
-import {
   moduleArticleExists,
   insertModuleArticle,
   listArticlesNeedingBody,
   listArticlesNeedingFactCheck,
   updateModuleArticleContent,
   updateModuleArticleFactCheck,
-} from '@/lib/dal/articles'
-import {
   listDuplicateGroupIdsByIssue,
   listDuplicatePostIdsByGroups,
-} from '@/lib/dal/dedup'
+} from '@/lib/dal'
 import type { ArticleGenerator } from './article-generator'
 
 /**

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { supabaseAdmin } from './supabase'
 import { triageAlert, isTriageEnabled } from './monitoring/alert-triage'
+import { getPublicationSettings, getSlackSettings } from './publication-settings'
 
 export class SlackNotificationService {
   private webhookUrl: string
@@ -11,13 +12,16 @@ export class SlackNotificationService {
 
   private async isNotificationEnabled(notificationType: string): Promise<boolean> {
     try {
-      const { data: setting } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', `slack_${notificationType}_enabled`)
-        .single()
-
-      return setting?.value === 'true'
+      // App-wide check — this service has no publication context. Threading
+      // publicationId through callers is a follow-up.
+      const key = `slack_${notificationType}_enabled`
+      const settings = await getPublicationSettings(null, [key])
+      // Default to enabled when the key is absent. The prior implementation
+      // used .single() which errored on missing rows and fell into a catch
+      // that returned true; getPublicationSettings instead returns {} for
+      // missing keys, so we must check undefined explicitly to preserve
+      // that "default-true" behavior.
+      return settings[key] === undefined ? true : settings[key] === 'true'
     } catch (error) {
       // Default to enabled if setting doesn't exist
       return true
@@ -26,13 +30,8 @@ export class SlackNotificationService {
 
   private async getWebhookUrl(): Promise<string> {
     try {
-      const { data: setting } = await supabaseAdmin
-        .from('app_settings')
-        .select('value')
-        .eq('key', 'slack_webhook_url')
-        .single()
-
-      return setting?.value || this.webhookUrl
+      const slack = await getSlackSettings(null)
+      return slack.webhook_url || this.webhookUrl
     } catch (error) {
       return this.webhookUrl
     }

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -423,7 +423,7 @@ export class HealthMonitor {
     try {
       const { data: feeds, error } = await supabaseAdmin
         .from('rss_feeds')
-        .select('*')
+        .select('id, name, processing_errors')
         .eq('active', true)
 
       if (error) throw error
@@ -475,7 +475,7 @@ export class HealthMonitor {
 
       const { data: issues, error } = await supabaseAdmin
         .from('publication_issues')
-        .select('*')
+        .select('id')
         .gte('created_at', yesterday.toISOString())
 
       if (error) throw error


### PR DESCRIPTION
## Summary
Six commits on staging hardening the DAL, AI prompt resolution, and analytics pagination. All staging-tested; gate-reviewed.

**AI prompts — publication-scoped fallback**
- 14 of 18 `AI_PROMPTS.*` functions were querying `app_settings` directly with no per-publication override. New `fetchPromptRow(key, publicationId?)` does publication→app fallback; 5 criteria evaluators consolidated into a shared loader.
- 60s TTL in-process cache wraps `fetchPromptRow` so hot scoring loops (breakingNewsScorer per-post, criteria evaluators per-article) hit a Map after the first read instead of repeating publication+app double-queries.

**DAL extension**
- Barrel re-exports posts/articles/dedup/excluded-ips. New `dal/excluded-ips.ts` consolidates the IPExclusion fetch+normalize duplicated across 3+ analytics sites; supports `throwOnError: true` for callers that drive external writes.
- `rss-processor/*` migrated from deep imports to `from '@/lib/dal'`.

**Pagination correctness (silent 1000-row truncation)**
- `feedback/analytics`: paginated `excluded_ips` and `feedback_responses` (truncation was corrupting section/daily aggregates). Reads now run in parallel via `Promise.allSettled`.
- `link-tracking/analytics`: paginated `excluded_ips` (truncation inflated CTR by counting bot clicks as real).
- `cron/process-mailerlite-updates`: paginated `excluded_ips` (truncation caused repeated MailerLite/Beehiiv field writes).
- DB-side ordering removed from paginated `feedback_responses` query — offset pagination + ORDER BY + concurrent inserts produces duplicates; sorted in-memory after fetch instead.
- Added `.order('id')` to `getExcludedIPs` paginator for stable offset windows.

**Security / correctness polish**
- `recentResponses` in `feedback/analytics` now projects away `ip_address` (PII) and `publication_id` before serializing.
- `process-mailerlite-updates` restored skip-on-error (DB blip on exclusion fetch → `continue` rather than silently degrade to empty list).

## Commits (oldest → newest)
- `afbfcfc5` fix(ai-prompts): publication-scoped fallback for AI_PROMPTS + 4 settings consolidations
- `fd361945` fix(api): paginate excluded_ips + feedback_responses past 1000-row default
- `6caaf81a` refactor(dal): re-export posts/articles/dedup from barrel + migrate callers
- `3a41421d` perf(prompt-loaders): in-process TTL cache for fetchPromptRow
- `9a8e74c9` refactor(simplify): extract dal/excluded-ips + parallelize feedback reads + cache cleanup
- `283c25d6` fix(review-gate): order/PII findings from /review:pre-push gate

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run test:run` — 762/762 passing (was 738 baseline → +24 new tests covering DAL extensions, pagination, cache, prompt fallback)
- [x] `/simplify` gate — findings applied in 9a8e74c9
- [x] `/review:pre-push` gate — Critical findings (`.order()` in paginated builder, cron skip-on-error regression) fixed in 283c25d6
- [ ] Verify staging deploy in `aiprodaily-staging`
- [ ] Smoke test `/feedback/analytics` and `/link-tracking/analytics` dashboards
- [ ] Verify `breakingNewsScorer` cache hit on warm Vercel instance (look for the per-post DB query count to drop)
- [ ] Watch first `process-mailerlite-updates` cron run for unexpected per-publication skips

## Known follow-ups (not blocking)
- `syncRealClickStatus` 120s timeout exposure (pre-existing — flagged by ops reviewer, not introduced by this PR)
- Composite index on `feedback_responses(publication_id, campaign_date)` — separate DB migration
- `clearPromptCache()` invocation in `/api/settings/ai-prompts` write paths — closes the cross-instance staleness window after editorial saves
- Migrate the 9+ pre-existing call sites that still inline the IPExclusion fetch+map pattern to `getExcludedIPs()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publication-specific AI prompt templates and settings customization.
  * Enabled per-publication configuration for AI app settings, directory pricing, and Slack notifications.

* **Bug Fixes**
  * Improved error handling for IP exclusions with stricter validation and retry logic.

* **Tests**
  * Added comprehensive test suites for publication settings, excluded IPs, and prompt loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->