### PR TITLE
Promote staging → production (incl. cross-issue ticker cooldown)

### DIFF
--- a/docs/superpowers/plans/2026-05-20-ticker-cooldown.md
+++ b/docs/superpowers/plans/2026-05-20-ticker-cooldown.md
@@ -66,16 +66,18 @@ describe('selectPostsWithTickerCooldown', () => {
   })
 
   it('skips a ticker that is on cooldown', () => {
+    // articlesNeeded=2 and two non-cooldown posts exist, so no backfill.
     const posts = [post('a', 'COR'), post('b', 'IBM'), post('c', 'MKL')]
-    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 3, 12)
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 2, 12)
     expect(r.selected.map(p => p.id)).toEqual(['b', 'c'])
     expect(r.skippedByCooldown).toBe(1)
     expect(r.backfilled).toBe(0)
   })
 
   it('matches cooldown tickers case-insensitively', () => {
+    // articlesNeeded=1 and one non-cooldown post exists, so no backfill.
     const posts = [post('a', 'cor'), post('b', 'IBM')]
-    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 3, 12)
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 1, 12)
     expect(r.selected.map(p => p.id)).toEqual(['b'])
   })
 

--- a/docs/superpowers/plans/2026-05-20-ticker-cooldown.md
+++ b/docs/superpowers/plans/2026-05-20-ticker-cooldown.md
@@ -1,0 +1,732 @@
+# Cross-Issue Ticker Cooldown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-article-module ticker cooldown that prevents the same company (ticker) from being selected as an article on issues fewer than N days apart.
+
+**Architecture:** A pure selection function (`selectPostsWithTickerCooldown`) replaces the intra-issue "one article per ticker" loop in `assignPostsToModule`. It additionally skips tickers featured in recent issues — supplied by a new DAL function (`listRecentlyFeaturedTickers`) — and backfills if the cooldown would leave the module short. The window is configured per article module in `article_modules.config.ticker_cooldown_days`, edited via a toggle in the module's "Article Selection Settings" UI. Absent config = disabled = today's exact behavior.
+
+**Tech Stack:** TypeScript, Next.js (App Router), Supabase (`supabaseAdmin`), Vitest, React.
+
+**Spec:** `docs/superpowers/specs/2026-05-20-ticker-cooldown-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `src/lib/rss-processor/ticker-cooldown.ts` | Pure cooldown-aware candidate selection | Create |
+| `src/lib/rss-processor/__tests__/ticker-cooldown.test.ts` | Unit tests for the pure function | Create |
+| `src/lib/dal/articles.ts` | Add `listRecentlyFeaturedTickers` | Modify |
+| `src/lib/dal/__tests__/articles.test.ts` | Tests for `listRecentlyFeaturedTickers` | Modify |
+| `src/lib/dal/index.ts` | Export `listRecentlyFeaturedTickers` | Modify |
+| `src/lib/rss-processor/module-articles.ts` | Wire cooldown into `assignPostsToModule` | Modify |
+| `src/components/article-modules/ArticleModuleGeneralTab.tsx` | Toggle + days input UI control | Modify |
+
+---
+
+## Setup
+
+- [ ] **Create the feature branch**
+
+Run:
+```bash
+git checkout staging
+git pull
+git checkout -b feature/ticker-cooldown
+```
+Expected: `Switched to a new branch 'feature/ticker-cooldown'`
+
+---
+
+## Task 1: Pure selection function `selectPostsWithTickerCooldown`
+
+**Files:**
+- Create: `src/lib/rss-processor/ticker-cooldown.ts`
+- Test: `src/lib/rss-processor/__tests__/ticker-cooldown.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/rss-processor/__tests__/ticker-cooldown.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { selectPostsWithTickerCooldown } from '../ticker-cooldown'
+
+const post = (id: string, ticker: string | null) => ({ id, ticker })
+
+describe('selectPostsWithTickerCooldown', () => {
+  it('with an empty cooldown set, behaves like one-per-ticker dedup', () => {
+    const posts = [post('a', 'AAA'), post('b', 'AAA'), post('c', 'BBB')]
+    const r = selectPostsWithTickerCooldown(posts, new Set<string>(), 3, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['a', 'c'])
+    expect(r.skippedByCooldown).toBe(0)
+    expect(r.backfilled).toBe(0)
+  })
+
+  it('skips a ticker that is on cooldown', () => {
+    const posts = [post('a', 'COR'), post('b', 'IBM'), post('c', 'MKL')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 3, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['b', 'c'])
+    expect(r.skippedByCooldown).toBe(1)
+    expect(r.backfilled).toBe(0)
+  })
+
+  it('matches cooldown tickers case-insensitively', () => {
+    const posts = [post('a', 'cor'), post('b', 'IBM')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 3, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['b'])
+  })
+
+  it('backfills cooled-down posts when the primary pass is short of the minimum', () => {
+    const posts = [post('a', 'COR'), post('b', 'IBM'), post('c', 'COR')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 2, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['b', 'a'])
+    expect(r.skippedByCooldown).toBe(2)
+    expect(r.backfilled).toBe(1)
+  })
+
+  it('does not backfill when the primary pass already meets the minimum', () => {
+    const posts = [post('a', 'COR'), post('b', 'IBM'), post('c', 'MKL')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 2, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['b', 'c'])
+    expect(r.backfilled).toBe(0)
+  })
+
+  it('never selects two posts for the same ticker, even via backfill', () => {
+    const posts = [post('a', 'COR'), post('b', 'COR'), post('c', 'COR')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 3, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['a'])
+    expect(r.backfilled).toBe(1)
+  })
+
+  it('passes through posts with no ticker without deduping them', () => {
+    const posts = [post('a', null), post('b', null), post('c', 'COR')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 2, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['a', 'b'])
+    expect(r.skippedByCooldown).toBe(1)
+  })
+
+  it('caps the primary pass at postsToAssign', () => {
+    const posts = [post('a', 'A'), post('b', 'B'), post('c', 'C'), post('d', 'D')]
+    const r = selectPostsWithTickerCooldown(posts, new Set<string>(), 2, 3)
+    expect(r.selected.map(p => p.id)).toEqual(['a', 'b', 'c'])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/lib/rss-processor/__tests__/ticker-cooldown.test.ts`
+Expected: FAIL — `Failed to resolve import "../ticker-cooldown"` (file does not exist yet).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/rss-processor/ticker-cooldown.ts`:
+
+```typescript
+/**
+ * Cooldown-aware candidate selection for article modules.
+ *
+ * Pure, side-effect-free. Replaces the intra-issue "one article per ticker"
+ * loop in `assignPostsToModule` and additionally skips tickers featured in a
+ * recent issue (the cross-issue cooldown). A backfill pass guarantees the
+ * module is never left short purely because of the cooldown.
+ */
+
+/** Minimal shape the cooldown selector needs from a candidate post. */
+export interface CandidatePost {
+  id: string
+  ticker?: string | null
+}
+
+export interface TickerCooldownResult<T> {
+  /** Posts chosen for the module, in selection order. */
+  selected: T[]
+  /** Count of candidate posts skipped because their ticker was on cooldown. */
+  skippedByCooldown: number
+  /** Count of cooled-down posts restored by the backfill pass. */
+  backfilled: number
+}
+
+/**
+ * Select candidate posts for an article module, one per ticker, applying a
+ * cross-issue ticker cooldown.
+ *
+ * @param sortedPosts      candidates already sorted by score, descending
+ * @param cooldownTickers  UPPER-CASED tickers featured in a recent issue
+ * @param articlesNeeded   minimum posts the module must fill (articles_count)
+ * @param postsToAssign    candidate target (>= articlesNeeded)
+ */
+export function selectPostsWithTickerCooldown<T extends CandidatePost>(
+  sortedPosts: T[],
+  cooldownTickers: Set<string>,
+  articlesNeeded: number,
+  postsToAssign: number,
+): TickerCooldownResult<T> {
+  const selected: T[] = []
+  const seenTickers = new Set<string>()
+  const cooledDown: T[] = []
+  let skippedByCooldown = 0
+
+  // Primary pass: one post per ticker, skipping tickers on cooldown.
+  for (const post of sortedPosts) {
+    if (selected.length >= postsToAssign) break
+
+    const ticker = post.ticker ? post.ticker.toUpperCase() : ''
+
+    if (ticker && seenTickers.has(ticker)) {
+      continue // already have a post for this company this issue
+    }
+    if (ticker && cooldownTickers.has(ticker)) {
+      cooledDown.push(post)
+      skippedByCooldown++
+      continue
+    }
+
+    selected.push(post)
+    if (ticker) seenTickers.add(ticker)
+  }
+
+  // Backfill pass: if the cooldown left us short of the minimum, restore the
+  // highest-scored cooled-down posts (still one per ticker).
+  let backfilled = 0
+  for (const post of cooledDown) {
+    if (selected.length >= articlesNeeded) break
+
+    const ticker = post.ticker ? post.ticker.toUpperCase() : ''
+    if (ticker && seenTickers.has(ticker)) continue
+
+    selected.push(post)
+    if (ticker) seenTickers.add(ticker)
+    backfilled++
+  }
+
+  return { selected, skippedByCooldown, backfilled }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/lib/rss-processor/__tests__/ticker-cooldown.test.ts`
+Expected: PASS — 8 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/rss-processor/ticker-cooldown.ts src/lib/rss-processor/__tests__/ticker-cooldown.test.ts
+git commit -m "feat(rss): pure cooldown-aware article selection function"
+```
+
+---
+
+## Task 2: DAL function `listRecentlyFeaturedTickers`
+
+**Files:**
+- Modify: `src/lib/dal/articles.ts` (append a new function)
+- Modify: `src/lib/dal/index.ts:52-70` (add to the articles export block)
+- Test: `src/lib/dal/__tests__/articles.test.ts` (add to import list + append a describe block)
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/lib/dal/__tests__/articles.test.ts`, add `listRecentlyFeaturedTickers` to the import block. Change:
+
+```typescript
+import {
+  listModuleArticlesByIssue,
+  moduleArticleExists,
+  listArticlesNeedingBody,
+  listArticlesNeedingFactCheck,
+  insertModuleArticle,
+  updateModuleArticleContent,
+  updateModuleArticleFactCheck,
+  listManualArticlesByPublication,
+  findNextAvailableSlug,
+  insertManualArticle,
+  updateManualArticle,
+  deleteManualArticle,
+} from '../articles'
+```
+
+to:
+
+```typescript
+import {
+  listModuleArticlesByIssue,
+  moduleArticleExists,
+  listArticlesNeedingBody,
+  listArticlesNeedingFactCheck,
+  insertModuleArticle,
+  updateModuleArticleContent,
+  updateModuleArticleFactCheck,
+  listManualArticlesByPublication,
+  findNextAvailableSlug,
+  insertManualArticle,
+  updateManualArticle,
+  deleteManualArticle,
+  listRecentlyFeaturedTickers,
+} from '../articles'
+```
+
+Then append this describe block to the end of the file:
+
+```typescript
+// ---------------------------------------------------------------------------
+describe('listRecentlyFeaturedTickers', () => {
+  it('returns the distinct, upper-cased set of recent active tickers', async () => {
+    mockChainResult = {
+      data: [{ ticker: 'COR' }, { ticker: 'ibm' }, { ticker: 'COR' }],
+      error: null,
+    }
+    const result = await listRecentlyFeaturedTickers('pub-1', '2026-05-20', 7, 'iss-cur')
+    expect(result).toEqual(new Set(['COR', 'IBM']))
+  })
+
+  it('computes the cutoff date as issueDate minus cooldownDays', async () => {
+    mockChainResult = { data: [], error: null }
+    await listRecentlyFeaturedTickers('pub-1', '2026-05-20', 7, 'iss-cur')
+    expect(mockChain.gte).toHaveBeenCalledWith('publication_issues.date', '2026-05-13')
+    expect(mockChain.lte).toHaveBeenCalledWith('publication_issues.date', '2026-05-20')
+  })
+
+  it('filters by is_active, non-null ticker, publication, and excludes the current issue', async () => {
+    mockChainResult = { data: [], error: null }
+    await listRecentlyFeaturedTickers('pub-1', '2026-05-20', 7, 'iss-cur')
+    expect(mockChain.eq).toHaveBeenCalledWith('is_active', true)
+    expect(mockChain.not).toHaveBeenCalledWith('ticker', 'is', null)
+    expect(mockChain.eq).toHaveBeenCalledWith('publication_issues.publication_id', 'pub-1')
+    expect(mockChain.neq).toHaveBeenCalledWith('issue_id', 'iss-cur')
+  })
+
+  it('returns an empty set on query error', async () => {
+    mockChainResult = { data: null, error: { message: 'fail' } }
+    const result = await listRecentlyFeaturedTickers('pub-1', '2026-05-20', 7, 'iss-cur')
+    expect(result).toEqual(new Set())
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/lib/dal/__tests__/articles.test.ts`
+Expected: FAIL — `listRecentlyFeaturedTickers` is not exported from `../articles`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append this function to the end of the `// ==================== module_articles ====================` section in `src/lib/dal/articles.ts` (immediately before the `// ==================== manual_articles ====================` comment on line 265):
+
+```typescript
+/**
+ * Tickers featured as an active article in a publication's recent issues.
+ * Used to enforce a cross-issue ticker cooldown during article selection.
+ *
+ * Returns the distinct set of UPPER-CASED tickers that were `is_active`
+ * module_articles in issues dated within `[issueDate - cooldownDays, issueDate]`,
+ * excluding the issue currently being built. Issue status is intentionally NOT
+ * filtered — sent, in-review, and draft issues all count. On any failure
+ * returns an empty set, degrading safely to "no cooldown".
+ */
+export async function listRecentlyFeaturedTickers(
+  publicationId: string,
+  issueDate: string,
+  cooldownDays: number,
+  excludeIssueId: string
+): Promise<Set<string>> {
+  try {
+    const cutoff = new Date(`${issueDate}T00:00:00Z`)
+    cutoff.setUTCDate(cutoff.getUTCDate() - cooldownDays)
+    const cutoffDate = cutoff.toISOString().split('T')[0]
+
+    const { data, error } = await supabaseAdmin
+      .from('module_articles')
+      .select('ticker, publication_issues!inner(publication_id, date)')
+      .eq('is_active', true)
+      .not('ticker', 'is', null)
+      .eq('publication_issues.publication_id', publicationId)
+      .gte('publication_issues.date', cutoffDate)
+      .lte('publication_issues.date', issueDate)
+      .neq('issue_id', excludeIssueId)
+
+    if (error) {
+      log.error({ err: error, publicationId }, 'listRecentlyFeaturedTickers failed')
+      return new Set()
+    }
+
+    const tickers = new Set<string>()
+    for (const row of data || []) {
+      const t = (row as any).ticker
+      if (t) tickers.add(String(t).toUpperCase())
+    }
+    return tickers
+  } catch (err) {
+    log.error({ err, publicationId }, 'listRecentlyFeaturedTickers exception')
+    return new Set()
+  }
+}
+```
+
+- [ ] **Step 4: Export it from the DAL barrel**
+
+In `src/lib/dal/index.ts`, change the articles export block (lines 52-70):
+
+```typescript
+// Articles DAL — module_articles + manual_articles
+export {
+  MODULE_ARTICLE_COLUMNS,
+  MODULE_ARTICLE_BODY_GEN_SELECT,
+  MODULE_ARTICLE_FACT_CHECK_SELECT,
+  MANUAL_ARTICLE_COLUMNS,
+  MANUAL_ARTICLE_WITH_CATEGORY_SELECT,
+  listModuleArticlesByIssue,
+  moduleArticleExists,
+  listArticlesNeedingBody,
+  listArticlesNeedingFactCheck,
+  insertModuleArticle,
+  updateModuleArticleContent,
+  updateModuleArticleFactCheck,
+  listManualArticlesByPublication,
+  findNextAvailableSlug,
+  insertManualArticle,
+  updateManualArticle,
+  deleteManualArticle,
+} from './articles'
+```
+
+to add `listRecentlyFeaturedTickers`:
+
+```typescript
+// Articles DAL — module_articles + manual_articles
+export {
+  MODULE_ARTICLE_COLUMNS,
+  MODULE_ARTICLE_BODY_GEN_SELECT,
+  MODULE_ARTICLE_FACT_CHECK_SELECT,
+  MANUAL_ARTICLE_COLUMNS,
+  MANUAL_ARTICLE_WITH_CATEGORY_SELECT,
+  listModuleArticlesByIssue,
+  moduleArticleExists,
+  listArticlesNeedingBody,
+  listArticlesNeedingFactCheck,
+  insertModuleArticle,
+  updateModuleArticleContent,
+  updateModuleArticleFactCheck,
+  listRecentlyFeaturedTickers,
+  listManualArticlesByPublication,
+  findNextAvailableSlug,
+  insertManualArticle,
+  updateManualArticle,
+  deleteManualArticle,
+} from './articles'
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/lib/dal/__tests__/articles.test.ts`
+Expected: PASS — all tests pass, including the 4 new `listRecentlyFeaturedTickers` tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/dal/articles.ts src/lib/dal/index.ts src/lib/dal/__tests__/articles.test.ts
+git commit -m "feat(dal): listRecentlyFeaturedTickers for cross-issue ticker cooldown"
+```
+
+---
+
+## Task 3: Wire the cooldown into `assignPostsToModule`
+
+**Files:**
+- Modify: `src/lib/rss-processor/module-articles.ts` (imports + the candidate-selection block)
+
+This task replaces the intra-issue `seenTickers` loop. There is no unit test for `assignPostsToModule` (it is database-integration glue); the logic it now relies on is fully covered by Task 1 and Task 2. Verification here is type-check + the full unit suite.
+
+- [ ] **Step 1: Add the imports**
+
+In `src/lib/rss-processor/module-articles.ts`, the current import block (lines 1-19) is:
+
+```typescript
+import { supabaseAdmin } from '../supabase'
+import { AI_CALL, callOpenAI } from '../openai'
+import { normalizeTransactionType } from '../transaction-type'
+import { detectAIRefusal, getNewsletterIdFromIssue } from './shared-context'
+import {
+  listPostsForScoring,
+  assignPostsToIssue,
+  listAssignedPostsForModule,
+  POST_WITH_RATINGS_BRIEF,
+  moduleArticleExists,
+  insertModuleArticle,
+  listArticlesNeedingBody,
+  listArticlesNeedingFactCheck,
+  updateModuleArticleContent,
+  updateModuleArticleFactCheck,
+  listDuplicateGroupIdsByIssue,
+  listDuplicatePostIdsByGroups,
+} from '@/lib/dal'
+import type { ArticleGenerator } from './article-generator'
+```
+
+Replace it with (adds `selectPostsWithTickerCooldown` import and `listRecentlyFeaturedTickers` to the DAL import):
+
+```typescript
+import { supabaseAdmin } from '../supabase'
+import { AI_CALL, callOpenAI } from '../openai'
+import { normalizeTransactionType } from '../transaction-type'
+import { detectAIRefusal, getNewsletterIdFromIssue } from './shared-context'
+import { selectPostsWithTickerCooldown } from './ticker-cooldown'
+import {
+  listPostsForScoring,
+  assignPostsToIssue,
+  listAssignedPostsForModule,
+  POST_WITH_RATINGS_BRIEF,
+  moduleArticleExists,
+  insertModuleArticle,
+  listArticlesNeedingBody,
+  listArticlesNeedingFactCheck,
+  updateModuleArticleContent,
+  updateModuleArticleFactCheck,
+  listDuplicateGroupIdsByIssue,
+  listDuplicatePostIdsByGroups,
+  listRecentlyFeaturedTickers,
+} from '@/lib/dal'
+import type { ArticleGenerator } from './article-generator'
+```
+
+- [ ] **Step 2: Replace the candidate-selection block**
+
+In `src/lib/rss-processor/module-articles.ts`, inside `assignPostsToModule`, find this block (currently lines ~139-165):
+
+```typescript
+    // Sort by total score descending
+    const sortedPosts = eligiblePosts
+      .sort((a: any, b: any) => {
+        const scoreA = a.post_ratings?.[0]?.total_score || 0
+        const scoreB = b.post_ratings?.[0]?.total_score || 0
+        return scoreB - scoreA
+      })
+
+    // Select top posts: 1 per ticker (company), then fill remaining slots
+    const selectedPosts: any[] = []
+    const seenTickers = new Set<string>()
+
+    for (const post of sortedPosts) {
+      if (selectedPosts.length >= postsToAssign) break
+
+      const ticker = (post as any).ticker?.toUpperCase()
+      if (ticker && seenTickers.has(ticker)) {
+        continue // Skip: already have a post for this company
+      }
+
+      selectedPosts.push(post)
+      if (ticker) seenTickers.add(ticker)
+    }
+
+    if (seenTickers.size > 0) {
+      console.log(`[Module] Ticker dedup: ${sortedPosts.length} candidates → ${selectedPosts.length} selected (${seenTickers.size} unique companies)`)
+    }
+```
+
+Replace it with:
+
+```typescript
+    // Sort by total score descending
+    const sortedPosts = eligiblePosts
+      .sort((a: any, b: any) => {
+        const scoreA = a.post_ratings?.[0]?.total_score || 0
+        const scoreB = b.post_ratings?.[0]?.total_score || 0
+        return scoreB - scoreA
+      })
+
+    // Cross-issue ticker cooldown — per-module config; absent/0 = disabled.
+    const cooldownDaysRaw = (mod.config as Record<string, any>)?.ticker_cooldown_days
+    const cooldownDays = typeof cooldownDaysRaw === 'number' ? cooldownDaysRaw : 0
+    let cooldownTickers = new Set<string>()
+    if (cooldownDays >= 1) {
+      const { data: issueRow } = await supabaseAdmin
+        .from('publication_issues')
+        .select('publication_id, date')
+        .eq('id', issueId)
+        .single()
+      if (issueRow?.publication_id && issueRow?.date) {
+        cooldownTickers = await listRecentlyFeaturedTickers(
+          issueRow.publication_id,
+          issueRow.date,
+          cooldownDays,
+          issueId
+        )
+      }
+    }
+
+    // Select top posts: 1 per ticker, skipping tickers on cooldown. Backfill
+    // ensures the module is never short purely because of the cooldown.
+    const { selected: selectedPosts, skippedByCooldown, backfilled } =
+      selectPostsWithTickerCooldown(sortedPosts, cooldownTickers, articlesNeeded, postsToAssign)
+
+    if (cooldownDays >= 1) {
+      console.log(`[Module] Ticker cooldown (${cooldownDays}d): ${sortedPosts.length} candidates → ${selectedPosts.length} selected, ${skippedByCooldown} skipped (cooldown), ${backfilled} backfilled`)
+    }
+```
+
+Note: `articlesNeeded` and `postsToAssign` are already declared earlier in this function (lines ~74-78); `selectedPosts` is still an `any[]` and the existing `if (selectedPosts.length > 0)` assignment block below is unchanged.
+
+- [ ] **Step 3: Run the type-checker**
+
+Run: `npm run type-check`
+Expected: PASS — no type errors.
+
+- [ ] **Step 4: Run the full unit test suite**
+
+Run: `npm run test:run`
+Expected: PASS — all tests pass (the suite includes Task 1 and Task 2 tests; no existing test exercises `module-articles.ts`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/rss-processor/module-articles.ts
+git commit -m "feat(rss): apply per-module ticker cooldown in assignPostsToModule"
+```
+
+---
+
+## Task 4: Settings UI control
+
+**Files:**
+- Modify: `src/components/article-modules/ArticleModuleGeneralTab.tsx` (insert into the "Article Selection Settings" section)
+
+The article-module settings components have no test harness; this control mirrors the existing untested "Extra Candidates" toggle in the same file. Verification is type-check + build + a manual check.
+
+- [ ] **Step 1: Insert the toggle + days input**
+
+In `src/components/article-modules/ArticleModuleGeneralTab.tsx`, find the end of the "Extra Candidates" block and the section's closing tags (currently lines ~125-130):
+
+```tsx
+            )
+          })()}
+        </div>
+      </div>
+
+      <RssOutputSection module={module} onUpdate={onUpdate} disabled={isDisabled} saving={saving} setSaving={setSaving} variant="draft" />
+```
+
+Replace it with (inserts the new IIFE before the section's closing `</div>`):
+
+```tsx
+            )
+          })()}
+          {(() => {
+            const cooldownDays = (module.config as Record<string, any>)?.ticker_cooldown_days
+            const isEnabled = typeof cooldownDays === 'number' && cooldownDays >= 1
+            const handleCooldownChange = (value: number | null) => withSaving(async () => {
+              const currentConfig = (module.config as Record<string, any>) || {}
+              if (value === null) {
+                const { ticker_cooldown_days: _, ...rest } = currentConfig
+                await onUpdate({ config: rest } as any)
+              } else {
+                await onUpdate({ config: { ...currentConfig, ticker_cooldown_days: value } } as any)
+              }
+            })
+            return (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <label className="text-sm font-medium text-gray-700">Ticker Cooldown</label>
+                    <p className="text-xs text-gray-500">{isEnabled ? `Skips any company (ticker) featured in the last ${cooldownDays} days` : 'Off — a company can be selected on consecutive issues. For trades newsletters.'}</p>
+                  </div>
+                  <button type="button" onClick={() => handleCooldownChange(isEnabled ? null : 7)} disabled={isDisabled} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isEnabled ? 'bg-emerald-500' : 'bg-gray-300'} ${isDisabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}`}>
+                    <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${isEnabled ? 'translate-x-6' : 'translate-x-1'}`} />
+                  </button>
+                </div>
+                {isEnabled && (
+                  <div className="flex items-center gap-2 pl-1">
+                    <span className="text-xs text-gray-500">Cooldown days:</span>
+                    <input type="number" min={1} max={30} value={cooldownDays} onChange={(e) => { const val = parseInt(e.target.value); if (!isNaN(val) && val >= 1 && val <= 30) handleCooldownChange(val) }} disabled={isDisabled} className="w-20 px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500" />
+                  </div>
+                )}
+              </div>
+            )
+          })()}
+        </div>
+      </div>
+
+      <RssOutputSection module={module} onUpdate={onUpdate} disabled={isDisabled} saving={saving} setSaving={setSaving} variant="draft" />
+```
+
+- [ ] **Step 2: Type-check and build**
+
+Run: `npm run type-check`
+Expected: PASS — no type errors.
+
+Run: `npm run build`
+Expected: PASS — build completes successfully.
+
+- [ ] **Step 3: Manual verification**
+
+Start the dev server (`npm run dev`), then in the dashboard go to **Settings → Sections**, open an article module, and select the **General** tab. Under **Article Selection Settings**, confirm:
+1. A "Ticker Cooldown" row appears below "Extra Candidates" with an off (grey) toggle and the help text "Off — a company can be selected on consecutive issues."
+2. Clicking the toggle turns it green, reveals a "Cooldown days" number input pre-filled with `7`, and the help text changes to "Skips any company (ticker) featured in the last 7 days".
+3. Changing the number to e.g. `5` persists (reload the page — the value and toggle state survive).
+4. Toggling off hides the input; reloading shows it still off.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/article-modules/ArticleModuleGeneralTab.tsx
+git commit -m "feat(ui): ticker cooldown toggle in article module settings"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: Run the full verification suite**
+
+Run each and confirm it passes:
+```bash
+npm run build
+npm run type-check
+npm run lint
+npm run test:run
+npm run check:bug-patterns
+```
+Expected: `build`, `type-check`, `test:run`, `check:bug-patterns` pass; `lint` passes within the `--max-warnings 360` ceiling.
+
+- [ ] **Step 2: Fix any failures**
+
+If any command fails, fix the cause and re-run that command before proceeding. Do not proceed with failing checks.
+
+- [ ] **Step 3: Pre-push review gate**
+
+Before pushing, run the project's required pre-push review (per `CLAUDE.md` §5): `/simplify`, `/requesting-code-review`, `/review:pre-push`. Address findings, then push the `feature/ticker-cooldown` branch and open a PR into `staging`.
+
+---
+
+## Task 6: Enable the cooldown for Trader Leak (post-deploy)
+
+This is an operational step, performed **after** the code is deployed to the environment where Trader Leak runs. No code change.
+
+- [ ] **Step 1: Enable via the UI (preferred)**
+
+In the dashboard for the **Trader Leak** publication, go to **Settings → Sections**, open the **Politician Trades** article module (`9f9cd920-c2fe-4b46-92f0-abd453e4d661`), **General** tab → **Article Selection Settings** → turn on **Ticker Cooldown** and set **Cooldown days** to `7`.
+
+- [ ] **Step 2: Fallback — enable via SQL**
+
+If setting it directly in the database instead, run against the relevant Supabase project:
+
+```sql
+UPDATE article_modules
+SET config = COALESCE(config, '{}'::jsonb) || '{"ticker_cooldown_days": 7}'::jsonb
+WHERE id = '9f9cd920-c2fe-4b46-92f0-abd453e4d661';
+```
+
+- [ ] **Step 3: Verify on the next issue build**
+
+After the next Trader Leak issue is built, check the workflow logs for a line like:
+`[Module] Ticker cooldown (7d): N candidates → M selected, X skipped (cooldown), Y backfilled`
+and confirm no ticker from an issue in the previous 7 days reappears as an article.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** setting (§1) → Task 4 + Task 6; DAL `listRecentlyFeaturedTickers` (§2) → Task 2; pure `selectPostsWithTickerCooldown` (§3) → Task 1; wiring (§4) → Task 3; logging (§5) → Task 3 Step 2; UI (§6) → Task 4; tests (§7) → Task 1 + Task 2; rollout → Task 6.
+- **Design refinement:** the spec leaves the `listRecentlyFeaturedTickers` query shape open; this plan uses a single PostgREST embedded `publication_issues!inner(...)` query (the `module_articles_issue_id_fkey` foreign key exists), which keeps it to one round-trip and trivially unit-testable.

--- a/docs/superpowers/specs/2026-05-20-ticker-cooldown-design.md
+++ b/docs/superpowers/specs/2026-05-20-ticker-cooldown-design.md
@@ -1,0 +1,197 @@
+---
+name: ticker-cooldown
+description: Cross-issue ticker cooldown to stop the same company recurring as a lead trade article on consecutive issues
+status: complete
+created: 2026-05-20T13:49:49Z
+updated: 2026-05-20T13:49:49Z
+---
+
+# Cross-Issue Ticker Cooldown
+
+## Problem
+
+On 2026-05-19 and 2026-05-20, the Trader Leak publication
+(`8277682a-7292-4c36-bca1-a39ca420b305`) featured the same congressional trade
+— Michael T. McCaul selling Cencora (`COR`) — as a top article two days in a
+row. The 5/19 article (`module_articles` `70beac99`, post `579fc764`) and the
+5/20 article (post `2570c7e1`) were built from two **different** Yahoo Finance
+news stories:
+
+- 5/19: "Cencora Legal Probes Test Investor Confidence After Weaker Q2 Revenue Outlook"
+- 5/20: "The Top 5 Analyst Questions From Cencora's Q1 Earnings Call"
+
+The 5/20 issue was caught in review and manually corrected before send.
+
+### Root cause
+
+The existing deduplication system (`src/lib/deduplicator.ts`) de-duplicates
+**news articles** across recent issues via three checks: exact content hash,
+headline Jaccard similarity (threshold `0.7` for Trader Leak), and AI semantic
+comparison of article text. It ran correctly on the 5/20 issue (creating four
+historical-match groups) and the 5/19 issue *was* sent and inside the lookback
+window — so this was not a timing miss.
+
+The two Cencora items are genuinely different news stories, so every
+article-level check correctly concluded they were not the same article. The gap
+is that Trader Leak articles are organized around a **trade**
+(`ticker` + `member_name` + `transaction_type`), and the "Politician Trades"
+feed supplies whatever fresh news exists about a ticker. A heavily-covered stock
+(`COR` is under multiple securities-fraud investigations) keeps generating new
+articles, so the same trade resurfaces day after day on a different news hook.
+
+The only ticker de-duplication that exists is the `seenTickers` loop in
+`ModuleArticles.assignPostsToModule` (`src/lib/rss-processor/module-articles.ts`)
+— "one article per company" — and it is **intra-issue only**. Nothing checks
+whether a ticker was featured in a *recent* issue.
+
+This is systemic. Other repeated tickers in active `module_articles` over the
+prior 10 days: `GS`/Salazar (5/11, 5/13 — within a 3-day window), `MSFT`/Gottheimer
+(5/14, 5/17), `TSM`/Cleo Fields (5/11, 5/20).
+
+## Goals
+
+- Prevent the same `ticker` from being selected as an article in issues that are
+  fewer than N days apart, for publications that opt in.
+- Never leave an issue short of articles purely because of the cooldown.
+- Zero behavior change for publications that do not opt in.
+
+## Non-Goals
+
+- No change to the article-text deduplication system.
+- No cooldown keyed on `member_name` or `transaction_type` — ticker only.
+- No dashboard UI control in this iteration (the setting is configured directly
+  in the database; a settings-page toggle is a possible later addition).
+- No database schema migration.
+
+## Design
+
+### 1. Setting: `ticker_cooldown_days`
+
+A new key/value setting resolved through the standard two-tier fallback
+(`getPublicationSetting` → `publication_settings`, then `app_settings`).
+
+- Type: integer, number of days.
+- Default: `0` (disabled). When `0` or absent, the cooldown code path is fully
+  skipped — no query, no filtering, identical behavior to today.
+- Trader Leak: a `publication_settings` row set to `7`.
+- An optional `app_settings` row of `0` may be added to document the default;
+  it is not required for correctness since an absent setting resolves to `0`.
+
+### 2. DAL function: `listRecentlyFeaturedTickers`
+
+New function in `src/lib/dal/articles.ts`:
+
+```
+listRecentlyFeaturedTickers(
+  publicationId: string,
+  issueDate: string,        // YYYY-MM-DD of the issue being built
+  cooldownDays: number,
+  excludeIssueId: string,   // the issue currently being built
+): Promise<Set<string>>
+```
+
+Returns the distinct set of tickers that were active `module_articles`
+(`is_active = true`, `ticker IS NOT NULL`) in any of that publication's issues
+dated within `[issueDate − cooldownDays, issueDate]`, excluding `excludeIssueId`.
+
+- Issue **status is not filtered** — sent, in-review, and draft issues all
+  count. This makes the cooldown robust when the previous day's issue is still
+  in review when the next issue is built.
+- Date comparison uses local date strings (`YYYY-MM-DD`), per the project date
+  rule — no `toISOString()` for logic.
+- Follows DAL conventions: explicit column list, filters by `publication_id`,
+  errors logged via pino and swallowed (returns an empty set on failure, which
+  degrades safely to "no cooldown").
+
+### 3. Pure selection function: `selectPostsWithTickerCooldown`
+
+New file `src/lib/rss-processor/ticker-cooldown.ts` exporting a pure,
+side-effect-free function:
+
+```
+selectPostsWithTickerCooldown(
+  sortedPosts: PostWithTicker[],   // already sorted by score, descending
+  cooldownTickers: Set<string>,    // from listRecentlyFeaturedTickers
+  articlesNeeded: number,          // module.articles_count — the minimum
+  postsToAssign: number,           // candidate target (>= articlesNeeded)
+): { selected: PostWithTicker[]; skippedByCooldown: number; backfilled: number }
+```
+
+Logic:
+
+1. **Primary pass** — walk `sortedPosts` by score. Take one post per ticker, up
+   to `postsToAssign`. Skip a post if its (upper-cased) ticker has already been
+   selected in this issue *or* is in `cooldownTickers`. Cooldown-skipped posts
+   are remembered for the backfill pass.
+2. **Backfill pass** — if the primary pass selected fewer than `articlesNeeded`
+   posts, walk the cooldown-skipped posts (highest score first, still one per
+   ticker) and add them until `selected.length` reaches `articlesNeeded` or the
+   pool is exhausted.
+
+Posts with a falsy/empty ticker are passed through by the existing per-ticker
+logic exactly as today (never filtered, never deduped on ticker).
+
+Being a pure function, it is unit-tested directly with no database mocking.
+
+### 4. Wiring in `assignPostsToModule`
+
+`ModuleArticles.assignPostsToModule` (`src/lib/rss-processor/module-articles.ts`)
+currently sorts candidates by score and runs the intra-issue `seenTickers`
+loop (lines ~147-165). That loop is replaced by a single call to
+`selectPostsWithTickerCooldown`, which subsumes the intra-issue dedup (a post is
+skipped if its ticker was already selected this issue) — so there is one
+selection code path whether or not cooldown is enabled:
+
+- Fetch the issue's `publication_id` and `date` in one query
+  (`select('publication_id, date')`).
+- Read `ticker_cooldown_days` via `getPublicationSetting`.
+- If `> 0`: call `listRecentlyFeaturedTickers` to build the cooldown set.
+- If `0`: use an empty cooldown set and skip the DAL query.
+- Always run candidate selection through `selectPostsWithTickerCooldown`. With
+  an empty cooldown set its output is identical to today's intra-issue
+  `seenTickers` behavior (covered by a test), so a disabled publication sees no
+  change.
+
+### 5. Logging
+
+One-line summary per the project logging rule, e.g.:
+
+```
+[Module] Ticker cooldown (7d): 12 candidates → 8 selected, 4 skipped (cooldown), 1 backfilled to meet minimum
+```
+
+### 6. Tests
+
+Unit tests (Vitest):
+
+- `selectPostsWithTickerCooldown`:
+  - cooldown set filters a ticker out of the primary pass;
+  - backfill restores cooldown-skipped posts when the primary pass is short of
+    `articlesNeeded`;
+  - no backfill when the primary pass already meets `articlesNeeded`;
+  - posts with `null`/empty ticker are unaffected;
+  - empty cooldown set produces the same result as the pre-existing intra-issue
+    dedup.
+- `listRecentlyFeaturedTickers`: date-window boundaries (inclusive of
+  `issueDate − cooldownDays`), `is_active = true` filter, `excludeIssueId`
+  exclusion, `publication_id` scoping.
+
+## Edge Cases
+
+- **Cooldown empties the pool** — handled by the backfill pass; the issue still
+  fills `articles_count` slots, drawing from the least-recently-acceptable
+  cooled-down tickers (ordered by score).
+- **Non-trades publications** — their posts have `ticker = null`; the setting
+  defaults to `0` anyway, so there is no effect even if enabled.
+- **DAL query failure** — `listRecentlyFeaturedTickers` returns an empty set,
+  degrading safely to "no cooldown" rather than blocking the workflow.
+- **Same-date sibling issues** (e.g. a secondary send) — excluded by
+  `excludeIssueId` for the current issue; other same-date issues are still
+  counted as recent history.
+
+## Rollout
+
+1. Ship the code change (default `0`, no behavior change anywhere).
+2. Insert `publication_settings` row: Trader Leak `ticker_cooldown_days = 7`.
+3. Verify on the next Trader Leak issue build that recently-featured tickers are
+   skipped and the log line appears.

--- a/docs/superpowers/specs/2026-05-20-ticker-cooldown-design.md
+++ b/docs/superpowers/specs/2026-05-20-ticker-cooldown-design.md
@@ -3,7 +3,7 @@ name: ticker-cooldown
 description: Cross-issue ticker cooldown to stop the same company recurring as a lead trade article on consecutive issues
 status: complete
 created: 2026-05-20T13:49:49Z
-updated: 2026-05-20T13:49:49Z
+updated: 2026-05-20T14:02:54Z
 ---
 
 # Cross-Issue Ticker Cooldown
@@ -51,31 +51,38 @@ prior 10 days: `GS`/Salazar (5/11, 5/13 — within a 3-day window), `MSFT`/Gotth
 ## Goals
 
 - Prevent the same `ticker` from being selected as an article in issues that are
-  fewer than N days apart, for publications that opt in.
+  fewer than N days apart, for article modules that opt in.
 - Never leave an issue short of articles purely because of the cooldown.
-- Zero behavior change for publications that do not opt in.
+- Zero behavior change for article modules that do not opt in.
+- Provide a settings-page control to enable/disable the cooldown and adjust the
+  window, without editing the database directly.
 
 ## Non-Goals
 
 - No change to the article-text deduplication system.
 - No cooldown keyed on `member_name` or `transaction_type` — ticker only.
-- No dashboard UI control in this iteration (the setting is configured directly
-  in the database; a settings-page toggle is a possible later addition).
 - No database schema migration.
 
 ## Design
 
-### 1. Setting: `ticker_cooldown_days`
+### 1. Setting: `config.ticker_cooldown_days` on the article module
 
-A new key/value setting resolved through the standard two-tier fallback
-(`getPublicationSetting` → `publication_settings`, then `app_settings`).
+The cooldown is configured per **article module**, stored in the existing
+`article_modules.config` JSON column as `ticker_cooldown_days` — the same column
+that already holds the module's `candidate_multiplier`.
 
 - Type: integer, number of days.
-- Default: `0` (disabled). When `0` or absent, the cooldown code path is fully
-  skipped — no query, no filtering, identical behavior to today.
-- Trader Leak: a `publication_settings` row set to `7`.
-- An optional `app_settings` row of `0` may be added to document the default;
-  it is not required for correctness since an absent setting resolves to `0`.
+- Absent / not set: cooldown disabled. The cooldown code path is fully skipped —
+  no query, no filtering, identical behavior to today.
+- Present (`>= 1`): cooldown enabled with that window.
+- No `publication_settings` / `app_settings` / `getPublicationSetting`
+  involvement, and no new API route — `assignPostsToModule` already loads the
+  module and reads `config`, and the settings UI already persists `config` via
+  the existing `PATCH /api/article-modules/[id]` route.
+- Per-module granularity is correct: the cooldown applies during
+  `assignPostsToModule(issueId, moduleId)`. Trader Leak has a single article
+  module (`9f9cd920-c2fe-4b46-92f0-abd453e4d661`), so per-module and
+  per-publication are equivalent for it today.
 
 ### 2. DAL function: `listRecentlyFeaturedTickers`
 
@@ -136,21 +143,22 @@ Being a pure function, it is unit-tested directly with no database mocking.
 ### 4. Wiring in `assignPostsToModule`
 
 `ModuleArticles.assignPostsToModule` (`src/lib/rss-processor/module-articles.ts`)
-currently sorts candidates by score and runs the intra-issue `seenTickers`
-loop (lines ~147-165). That loop is replaced by a single call to
-`selectPostsWithTickerCooldown`, which subsumes the intra-issue dedup (a post is
-skipped if its ticker was already selected this issue) — so there is one
-selection code path whether or not cooldown is enabled:
+already loads the module via `ArticleModuleSelector.getModule(moduleId)` and
+reads `mod.config` (for `candidate_multiplier`). It currently sorts candidates by
+score and runs the intra-issue `seenTickers` loop (lines ~147-165). That loop is
+replaced by a single call to `selectPostsWithTickerCooldown`, which subsumes the
+intra-issue dedup (a post is skipped if its ticker was already selected this
+issue) — so there is one selection code path whether or not cooldown is enabled:
 
-- Fetch the issue's `publication_id` and `date` in one query
-  (`select('publication_id, date')`).
-- Read `ticker_cooldown_days` via `getPublicationSetting`.
-- If `> 0`: call `listRecentlyFeaturedTickers` to build the cooldown set.
-- If `0`: use an empty cooldown set and skip the DAL query.
+- Read `cooldownDays` from `mod.config.ticker_cooldown_days`.
+- If set and `>= 1`: fetch the current issue's `publication_id` and `date`
+  (`publication_issues.select('publication_id, date')`) and call
+  `listRecentlyFeaturedTickers` to build the cooldown set.
+- If absent: use an empty cooldown set and skip the DAL query.
 - Always run candidate selection through `selectPostsWithTickerCooldown`. With
   an empty cooldown set its output is identical to today's intra-issue
-  `seenTickers` behavior (covered by a test), so a disabled publication sees no
-  change.
+  `seenTickers` behavior (covered by a test), so a module without the setting
+  sees no change.
 
 ### 5. Logging
 
@@ -160,7 +168,31 @@ One-line summary per the project logging rule, e.g.:
 [Module] Ticker cooldown (7d): 12 candidates → 8 selected, 4 skipped (cooldown), 1 backfilled to meet minimum
 ```
 
-### 6. Tests
+### 6. Settings UI control
+
+Location: **Settings → Sections → [article module] → General tab → "Article
+Selection Settings"** (`src/components/article-modules/ArticleModuleGeneralTab.tsx`),
+added after the existing "Extra Candidates" control.
+
+It mirrors the "Extra Candidates" pattern exactly — a toggle plus an inline
+number input:
+
+- **Toggle "Ticker cooldown"** — off by default. Off → removes
+  `ticker_cooldown_days` from `module.config`. On → writes the days value
+  (defaulting to `7` when first enabled).
+- **Number input "Cooldown days"** — shown only while the toggle is on; accepts
+  `1`–`30`. Help text explains it prevents the same company (ticker) being
+  selected again within N days, and that it applies to trades-style modules.
+
+Persistence reuses the module's existing `onUpdate({ config })` path
+(`PATCH /api/article-modules/[id]`) — the same call `handleMultiplierChange`
+already uses for `candidate_multiplier`. No new API route, no email-settings
+changes.
+
+The control renders for every article module. For modules whose posts carry no
+ticker it is simply inert (see Edge Cases).
+
+### 7. Tests
 
 Unit tests (Vitest):
 
@@ -181,8 +213,9 @@ Unit tests (Vitest):
 - **Cooldown empties the pool** — handled by the backfill pass; the issue still
   fills `articles_count` slots, drawing from the least-recently-acceptable
   cooled-down tickers (ordered by score).
-- **Non-trades publications** — their posts have `ticker = null`; the setting
-  defaults to `0` anyway, so there is no effect even if enabled.
+- **Non-trades modules** — their posts have `ticker = null`; even if the
+  cooldown is enabled on such a module, no post can be on cooldown, so it is a
+  no-op.
 - **DAL query failure** — `listRecentlyFeaturedTickers` returns an empty set,
   degrading safely to "no cooldown" rather than blocking the workflow.
 - **Same-date sibling issues** (e.g. a secondary send) — excluded by
@@ -191,7 +224,10 @@ Unit tests (Vitest):
 
 ## Rollout
 
-1. Ship the code change (default `0`, no behavior change anywhere).
-2. Insert `publication_settings` row: Trader Leak `ticker_cooldown_days = 7`.
+1. Ship the code change (cooldown absent on every module → no behavior change
+   anywhere).
+2. Enable it for Trader Leak's article module: Settings → Sections → the
+   Politician Trades article module → General → Article Selection Settings →
+   toggle "Ticker cooldown" on, set `7` days.
 3. Verify on the next Trader Leak issue build that recently-featured tickers are
    skipped and the log line appears.

--- a/src/components/article-modules/ArticleModuleGeneralTab.tsx
+++ b/src/components/article-modules/ArticleModuleGeneralTab.tsx
@@ -124,6 +124,38 @@ export default function ArticleModuleGeneralTab({ module, onUpdate, disabled = f
               </div>
             )
           })()}
+          {(() => {
+            const cooldownDays = (module.config as Record<string, any>)?.ticker_cooldown_days
+            const isEnabled = typeof cooldownDays === 'number' && cooldownDays >= 1
+            const handleCooldownChange = (value: number | null) => withSaving(async () => {
+              const currentConfig = (module.config as Record<string, any>) || {}
+              if (value === null) {
+                const { ticker_cooldown_days: _, ...rest } = currentConfig
+                await onUpdate({ config: rest } as any)
+              } else {
+                await onUpdate({ config: { ...currentConfig, ticker_cooldown_days: value } } as any)
+              }
+            })
+            return (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <label className="text-sm font-medium text-gray-700">Ticker Cooldown</label>
+                    <p className="text-xs text-gray-500">{isEnabled ? `Skips any company (ticker) featured in the last ${cooldownDays} days` : 'Off — a company can be selected on consecutive issues. For trades newsletters.'}</p>
+                  </div>
+                  <button type="button" onClick={() => handleCooldownChange(isEnabled ? null : 7)} disabled={isDisabled} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isEnabled ? 'bg-emerald-500' : 'bg-gray-300'} ${isDisabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}`}>
+                    <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${isEnabled ? 'translate-x-6' : 'translate-x-1'}`} />
+                  </button>
+                </div>
+                {isEnabled && (
+                  <div className="flex items-center gap-2 pl-1">
+                    <span className="text-xs text-gray-500">Cooldown days:</span>
+                    <input type="number" min={1} max={30} value={cooldownDays} onChange={(e) => { const val = parseInt(e.target.value); if (!isNaN(val) && val >= 1 && val <= 30) handleCooldownChange(val) }} disabled={isDisabled} className="w-20 px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500" />
+                  </div>
+                )}
+              </div>
+            )
+          })()}
         </div>
       </div>
 

--- a/src/lib/dal/__tests__/articles.test.ts
+++ b/src/lib/dal/__tests__/articles.test.ts
@@ -373,4 +373,10 @@ describe('listRecentlyFeaturedTickers', () => {
     const result = await listRecentlyFeaturedTickers('pub-1', '2026-05-20', 7, 'iss-cur')
     expect(result).toEqual(new Set())
   })
+
+  it('selects ticker plus the inner-joined publication_issues columns', async () => {
+    mockChainResult = { data: [], error: null }
+    await listRecentlyFeaturedTickers('pub-1', '2026-05-20', 7, 'iss-cur')
+    expect(mockChain.select).toHaveBeenCalledWith('ticker, publication_issues!inner(publication_id, date)')
+  })
 })

--- a/src/lib/dal/__tests__/articles.test.ts
+++ b/src/lib/dal/__tests__/articles.test.ts
@@ -379,4 +379,16 @@ describe('listRecentlyFeaturedTickers', () => {
     await listRecentlyFeaturedTickers('pub-1', '2026-05-20', 7, 'iss-cur')
     expect(mockChain.select).toHaveBeenCalledWith('ticker, publication_issues!inner(publication_id, date)')
   })
+
+  it('computes the cutoff date correctly across a month boundary', async () => {
+    mockChainResult = { data: [], error: null }
+    await listRecentlyFeaturedTickers('pub-1', '2026-05-03', 7, 'iss-cur')
+    expect(mockChain.gte).toHaveBeenCalledWith('publication_issues.date', '2026-04-26')
+  })
+
+  it('computes the cutoff date correctly across a year boundary', async () => {
+    mockChainResult = { data: [], error: null }
+    await listRecentlyFeaturedTickers('pub-1', '2026-01-03', 7, 'iss-cur')
+    expect(mockChain.gte).toHaveBeenCalledWith('publication_issues.date', '2025-12-27')
+  })
 })

--- a/src/lib/dal/__tests__/articles.test.ts
+++ b/src/lib/dal/__tests__/articles.test.ts
@@ -55,6 +55,7 @@ import {
   insertManualArticle,
   updateManualArticle,
   deleteManualArticle,
+  listRecentlyFeaturedTickers,
 } from '../articles'
 
 beforeEach(() => {
@@ -337,5 +338,39 @@ describe('deleteManualArticle', () => {
     await deleteManualArticle('m1', 'pub-1')
     expect(mockChain.eq).toHaveBeenCalledWith('id', 'm1')
     expect(mockChain.eq).toHaveBeenCalledWith('publication_id', 'pub-1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('listRecentlyFeaturedTickers', () => {
+  it('returns the distinct, upper-cased set of recent active tickers', async () => {
+    mockChainResult = {
+      data: [{ ticker: 'COR' }, { ticker: 'ibm' }, { ticker: 'COR' }],
+      error: null,
+    }
+    const result = await listRecentlyFeaturedTickers('pub-1', '2026-05-20', 7, 'iss-cur')
+    expect(result).toEqual(new Set(['COR', 'IBM']))
+  })
+
+  it('computes the cutoff date as issueDate minus cooldownDays', async () => {
+    mockChainResult = { data: [], error: null }
+    await listRecentlyFeaturedTickers('pub-1', '2026-05-20', 7, 'iss-cur')
+    expect(mockChain.gte).toHaveBeenCalledWith('publication_issues.date', '2026-05-13')
+    expect(mockChain.lte).toHaveBeenCalledWith('publication_issues.date', '2026-05-20')
+  })
+
+  it('filters by is_active, non-null ticker, publication, and excludes the current issue', async () => {
+    mockChainResult = { data: [], error: null }
+    await listRecentlyFeaturedTickers('pub-1', '2026-05-20', 7, 'iss-cur')
+    expect(mockChain.eq).toHaveBeenCalledWith('is_active', true)
+    expect(mockChain.not).toHaveBeenCalledWith('ticker', 'is', null)
+    expect(mockChain.eq).toHaveBeenCalledWith('publication_issues.publication_id', 'pub-1')
+    expect(mockChain.neq).toHaveBeenCalledWith('issue_id', 'iss-cur')
+  })
+
+  it('returns an empty set on query error', async () => {
+    mockChainResult = { data: null, error: { message: 'fail' } }
+    const result = await listRecentlyFeaturedTickers('pub-1', '2026-05-20', 7, 'iss-cur')
+    expect(result).toEqual(new Set())
   })
 })

--- a/src/lib/dal/articles.ts
+++ b/src/lib/dal/articles.ts
@@ -262,6 +262,54 @@ export async function updateModuleArticleFactCheck(
   }
 }
 
+/**
+ * Tickers featured as an active article in a publication's recent issues.
+ * Used to enforce a cross-issue ticker cooldown during article selection.
+ *
+ * Returns the distinct set of UPPER-CASED tickers that were `is_active`
+ * module_articles in issues dated within `[issueDate - cooldownDays, issueDate]`,
+ * excluding the issue currently being built. Issue status is intentionally NOT
+ * filtered — sent, in-review, and draft issues all count. On any failure
+ * returns an empty set, degrading safely to "no cooldown".
+ */
+export async function listRecentlyFeaturedTickers(
+  publicationId: string,
+  issueDate: string,
+  cooldownDays: number,
+  excludeIssueId: string
+): Promise<Set<string>> {
+  try {
+    const cutoff = new Date(`${issueDate}T00:00:00Z`)
+    cutoff.setUTCDate(cutoff.getUTCDate() - cooldownDays)
+    const cutoffDate = cutoff.toISOString().split('T')[0]
+
+    const { data, error } = await supabaseAdmin
+      .from('module_articles')
+      .select('ticker, publication_issues!inner(publication_id, date)')
+      .eq('is_active', true)
+      .not('ticker', 'is', null)
+      .eq('publication_issues.publication_id', publicationId)
+      .gte('publication_issues.date', cutoffDate)
+      .lte('publication_issues.date', issueDate)
+      .neq('issue_id', excludeIssueId)
+
+    if (error) {
+      log.error({ err: error, publicationId }, 'listRecentlyFeaturedTickers failed')
+      return new Set()
+    }
+
+    const tickers = new Set<string>()
+    for (const row of data || []) {
+      const t = (row as any).ticker
+      if (t) tickers.add(String(t).toUpperCase())
+    }
+    return tickers
+  } catch (err) {
+    log.error({ err, publicationId }, 'listRecentlyFeaturedTickers exception')
+    return new Set()
+  }
+}
+
 // ==================== manual_articles ====================
 //
 // Note: the `ManualArticle` type in src/types/database.ts is stale; the actual

--- a/src/lib/dal/articles.ts
+++ b/src/lib/dal/articles.ts
@@ -14,6 +14,7 @@
 
 import { supabaseAdmin } from '@/lib/supabase'
 import { createLogger } from '@/lib/logger'
+import { fetchAllPaginated } from './paginate'
 import type { ModuleArticle, ManualArticleStatus } from '@/types/database'
 
 const log = createLogger({ module: 'dal:articles' })
@@ -283,33 +284,30 @@ export async function listRecentlyFeaturedTickers(
     cutoff.setUTCDate(cutoff.getUTCDate() - cooldownDays)
     const cutoffDate = cutoff.toISOString().split('T')[0]
 
-    // The publication_issues!inner join is required: the dot-notation filters
-    // below (publication_issues.*) only run as a server-side WHERE clause with
-    // an !inner join. A plain (!left) join would filter client-side and leak
-    // other publications' rows.
-    const { data, error } = await supabaseAdmin
-      .from('module_articles')
-      .select('ticker, publication_issues!inner(publication_id, date)')
-      .eq('is_active', true)
-      .not('ticker', 'is', null)
-      .eq('publication_issues.publication_id', publicationId)
-      .gte('publication_issues.date', cutoffDate)
-      .lte('publication_issues.date', issueDate)
-      .neq('issue_id', excludeIssueId)
-
-    if (error) {
-      log.error({ err: error, publicationId }, 'listRecentlyFeaturedTickers failed')
-      return new Set()
-    }
+    // fetchAllPaginated pages past Supabase's silent 1000-row cap. The
+    // publication_issues!inner join is required: the publication_issues.*
+    // dot-notation filters only run as a server-side WHERE with an !inner
+    // join — a !left join would filter client-side and leak other
+    // publications' rows.
+    const rows = await fetchAllPaginated<{ ticker: string | null }>(() =>
+      supabaseAdmin
+        .from('module_articles')
+        .select('ticker, publication_issues!inner(publication_id, date)')
+        .eq('is_active', true)
+        .not('ticker', 'is', null)
+        .eq('publication_issues.publication_id', publicationId)
+        .gte('publication_issues.date', cutoffDate)
+        .lte('publication_issues.date', issueDate)
+        .neq('issue_id', excludeIssueId) as any
+    )
 
     const tickers = new Set<string>()
-    for (const row of data || []) {
-      const t = (row as any).ticker
-      if (t) tickers.add(String(t).toUpperCase())
+    for (const row of rows) {
+      if (row.ticker) tickers.add(String(row.ticker).toUpperCase())
     }
     return tickers
   } catch (err) {
-    log.error({ err, publicationId }, 'listRecentlyFeaturedTickers exception')
+    log.error({ err, publicationId }, 'listRecentlyFeaturedTickers failed')
     return new Set()
   }
 }

--- a/src/lib/dal/articles.ts
+++ b/src/lib/dal/articles.ts
@@ -15,6 +15,7 @@
 import { supabaseAdmin } from '@/lib/supabase'
 import { createLogger } from '@/lib/logger'
 import { fetchAllPaginated } from './paginate'
+import { toLocalDateStr } from '@/lib/date-utils'
 import type { ModuleArticle, ManualArticleStatus } from '@/types/database'
 
 const log = createLogger({ module: 'dal:articles' })
@@ -280,9 +281,11 @@ export async function listRecentlyFeaturedTickers(
   excludeIssueId: string
 ): Promise<Set<string>> {
   try {
-    const cutoff = new Date(`${issueDate}T00:00:00Z`)
-    cutoff.setUTCDate(cutoff.getUTCDate() - cooldownDays)
-    const cutoffDate = cutoff.toISOString().split('T')[0]
+    // Local-date arithmetic (no toISOString/UTC shift) — issueDate is a plain
+    // YYYY-MM-DD; parse, subtract, and format all in the same (local) frame.
+    const cutoff = new Date(`${issueDate}T00:00:00`)
+    cutoff.setDate(cutoff.getDate() - cooldownDays)
+    const cutoffDate = toLocalDateStr(cutoff)
 
     // fetchAllPaginated pages past Supabase's silent 1000-row cap. The
     // publication_issues!inner join is required: the publication_issues.*

--- a/src/lib/dal/articles.ts
+++ b/src/lib/dal/articles.ts
@@ -283,6 +283,10 @@ export async function listRecentlyFeaturedTickers(
     cutoff.setUTCDate(cutoff.getUTCDate() - cooldownDays)
     const cutoffDate = cutoff.toISOString().split('T')[0]
 
+    // The publication_issues!inner join is required: the dot-notation filters
+    // below (publication_issues.*) only run as a server-side WHERE clause with
+    // an !inner join. A plain (!left) join would filter client-side and leak
+    // other publications' rows.
     const { data, error } = await supabaseAdmin
       .from('module_articles')
       .select('ticker, publication_issues!inner(publication_id, date)')

--- a/src/lib/dal/index.ts
+++ b/src/lib/dal/index.ts
@@ -62,6 +62,7 @@ export {
   insertModuleArticle,
   updateModuleArticleContent,
   updateModuleArticleFactCheck,
+  listRecentlyFeaturedTickers,
   listManualArticlesByPublication,
   findNextAvailableSlug,
   insertManualArticle,

--- a/src/lib/rss-processor/__tests__/ticker-cooldown.test.ts
+++ b/src/lib/rss-processor/__tests__/ticker-cooldown.test.ts
@@ -62,4 +62,10 @@ describe('selectPostsWithTickerCooldown', () => {
     const r = selectPostsWithTickerCooldown(posts, new Set<string>(), 2, 3)
     expect(r.selected.map(p => p.id)).toEqual(['a', 'b', 'c'])
   })
+
+  it('honors articlesNeeded even when postsToAssign is set below it', () => {
+    const posts = [post('a', 'A'), post('b', 'B'), post('c', 'C'), post('d', 'D')]
+    const r = selectPostsWithTickerCooldown(posts, new Set<string>(), 3, 1)
+    expect(r.selected.map(p => p.id)).toEqual(['a', 'b', 'c'])
+  })
 })

--- a/src/lib/rss-processor/__tests__/ticker-cooldown.test.ts
+++ b/src/lib/rss-processor/__tests__/ticker-cooldown.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { selectPostsWithTickerCooldown } from '../ticker-cooldown'
+
+const post = (id: string, ticker: string | null) => ({ id, ticker })
+
+describe('selectPostsWithTickerCooldown', () => {
+  it('with an empty cooldown set, behaves like one-per-ticker dedup', () => {
+    const posts = [post('a', 'AAA'), post('b', 'AAA'), post('c', 'BBB')]
+    const r = selectPostsWithTickerCooldown(posts, new Set<string>(), 3, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['a', 'c'])
+    expect(r.skippedByCooldown).toBe(0)
+    expect(r.backfilled).toBe(0)
+  })
+
+  it('skips a ticker that is on cooldown', () => {
+    // articlesNeeded=2 and two non-cooldown posts exist, so no backfill.
+    const posts = [post('a', 'COR'), post('b', 'IBM'), post('c', 'MKL')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 2, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['b', 'c'])
+    expect(r.skippedByCooldown).toBe(1)
+    expect(r.backfilled).toBe(0)
+  })
+
+  it('matches cooldown tickers case-insensitively', () => {
+    // articlesNeeded=1 and one non-cooldown post exists, so no backfill.
+    const posts = [post('a', 'cor'), post('b', 'IBM')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 1, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['b'])
+  })
+
+  it('backfills cooled-down posts when the primary pass is short of the minimum', () => {
+    const posts = [post('a', 'COR'), post('b', 'IBM'), post('c', 'COR')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 2, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['b', 'a'])
+    expect(r.skippedByCooldown).toBe(2)
+    expect(r.backfilled).toBe(1)
+  })
+
+  it('does not backfill when the primary pass already meets the minimum', () => {
+    const posts = [post('a', 'COR'), post('b', 'IBM'), post('c', 'MKL')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 2, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['b', 'c'])
+    expect(r.backfilled).toBe(0)
+  })
+
+  it('never selects two posts for the same ticker, even via backfill', () => {
+    const posts = [post('a', 'COR'), post('b', 'COR'), post('c', 'COR')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 3, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['a'])
+    expect(r.backfilled).toBe(1)
+  })
+
+  it('passes through posts with no ticker without deduping them', () => {
+    const posts = [post('a', null), post('b', null), post('c', 'COR')]
+    const r = selectPostsWithTickerCooldown(posts, new Set(['COR']), 2, 12)
+    expect(r.selected.map(p => p.id)).toEqual(['a', 'b'])
+    expect(r.skippedByCooldown).toBe(1)
+  })
+
+  it('caps the primary pass at postsToAssign', () => {
+    const posts = [post('a', 'A'), post('b', 'B'), post('c', 'C'), post('d', 'D')]
+    const r = selectPostsWithTickerCooldown(posts, new Set<string>(), 2, 3)
+    expect(r.selected.map(p => p.id)).toEqual(['a', 'b', 'c'])
+  })
+})

--- a/src/lib/rss-processor/module-articles.ts
+++ b/src/lib/rss-processor/module-articles.ts
@@ -147,9 +147,13 @@ export class ModuleArticles {
         return scoreB - scoreA
       })
 
-    // Cross-issue ticker cooldown — per-module config; absent/0 = disabled.
+    // Cross-issue ticker cooldown — per-module config. Absent / < 1 = disabled;
+    // floored and capped at 90 days as defense against malformed config.
     const cooldownDaysRaw = (mod.config as Record<string, any>)?.ticker_cooldown_days
-    const cooldownDays = typeof cooldownDaysRaw === 'number' ? cooldownDaysRaw : 0
+    const cooldownDays =
+      typeof cooldownDaysRaw === 'number' && cooldownDaysRaw >= 1
+        ? Math.min(Math.floor(cooldownDaysRaw), 90)
+        : 0
     let cooldownTickers = new Set<string>()
     if (cooldownDays >= 1) {
       // getIssueById logs its own errors and returns null on failure, so a DB
@@ -162,6 +166,8 @@ export class ModuleArticles {
           cooldownDays,
           issueId
         )
+      } else {
+        console.warn(`[Module] Ticker cooldown: could not resolve issue ${issueId} — cooldown skipped this run`)
       }
     }
 

--- a/src/lib/rss-processor/module-articles.ts
+++ b/src/lib/rss-processor/module-articles.ts
@@ -2,6 +2,7 @@ import { supabaseAdmin } from '../supabase'
 import { AI_CALL, callOpenAI } from '../openai'
 import { normalizeTransactionType } from '../transaction-type'
 import { detectAIRefusal, getNewsletterIdFromIssue } from './shared-context'
+import { selectPostsWithTickerCooldown } from './ticker-cooldown'
 import {
   listPostsForScoring,
   assignPostsToIssue,
@@ -15,6 +16,7 @@ import {
   updateModuleArticleFactCheck,
   listDuplicateGroupIdsByIssue,
   listDuplicatePostIdsByGroups,
+  listRecentlyFeaturedTickers,
 } from '@/lib/dal'
 import type { ArticleGenerator } from './article-generator'
 
@@ -144,24 +146,33 @@ export class ModuleArticles {
         return scoreB - scoreA
       })
 
-    // Select top posts: 1 per ticker (company), then fill remaining slots
-    const selectedPosts: any[] = []
-    const seenTickers = new Set<string>()
-
-    for (const post of sortedPosts) {
-      if (selectedPosts.length >= postsToAssign) break
-
-      const ticker = (post as any).ticker?.toUpperCase()
-      if (ticker && seenTickers.has(ticker)) {
-        continue // Skip: already have a post for this company
+    // Cross-issue ticker cooldown — per-module config; absent/0 = disabled.
+    const cooldownDaysRaw = (mod.config as Record<string, any>)?.ticker_cooldown_days
+    const cooldownDays = typeof cooldownDaysRaw === 'number' ? cooldownDaysRaw : 0
+    let cooldownTickers = new Set<string>()
+    if (cooldownDays >= 1) {
+      const { data: issueRow } = await supabaseAdmin
+        .from('publication_issues')
+        .select('publication_id, date')
+        .eq('id', issueId)
+        .single()
+      if (issueRow?.publication_id && issueRow?.date) {
+        cooldownTickers = await listRecentlyFeaturedTickers(
+          issueRow.publication_id,
+          issueRow.date,
+          cooldownDays,
+          issueId
+        )
       }
-
-      selectedPosts.push(post)
-      if (ticker) seenTickers.add(ticker)
     }
 
-    if (seenTickers.size > 0) {
-      console.log(`[Module] Ticker dedup: ${sortedPosts.length} candidates → ${selectedPosts.length} selected (${seenTickers.size} unique companies)`)
+    // Select top posts: 1 per ticker, skipping tickers on cooldown. Backfill
+    // ensures the module is never short purely because of the cooldown.
+    const { selected: selectedPosts, skippedByCooldown, backfilled } =
+      selectPostsWithTickerCooldown(sortedPosts, cooldownTickers, articlesNeeded, postsToAssign)
+
+    if (cooldownDays >= 1) {
+      console.log(`[Module] Ticker cooldown (${cooldownDays}d): ${sortedPosts.length} candidates → ${selectedPosts.length} selected, ${skippedByCooldown} skipped (cooldown), ${backfilled} backfilled`)
     }
 
     if (selectedPosts.length > 0) {

--- a/src/lib/rss-processor/module-articles.ts
+++ b/src/lib/rss-processor/module-articles.ts
@@ -4,6 +4,7 @@ import { normalizeTransactionType } from '../transaction-type'
 import { detectAIRefusal, getNewsletterIdFromIssue } from './shared-context'
 import { selectPostsWithTickerCooldown } from './ticker-cooldown'
 import {
+  getIssueById,
   listPostsForScoring,
   assignPostsToIssue,
   listAssignedPostsForModule,
@@ -151,11 +152,9 @@ export class ModuleArticles {
     const cooldownDays = typeof cooldownDaysRaw === 'number' ? cooldownDaysRaw : 0
     let cooldownTickers = new Set<string>()
     if (cooldownDays >= 1) {
-      const { data: issueRow } = await supabaseAdmin
-        .from('publication_issues')
-        .select('publication_id, date')
-        .eq('id', issueId)
-        .single()
+      // getIssueById logs its own errors and returns null on failure, so a DB
+      // problem degrades safely to "no cooldown" instead of silently swallowing.
+      const issueRow = await getIssueById(issueId)
       if (issueRow?.publication_id && issueRow?.date) {
         cooldownTickers = await listRecentlyFeaturedTickers(
           issueRow.publication_id,

--- a/src/lib/rss-processor/ticker-cooldown.ts
+++ b/src/lib/rss-processor/ticker-cooldown.ts
@@ -1,0 +1,79 @@
+/**
+ * Cooldown-aware candidate selection for article modules.
+ *
+ * Pure, side-effect-free. Replaces the intra-issue "one article per ticker"
+ * loop in `assignPostsToModule` and additionally skips tickers featured in a
+ * recent issue (the cross-issue cooldown). A backfill pass guarantees the
+ * module is never left short purely because of the cooldown.
+ */
+
+/** Minimal shape the cooldown selector needs from a candidate post. */
+export interface CandidatePost {
+  id: string
+  ticker?: string | null
+}
+
+export interface TickerCooldownResult<T> {
+  /** Posts chosen for the module, in selection order. */
+  selected: T[]
+  /** Count of candidate posts skipped because their ticker was on cooldown. */
+  skippedByCooldown: number
+  /** Count of cooled-down posts restored by the backfill pass. */
+  backfilled: number
+}
+
+/**
+ * Select candidate posts for an article module, one per ticker, applying a
+ * cross-issue ticker cooldown.
+ *
+ * @param sortedPosts      candidates already sorted by score, descending
+ * @param cooldownTickers  UPPER-CASED tickers featured in a recent issue
+ * @param articlesNeeded   minimum posts the module must fill (articles_count)
+ * @param postsToAssign    candidate target (>= articlesNeeded)
+ */
+export function selectPostsWithTickerCooldown<T extends CandidatePost>(
+  sortedPosts: T[],
+  cooldownTickers: Set<string>,
+  articlesNeeded: number,
+  postsToAssign: number,
+): TickerCooldownResult<T> {
+  const selected: T[] = []
+  const seenTickers = new Set<string>()
+  const cooledDown: T[] = []
+  let skippedByCooldown = 0
+
+  // Primary pass: one post per ticker, skipping tickers on cooldown.
+  for (const post of sortedPosts) {
+    if (selected.length >= postsToAssign) break
+
+    const ticker = post.ticker ? post.ticker.toUpperCase() : ''
+
+    if (ticker && seenTickers.has(ticker)) {
+      continue // already have a post for this company this issue
+    }
+    if (ticker && cooldownTickers.has(ticker)) {
+      cooledDown.push(post)
+      skippedByCooldown++
+      continue
+    }
+
+    selected.push(post)
+    if (ticker) seenTickers.add(ticker)
+  }
+
+  // Backfill pass: if the cooldown left us short of the minimum, restore the
+  // highest-scored cooled-down posts (still one per ticker).
+  let backfilled = 0
+  for (const post of cooledDown) {
+    if (selected.length >= articlesNeeded) break
+
+    const ticker = post.ticker ? post.ticker.toUpperCase() : ''
+    if (ticker && seenTickers.has(ticker)) continue
+
+    selected.push(post)
+    if (ticker) seenTickers.add(ticker)
+    backfilled++
+  }
+
+  return { selected, skippedByCooldown, backfilled }
+}

--- a/src/lib/rss-processor/ticker-cooldown.ts
+++ b/src/lib/rss-processor/ticker-cooldown.ts
@@ -29,7 +29,9 @@ export interface TickerCooldownResult<T> {
  * @param sortedPosts      candidates already sorted by score, descending
  * @param cooldownTickers  UPPER-CASED tickers featured in a recent issue
  * @param articlesNeeded   minimum posts the module must fill (articles_count)
- * @param postsToAssign    candidate target (>= articlesNeeded)
+ * @param postsToAssign    upper bound on candidates to select; the primary pass
+ *                         effectively uses max(postsToAssign, articlesNeeded) so
+ *                         the module is never left short of articlesNeeded
  */
 export function selectPostsWithTickerCooldown<T extends CandidatePost>(
   sortedPosts: T[],
@@ -42,9 +44,13 @@ export function selectPostsWithTickerCooldown<T extends CandidatePost>(
   const cooledDown: T[] = []
   let skippedByCooldown = 0
 
+  // The primary pass never stops short of articlesNeeded — postsToAssign is
+  // only an upper bound on extra candidates.
+  const primaryTarget = Math.max(postsToAssign, articlesNeeded)
+
   // Primary pass: one post per ticker, skipping tickers on cooldown.
   for (const post of sortedPosts) {
-    if (selected.length >= postsToAssign) break
+    if (selected.length >= primaryTarget) break
 
     const ticker = post.ticker ? post.ticker.toUpperCase() : ''
 


### PR DESCRIPTION
## Staging → production promotion

Promotes all work currently on `staging` to `master`.

### Headline change — cross-issue ticker cooldown

Prevents the same stock ticker (company) from being selected as a newsletter article on issues within a configurable window. Closes the gap where the article-level deduplication could not catch the same congressional trade being re-run via a *different* news article (Trader Leak ran a McCaul/Cencora trade as the lead on both 5/19 and 5/20).

- New per-article-module setting `config.ticker_cooldown_days` (absent = disabled) with a toggle in the module's General → "Article Selection Settings" tab.
- `selectPostsWithTickerCooldown` (pure function) + `listRecentlyFeaturedTickers` (paginated DAL query) wired into `assignPostsToModule`.
- Spec: `docs/superpowers/specs/2026-05-20-ticker-cooldown-design.md`; plan: `docs/superpowers/plans/2026-05-20-ticker-cooldown.md`.
- Reviewed across per-task spec + code-quality passes, a final whole-feature review, and a 7-role pre-push gate (one Critical — query pagination — found and fixed).

### Scope note

This PR also carries other accumulated `staging` changes (~100+ files) not part of the ticker-cooldown work. Review the full commit history / diff for those.

## Test plan

- [ ] CI green (build, lint, type-check)
- [ ] Full unit suite passes (778 tests pass locally on staging)
- [ ] After deploy: enable ticker cooldown on Trader Leak's "Politician Trades" module (`9f9cd920-c2fe-4b46-92f0-abd453e4d661`) and confirm the `[Module] Ticker cooldown` log line on the next issue build
- [ ] Smoke-test the broader staging changes per their own context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ticker cooldown setting to article modules. Users can now enable cooldown to prevent recently featured tickers from being re-selected within a configurable 1–30 day window, reducing duplicate tickers across consecutive issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Venture-Formations/aiprodaily/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->