### PR TITLE
fix(sparkloop): match budgets by partner_program_uuid, pause unknown-budget paid recs

### DIFF
--- a/scripts/diagnose-sparkloop-budget-match.mjs
+++ b/scripts/diagnose-sparkloop-budget-match.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * Diagnose SparkLoop budget-match failures.
+ *
+ * Calls `/v2/upscribes/{upscribeId}/recommendations` (per-publication) and
+ * `/v2/partner_profile/partner_campaigns` (account-level) for one or more
+ * publications and reports, per rec, which match strategy (if any) would
+ * succeed. Pure read; writes nothing.
+ *
+ * Usage:
+ *   node scripts/diagnose-sparkloop-budget-match.mjs
+ *   node scripts/diagnose-sparkloop-budget-match.mjs --publication-id=8277682a-7292-4c36-bca1-a39ca420b305
+ *   node scripts/diagnose-sparkloop-budget-match.mjs --slug=trader-leak --sample-keys
+ *   node scripts/diagnose-sparkloop-budget-match.mjs --dump-unmatched
+ *
+ * Default publications: Trader Leak (broken) and AI Accounting Daily (working).
+ *
+ * Environment (.env.local):
+ *   SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL)
+ *   SUPABASE_SERVICE_ROLE_KEY
+ *   SPARKLOOP_API_KEY
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import dotenv from 'dotenv'
+
+dotenv.config({ path: '.env.local' })
+dotenv.config()
+
+const SPARKLOOP_API_BASE = 'https://api.sparkloop.app/v2'
+
+const DEFAULT_PUBLICATION_IDS = [
+  '8277682a-7292-4c36-bca1-a39ca420b305', // Trader Leak (broken)
+  'eaaf8ba4-a3eb-4fff-9cad-6776acc36dcf', // AI Accounting Daily (working)
+]
+
+function parseArgs() {
+  const args = {
+    publicationIds: [],
+    slugs: [],
+    sampleKeys: false,
+    dumpUnmatched: false,
+    dumpAll: false,
+  }
+  for (const arg of process.argv.slice(2)) {
+    if (arg === '--sample-keys') args.sampleKeys = true
+    else if (arg === '--dump-unmatched') args.dumpUnmatched = true
+    else if (arg === '--dump-all') args.dumpAll = true
+    else if (arg.startsWith('--publication-id=')) args.publicationIds.push(arg.slice('--publication-id='.length))
+    else if (arg.startsWith('--slug=')) args.slugs.push(arg.slice('--slug='.length))
+  }
+  return args
+}
+
+function normalizeName(s) {
+  return (s || '').trim().toLowerCase()
+}
+
+async function fetchAllRecommendations(apiKey, upscribeId) {
+  const all = []
+  let page = 1
+  while (true) {
+    const url = `${SPARKLOOP_API_BASE}/upscribes/${upscribeId}/recommendations?per_page=200&page=${page}`
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { 'X-API-KEY': apiKey, 'Content-Type': 'application/json' },
+    })
+    if (!res.ok) {
+      const text = await res.text()
+      throw new Error(`recommendations ${res.status}: ${text.slice(0, 200)}`)
+    }
+    const data = await res.json()
+    all.push(...(data.recommendations || []))
+    if (!data.meta || page >= data.meta.total_pages) break
+    page++
+  }
+  return all
+}
+
+async function fetchAllPartnerCampaigns(apiKey) {
+  // Try paginated. Current production code only fetches per_page=200 page 1 — we paginate
+  // here to detect whether truncation is part of the bug.
+  const all = []
+  let page = 1
+  while (true) {
+    const url = `${SPARKLOOP_API_BASE}/partner_profile/partner_campaigns?per_page=200&page=${page}`
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { 'X-API-KEY': apiKey, 'Content-Type': 'application/json' },
+    })
+    if (!res.ok) {
+      const text = await res.text()
+      throw new Error(`partner_campaigns ${res.status}: ${text.slice(0, 200)}`)
+    }
+    const data = await res.json()
+    const campaigns = data.partner_campaigns || []
+    all.push(...campaigns)
+    if (!data.meta || !data.meta.total_pages || page >= data.meta.total_pages) break
+    page++
+    if (page > 50) break // safety
+  }
+  return all
+}
+
+function buildLookups(campaigns) {
+  const byUuid = new Map()
+  const byName = new Map()
+  const byPartnerProgramUuid = new Map()
+  const byAnyUuidField = new Map()
+  const allCampaignFields = new Set()
+
+  for (const c of campaigns) {
+    for (const k of Object.keys(c)) allCampaignFields.add(k)
+    if (c.uuid) byUuid.set(c.uuid, c)
+    const nm = normalizeName(c.name || c.publication_name || c.title)
+    if (nm) {
+      // Keep first occurrence
+      if (!byName.has(nm)) byName.set(nm, c)
+    }
+    if (c.partner_program_uuid) byPartnerProgramUuid.set(c.partner_program_uuid, c)
+
+    // Collect any *_uuid fields for diagnosis
+    for (const [k, v] of Object.entries(c)) {
+      if (typeof v === 'string' && (k.endsWith('_uuid') || k === 'uuid') && v) {
+        if (!byAnyUuidField.has(v)) byAnyUuidField.set(v, { campaign: c, field: k })
+      }
+    }
+  }
+  return { byUuid, byName, byPartnerProgramUuid, byAnyUuidField, allCampaignFields }
+}
+
+function classifyRec(rec, lookups) {
+  const checks = []
+  if (lookups.byUuid.has(rec.uuid)) checks.push('byUuid:rec.uuid')
+  if (lookups.byUuid.has(rec.partner_program_uuid)) checks.push('byUuid:rec.partner_program_uuid')
+  if (lookups.byPartnerProgramUuid.has(rec.partner_program_uuid)) checks.push('byPartnerProgramUuid:rec.partner_program_uuid')
+  if (lookups.byPartnerProgramUuid.has(rec.uuid)) checks.push('byPartnerProgramUuid:rec.uuid')
+  const nm = normalizeName(rec.publication_name)
+  if (nm && lookups.byName.has(nm)) checks.push(`byName:${nm}`)
+  if (lookups.byAnyUuidField.has(rec.uuid)) {
+    const hit = lookups.byAnyUuidField.get(rec.uuid)
+    if (hit.field !== 'uuid') checks.push(`byAnyUuidField[${hit.field}]:rec.uuid`)
+  }
+  if (lookups.byAnyUuidField.has(rec.partner_program_uuid)) {
+    const hit = lookups.byAnyUuidField.get(rec.partner_program_uuid)
+    if (hit.field !== 'uuid' && hit.field !== 'partner_program_uuid') checks.push(`byAnyUuidField[${hit.field}]:rec.partner_program_uuid`)
+  }
+  return checks
+}
+
+async function getUpscribeIdForPublication(sb, publicationId) {
+  const { data, error } = await sb
+    .from('publication_settings')
+    .select('key, value')
+    .eq('publication_id', publicationId)
+    .in('key', ['sparkloop_upscribe_id'])
+  if (error) throw error
+  const map = Object.fromEntries((data || []).map(r => [r.key, r.value]))
+  return map.sparkloop_upscribe_id || null
+}
+
+async function getPublication(sb, slugOrId) {
+  const { data, error } = await sb
+    .from('publications')
+    .select('id, name, slug')
+    .or(`id.eq.${slugOrId},slug.eq.${slugOrId}`)
+    .single()
+  if (error) return null
+  return data
+}
+
+function pct(num, denom) {
+  if (!denom) return '0.0%'
+  return `${((num / denom) * 100).toFixed(1)}%`
+}
+
+async function runForPublication(sb, apiKey, publication, opts) {
+  console.log('\n' + '='.repeat(72))
+  console.log(`Publication: ${publication.name} (${publication.slug})`)
+  console.log(`  id: ${publication.id}`)
+
+  const upscribeId = await getUpscribeIdForPublication(sb, publication.id)
+  if (!upscribeId) {
+    console.log('  ❌ No sparkloop_upscribe_id configured — skipping')
+    return
+  }
+  console.log(`  upscribe_id: ${upscribeId}`)
+
+  const [recs, campaigns] = await Promise.all([
+    fetchAllRecommendations(apiKey, upscribeId),
+    fetchAllPartnerCampaigns(apiKey),
+  ])
+
+  console.log(`\n  recommendations: ${recs.length} (active=${recs.filter(r => r.status === 'active').length}, paused=${recs.filter(r => r.status === 'paused').length})`)
+  console.log(`  partner_campaigns: ${campaigns.length}`)
+
+  if (opts.sampleKeys && campaigns.length > 0) {
+    const sample = campaigns[0]
+    console.log(`\n  Sample partner_campaign keys: ${Object.keys(sample).join(', ')}`)
+    console.log(`  Sample partner_campaign values:`)
+    for (const [k, v] of Object.entries(sample)) {
+      const vstr = typeof v === 'object' ? JSON.stringify(v) : String(v)
+      console.log(`    ${k}: ${vstr.slice(0, 120)}`)
+    }
+  }
+
+  const lookups = buildLookups(campaigns)
+
+  const strategyCounts = {
+    matched: 0,
+    unmatched: 0,
+    by_byUuid_rec_uuid: 0,
+    by_byUuid_partner_program_uuid: 0,
+    by_byPartnerProgramUuid: 0,
+    by_byName: 0,
+    by_byAnyUuidField: 0,
+  }
+
+  const unmatched = []
+  for (const rec of recs) {
+    const checks = classifyRec(rec, lookups)
+    if (checks.length === 0) {
+      strategyCounts.unmatched++
+      unmatched.push(rec)
+    } else {
+      strategyCounts.matched++
+      if (checks.some(c => c.startsWith('byUuid:rec.uuid'))) strategyCounts.by_byUuid_rec_uuid++
+      if (checks.some(c => c.startsWith('byUuid:rec.partner_program_uuid'))) strategyCounts.by_byUuid_partner_program_uuid++
+      if (checks.some(c => c.startsWith('byPartnerProgramUuid'))) strategyCounts.by_byPartnerProgramUuid++
+      if (checks.some(c => c.startsWith('byName'))) strategyCounts.by_byName++
+      if (checks.some(c => c.startsWith('byAnyUuidField'))) strategyCounts.by_byAnyUuidField++
+    }
+    if (opts.dumpAll) {
+      console.log(`    rec ${rec.publication_name} | uuid=${rec.uuid} | ppu=${rec.partner_program_uuid} | match=[${checks.join(' | ') || 'NONE'}]`)
+    }
+  }
+
+  console.log(`\n  Match results:`)
+  console.log(`    matched:   ${strategyCounts.matched} (${pct(strategyCounts.matched, recs.length)})`)
+  console.log(`    unmatched: ${strategyCounts.unmatched} (${pct(strategyCounts.unmatched, recs.length)})`)
+  console.log(`\n  Strategy hits (a rec can hit multiple strategies):`)
+  console.log(`    byUuid via rec.uuid:                ${strategyCounts.by_byUuid_rec_uuid}`)
+  console.log(`    byUuid via rec.partner_program_uuid:${strategyCounts.by_byUuid_partner_program_uuid}`)
+  console.log(`    byPartnerProgramUuid (new strategy):${strategyCounts.by_byPartnerProgramUuid}`)
+  console.log(`    byName (publication_name):          ${strategyCounts.by_byName}`)
+  console.log(`    byAnyUuidField (other *_uuid):      ${strategyCounts.by_byAnyUuidField}`)
+
+  if (opts.dumpUnmatched && unmatched.length > 0) {
+    console.log(`\n  Unmatched recs (showing up to 10):`)
+    for (const r of unmatched.slice(0, 10)) {
+      const nm = normalizeName(r.publication_name)
+      const sample = campaigns.find(c =>
+        normalizeName(c.name).includes(nm.slice(0, 8)) ||
+        normalizeName(c.publication_name).includes(nm.slice(0, 8)) ||
+        normalizeName(c.title).includes(nm.slice(0, 8))
+      )
+      console.log(`    - "${r.publication_name}" status=${r.status} uuid=${r.uuid} ppu=${r.partner_program_uuid}`)
+      if (sample) {
+        console.log(`        possible fuzzy match in campaigns: uuid=${sample.uuid} name="${sample.name}" pub_name="${sample.publication_name}" title="${sample.title}"`)
+      }
+    }
+  }
+}
+
+async function main() {
+  const args = parseArgs()
+  const apiKey = process.env.SPARKLOOP_API_KEY
+  if (!apiKey) throw new Error('Missing SPARKLOOP_API_KEY')
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !supabaseKey) throw new Error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY')
+  const sb = createClient(supabaseUrl, supabaseKey)
+
+  let targets = []
+  if (args.slugs.length || args.publicationIds.length) {
+    const slugTargets = await Promise.all(args.slugs.map(s => getPublication(sb, s)))
+    const idTargets = await Promise.all(args.publicationIds.map(id => getPublication(sb, id)))
+    targets = [...slugTargets, ...idTargets].filter(Boolean)
+  } else {
+    targets = await Promise.all(DEFAULT_PUBLICATION_IDS.map(id => getPublication(sb, id)))
+    targets = targets.filter(Boolean)
+  }
+
+  if (targets.length === 0) {
+    console.log('No publications matched.')
+    return
+  }
+
+  for (const p of targets) {
+    try {
+      await runForPublication(sb, apiKey, p, args)
+    } catch (err) {
+      console.error(`\n[${p.slug}] ERROR:`, err.message)
+    }
+  }
+}
+
+main().catch(err => {
+  console.error('FATAL:', err)
+  process.exit(1)
+})

--- a/src/lib/sparkloop-client/sparkloop-client.ts
+++ b/src/lib/sparkloop-client/sparkloop-client.ts
@@ -274,10 +274,11 @@ export class SparkLoopService {
    */
   async getPartnerCampaigns(): Promise<{
     byUuid: Map<string, { remaining_budget_dollars: number; referral_pending_period: number; name: string; status: string }>;
+    byPartnerProgramUuid: Map<string, { remaining_budget_dollars: number; referral_pending_period: number; status: string }>;
     nameSet: Set<string>;
     byName: Map<string, { remaining_budget_dollars: number; referral_pending_period: number; status: string }>;
   }> {
-    const emptyResult = { byUuid: new Map(), nameSet: new Set<string>(), byName: new Map() }
+    const emptyResult = { byUuid: new Map(), byPartnerProgramUuid: new Map(), nameSet: new Set<string>(), byName: new Map() }
     const url = `${SPARKLOOP_API_BASE}/partner_profile/partner_campaigns?per_page=200`
 
     const response = await fetch(url, {
@@ -306,18 +307,29 @@ export class SparkLoopService {
 
     // Build multiple lookup maps for reliable matching
     const byUuid = new Map<string, { remaining_budget_dollars: number; referral_pending_period: number; name: string; status: string }>()
+    // byPartnerProgramUuid is the primary match key: the partner_program_uuid is stable
+    // across upscribe placements, while `uuid` is placement-specific and only matches
+    // for one upscribe per program.
+    const byPartnerProgramUuid = new Map<string, { remaining_budget_dollars: number; referral_pending_period: number; status: string }>()
     const nameSet = new Set<string>()
     const byName = new Map<string, { remaining_budget_dollars: number; referral_pending_period: number; status: string }>()
 
     for (const campaign of campaigns) {
-      const campaignName = (campaign.name || campaign.publication_name || campaign.title || '').trim().toLowerCase()
+      // partner_campaigns names come as "<Pub Name>'s Partner Program"; recommendations
+      // use bare "<Pub Name>". Strip the suffix so byName can be a useful fallback.
+      const rawName = (campaign.name || campaign.publication_name || campaign.title || '').trim().toLowerCase()
+      const campaignName = rawName
+        .replace(/'s partner program$/i, '')
+        .replace(/ partner program$/i, '')
+        .trim()
       const budgetData = {
         remaining_budget_dollars: campaign.remaining_budget_dollars ?? 0,
         referral_pending_period: campaign.referral_pending_period ?? 14,
         status: (campaign.status || 'active').toLowerCase(),
       }
 
-      byUuid.set(campaign.uuid, { ...budgetData, name: campaignName })
+      if (campaign.uuid) byUuid.set(campaign.uuid, { ...budgetData, name: campaignName })
+      if (campaign.partner_program_uuid) byPartnerProgramUuid.set(campaign.partner_program_uuid, budgetData)
       if (campaignName) {
         nameSet.add(campaignName)
         byName.set(campaignName, budgetData)
@@ -328,8 +340,8 @@ export class SparkLoopService {
     for (const c of Array.from(byUuid.values())) {
       statusCounts[c.status] = (statusCounts[c.status] || 0) + 1
     }
-    console.log(`[SparkLoop] Fetched ${byUuid.size} partner campaigns (${nameSet.size} unique names, statuses: ${JSON.stringify(statusCounts)})`)
-    return { byUuid, nameSet, byName }
+    console.log(`[SparkLoop] Fetched ${byUuid.size} partner campaigns (${byPartnerProgramUuid.size} programs, ${nameSet.size} unique names, statuses: ${JSON.stringify(statusCounts)})`)
+    return { byUuid, byPartnerProgramUuid, nameSet, byName }
   }
 
   /**
@@ -364,12 +376,14 @@ export class SparkLoopService {
     let created = 0
     let updated = 0
     let lowBudget = 0
+    let unknownBudget = 0
     let confirmDeltas = 0
     let rejectionDeltas = 0
 
     // Log budget match diagnostics
     let budgetMatched = 0
     let budgetUnmatched = 0
+    let matchedByProgramUuid = 0
     let matchedByUuid = 0
     let matchedByName = 0
 
@@ -388,32 +402,44 @@ export class SparkLoopService {
         .eq('ref_code', rec.ref_code)
         .single()
 
-      // Get budget info from partner campaigns using multiple matching strategies
-      // Strategy 1: Match by partner_program_uuid (trust UUID — it's a unique identifier)
-      // Strategy 2: Match by rec.uuid
-      // Strategy 3: Match by publication name (case-insensitive, fallback)
+      // Get budget info from partner campaigns. Strategies in priority order:
+      //   1. byPartnerProgramUuid — `partner_program_uuid` is stable across upscribe
+      //      placements, so this matches every rec whose program is in our inventory.
+      //   2. byUuid via rec.uuid — matches when this upscribe IS the primary placement
+      //      that partner_campaigns happens to return per-program.
+      //   3. byName — last-resort fallback. partner_campaigns.name is normalized to
+      //      "<Pub Name>" (suffix stripped) in getPartnerCampaigns above.
       const recNameNormalized = (rec.publication_name || '').trim().toLowerCase()
 
       let budgetInfo: { remaining_budget_dollars: number; referral_pending_period: number; status: string } | undefined
       let matchMethod = 'none'
 
-      // Try UUID-based matching first — trust UUID matches without name verification.
-      // UUIDs are unique identifiers; requiring name verification caused mass false-negatives
-      // because campaign names often differ slightly from recommendation names.
-      const uuidMatch = campaignData.byUuid.get(rec.partner_program_uuid) || campaignData.byUuid.get(rec.uuid)
-      if (uuidMatch) {
-        budgetInfo = uuidMatch
-        matchMethod = 'uuid'
+      const programMatch = campaignData.byPartnerProgramUuid.get(rec.partner_program_uuid)
+      if (programMatch) {
+        budgetInfo = programMatch
+        matchMethod = 'partner_program_uuid'
       } else {
-        // No UUID match — try name-based matching
-        budgetInfo = campaignData.byName.get(recNameNormalized)
-        if (budgetInfo) {
-          matchMethod = 'name'
-          matchedByName++
+        const uuidMatch = campaignData.byUuid.get(rec.uuid) || campaignData.byUuid.get(rec.partner_program_uuid)
+        if (uuidMatch) {
+          budgetInfo = uuidMatch
+          matchMethod = 'uuid'
+        } else {
+          const nameMatch = campaignData.byName.get(recNameNormalized)
+          if (nameMatch) {
+            budgetInfo = nameMatch
+            matchMethod = 'name'
+          }
         }
       }
 
-      if (budgetInfo) { budgetMatched++; if (matchMethod === 'uuid') matchedByUuid++ } else { budgetUnmatched++ }
+      if (budgetInfo) {
+        budgetMatched++
+        if (matchMethod === 'partner_program_uuid') matchedByProgramUuid++
+        else if (matchMethod === 'uuid') matchedByUuid++
+        else if (matchMethod === 'name') matchedByName++
+      } else {
+        budgetUnmatched++
+      }
 
       // Trust rec.status from the recommendations API as source of truth for paused/active.
       // The partner_campaigns endpoint can disagree — recommendations API is authoritative.
@@ -425,23 +451,39 @@ export class SparkLoopService {
         ? 'manual'
         : (rec.status === 'paused' ? 'api_paused' : null)
 
-      const remainingBudget = budgetInfo?.remaining_budget_dollars ?? 0
+      // Store null (not 0) when budget is unknown so UI can distinguish "depleted"
+      // from "no data" — the column is nullable and CellRenderer renders null as "—".
+      const remainingBudget: number | null = budgetInfo ? budgetInfo.remaining_budget_dollars : null
       const screeningPeriod = budgetInfo?.referral_pending_period ?? null
       const cpaInDollars = (rec.cpa || 0) / 100
       const minBudgetRequired = cpaInDollars * minConversionsBudget
+      const isPaidRec = (rec.cpa || 0) > 0
 
-      // Budget-based auto-pause only for active recs with known budget
-      const isLowBudget = budgetInfo && remainingBudget < minBudgetRequired
+      const isLowBudget = budgetInfo != null && budgetInfo.remaining_budget_dollars < minBudgetRequired
+      // Paid recs with no budget info — we'd be sending traffic without knowing the
+      // partner can pay. Pause as a precaution; restored automatically once the
+      // partner_campaign reappears in the inventory.
+      //
+      // Safety: only apply this if partner_campaigns returned a real inventory.
+      // An empty response (API error, bad/rotated key) would otherwise pause every
+      // paid rec across all publications — a self-inflicted outage.
+      const haveCampaignInventory = campaignData.byPartnerProgramUuid.size > 0
+      const isUnknownBudget = !budgetInfo && isPaidRec && haveCampaignInventory
 
       if (isLowBudget && effectiveStatus === 'active' && !isManuallyPaused) {
         effectiveStatus = 'paused'
         pausedReason = 'low_budget'
         lowBudget++
-        console.log(`[SparkLoop] Auto-pausing ${rec.publication_name} (budget $${remainingBudget} < ${minConversionsBudget}x CPA $${minBudgetRequired})`)
-      } else if (budgetInfo && !isLowBudget && existing?.paused_reason === 'low_budget') {
-        // Budget restored — un-pause (effectiveStatus already set from rec.status above)
+        console.log(`[SparkLoop] Auto-pausing ${rec.publication_name} (budget $${budgetInfo?.remaining_budget_dollars} < ${minConversionsBudget}x CPA $${minBudgetRequired})`)
+      } else if (isUnknownBudget && effectiveStatus === 'active' && !isManuallyPaused) {
+        effectiveStatus = 'paused'
+        pausedReason = 'unknown_budget'
+        unknownBudget++
+        console.log(`[SparkLoop] Auto-pausing ${rec.publication_name} (no partner_campaign match — budget unknown, CPA $${cpaInDollars})`)
+      } else if (budgetInfo && !isLowBudget && (existing?.paused_reason === 'low_budget' || existing?.paused_reason === 'unknown_budget')) {
+        // Budget data restored — un-pause (effectiveStatus already set from rec.status above)
         pausedReason = rec.status === 'paused' ? 'api_paused' : null
-        console.log(`[SparkLoop] Auto-reactivating ${rec.publication_name} (budget restored: $${remainingBudget})`)
+        console.log(`[SparkLoop] Auto-reactivating ${rec.publication_name} (budget restored: $${budgetInfo.remaining_budget_dollars})`)
       }
 
       // Preserve manual exclusion state (not related to budget)
@@ -599,7 +641,7 @@ export class SparkLoopService {
     const active = recommendations.filter(r => r.status === 'active').length
     const paused = recommendations.filter(r => r.status === 'paused').length
 
-    console.log(`[SparkLoop] Synced ${recommendations.length} recommendations: ${created} created, ${updated} updated (API: ${active} active, ${paused} paused | ${pausedByPartner} disappeared, ${lowBudget} low-budget-paused, ${reactivated} reactivated | budget match: ${budgetMatched} [${matchedByUuid} uuid, ${matchedByName} name], unmatched: ${budgetUnmatched})`)
+    console.log(`[SparkLoop] Synced ${recommendations.length} recommendations: ${created} created, ${updated} updated (API: ${active} active, ${paused} paused | ${pausedByPartner} disappeared, ${lowBudget} low-budget-paused, ${unknownBudget} unknown-budget-paused, ${reactivated} reactivated | budget match: ${budgetMatched} [${matchedByProgramUuid} program_uuid, ${matchedByUuid} uuid, ${matchedByName} name], unmatched: ${budgetUnmatched})`)
     if (confirmDeltas > 0 || rejectionDeltas > 0) {
       console.log(`[SparkLoop] Deltas tracked: +${confirmDeltas} confirms, +${rejectionDeltas} rejections`)
     }


### PR DESCRIPTION
## Summary
- Fix SparkLoop budget lookup that was failing 100% on Trader Leak (0/110 matched) — every active rec was rendering a fabricated `$0` budget while keeping `status='active'`. The matcher now keys on the stable `partner_program_uuid` instead of the placement-specific `uuid`, which only resolves for one upscribe per program.
- Store `null` (not `0`) when no `partner_campaign` row exists, so the UI shows `"—"` instead of misleading `$0`. The column is nullable; `CellRenderer.tsx:213` already renders null as `"—"`.
- Auto-pause paid recs (CPA > 0) with no campaign match — `paused_reason='unknown_budget'`. Gated by `partner_campaigns` returning ≥1 row, so a transient API error or rotated key can't pause every paid rec across publications.

## Root cause
`partner_campaigns.uuid` is a per-placement identifier that SparkLoop only emits for the account's primary upscribe. AI Accounting Daily happened to be that primary upscribe so `byUuid.get(rec.uuid)` matched its 176 recs. Trader Leak's recs carry different placement UUIDs and never matched, so `budgetInfo` was always undefined and the code at `?? 0` fabricated `$0`. The byName fallback was also dead code — partner-campaigns returns `"<Pub Name>'s Partner Program"` while recommendations use bare `"<Pub Name>"`.

## Changes
- `src/lib/sparkloop-client/sparkloop-client.ts`:
  - `getPartnerCampaigns()`: add `byPartnerProgramUuid` map; strip `'s Partner Program` / ` Partner Program` suffix when normalizing names for `byName`.
  - Match priority in sync loop: `partner_program_uuid` → `uuid` → `name`.
  - Store `remaining_budget_dollars` as `null` when no match (vs `?? 0`).
  - Add `unknown_budget` auto-pause for paid recs with no match (gated by non-empty inventory).
  - Extend auto-restore to cover both `low_budget` and `unknown_budget` pauses.
  - Add `matchedByProgramUuid` and `unknownBudget` counters to the sync summary log.
- `scripts/diagnose-sparkloop-budget-match.mjs`: new read-only diagnostic that runs the same matching strategies against the live API and reports per-publication hit/miss breakdown.

## Predicted impact
- Trader Leak: ~90 of 110 recs match via `partner_program_uuid`. Eric Seto Investing's real $0 budget is now visible and the rec auto-pauses with `paused_reason='low_budget'`. ~20 unmatched (mostly directory recs not in your partner inventory): paid ones auto-pause as `unknown_budget`; free ones stay active with `"—"` for budget.
- AI Accounting Daily: same 176/220 matches as before (existing `byUuid` path still works for the primary upscribe). New behavior is that the previously-fabricated `$0` rows now show `"—"`.

## Test plan
- [ ] Trigger a manual sparkloop sync on staging (crons are off there).
- [ ] In the Trader Leak dashboard sparkloop view, verify:
  - [ ] Eric Seto Investing shows `paused` with `low_budget` badge and budget `$0`.
  - [ ] Previously `Active / $0` rows now show either a real budget value, or are paused as `unknown_budget` with budget `"—"`.
  - [ ] No row in the table simultaneously shows `Active` badge and `$0` budget.
- [ ] Confirm AI Accounting Daily's sparkloop view did not regress (paused/active counts roughly the same as before).
- [ ] Check the Vercel runtime log for the sync — summary line should include nonzero `program_uuid` matches and a reasonable `unknown-budget-paused` count.
- [ ] On a subsequent sync, verify recs that were correctly matched stay matched (no flapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic tool to identify and troubleshoot SparkLoop budget-match failures during recommendation syncing.

* **Improvements**
  * Enhanced partner campaign matching with improved budget detection strategies and fallback logic.
  * Implemented auto-pause for recommendations with unknown budgets.
  * Expanded sync logging with detailed budget-match statistics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Venture-Formations/aiprodaily/pull/249)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->