### PR TITLE
fix(email): getEmailSettings reads new mailerlite_* keys

### DIFF
--- a/src/lib/publication-settings.ts
+++ b/src/lib/publication-settings.ts
@@ -344,17 +344,19 @@ export async function getEmailSettings(publicationId: string): Promise<{
   const settings = await getPublicationSettings(publicationId, [
     'email_senderName',
     'email_fromEmail',
+    'mailerlite_review_group_id',
     'email_reviewGroupId',
     'subject_line_emoji',
+    'mailerlite_main_group_id',
     'mailerlite_group_id',
   ])
 
   const result = {
     sender_name: settings.email_senderName || 'Newsletter',
     from_email: settings.email_fromEmail || 'newsletter@example.com',
-    review_group_id: settings.email_reviewGroupId || '',
+    review_group_id: settings.mailerlite_review_group_id || settings.email_reviewGroupId || '',
     subject_line_emoji: settings.subject_line_emoji || '',
-    mailerlite_group_id: settings.mailerlite_group_id || '',
+    mailerlite_group_id: settings.mailerlite_main_group_id || settings.mailerlite_group_id || '',
   }
 
   // Fail-closed on non-production/staging: require override env vars so Preview/Staging never targets production audiences


### PR DESCRIPTION
## Summary
- `getEmailSettings()` was reading legacy keys (`email_reviewGroupId`, `mailerlite_group_id`) while the Email Settings UI saves to new keys (`mailerlite_review_group_id`, `mailerlite_main_group_id`). UI changes to Review/Main Group IDs were silently ignored on review and final sends.
- Updated `getEmailSettings()` to prefer the new keys and fall back to legacy — mirrors the pattern already used by `getEmailProviderSettings()`.

## Impact
- `createReviewissue()` and `createFinalissue()` (MailerLite) and `sendgrid.ts` now respect UI-saved group IDs.
- `createTestIssue()` already read `mailerlite_test_group_id` directly — unchanged.
- Verified per-publication settings: trader-leak (review → `187384764825601886`), accounting (review → `179851803000570889`), testing (schedule disabled).

## Why it matters
Before this fix, any publication without a per-tenant `email_reviewGroupId` row fell through to the app-wide legacy fallback (`162626524274493402` — AI Accounting Daily's old group), regardless of what the UI showed. Trader Leak review sends were going to the wrong group as a result.

## Test plan
- [x] `npm run type-check` passes
- [x] Pre-push checks pass (type-check, lint, bug-pattern)
- [ ] After merge: trigger next scheduled review send for Trader Leak; confirm MailerLite campaign lands in group `187384764825601886`
- [ ] Confirm AI Accounting Daily review send lands in group `179851803000570889` (intentional change — UI value, not legacy fallback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated email settings configuration handling to support newer settings keys while maintaining backward compatibility with legacy keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Venture-Formations/aiprodaily/pull/250)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->