### PR TITLE
fix(api): scope article-module PATCH issue query to its publication

### DIFF
--- a/src/app/api/article-modules/[id]/route.ts
+++ b/src/app/api/article-modules/[id]/route.ts
@@ -46,6 +46,33 @@ export const PATCH = withApiHandler(
     const id = params.id
     const body = await request.json()
 
+    // Resolve the module first so the issue-count adjustment below can be
+    // scoped to its publication — otherwise that query scans every
+    // publication's non-sent issues. Also gives a clean 404 before any writes.
+    const { data: moduleRow, error: moduleLookupError } = await supabaseAdmin
+      .from('article_modules')
+      .select('id, publication_id')
+      .eq('id', id)
+      .single()
+
+    // PGRST116 = no row found; any other error is a genuine DB failure and
+    // should surface as 500 (via withApiHandler) rather than a misleading 404.
+    if (moduleLookupError && moduleLookupError.code !== 'PGRST116') {
+      throw moduleLookupError
+    }
+    if (!moduleRow) {
+      return NextResponse.json(
+        { error: 'Article module not found' },
+        { status: 404 }
+      )
+    }
+    if (!moduleRow.publication_id) {
+      return NextResponse.json(
+        { error: 'Article module has no publication' },
+        { status: 500 }
+      )
+    }
+
     // Build update object with only allowed fields
     const updates: Record<string, any> = {}
     const allowedFields = [
@@ -86,6 +113,7 @@ export const PATCH = withApiHandler(
       const { data: issuesWithExcess } = await supabaseAdmin
         .from('publication_issues')
         .select('id')
+        .eq('publication_id', moduleRow.publication_id)
         .neq('status', 'sent')
 
       if (issuesWithExcess && issuesWithExcess.length > 0) {


### PR DESCRIPTION
## Summary

Single-commit promotion of one cleanup to production.

`PATCH /api/article-modules/[id]` adjusted article counts by querying `publication_issues` with only `.neq('status','sent')` — scanning **every** publication's non-sent issues. This change:

- Resolves the module up front and scopes that query to the module's own `publication_id` — only the module's own publication can ever match, so this is a performance improvement (and ages well as more publications are added).
- Distinguishes a genuine DB error (→ 500, via `withApiHandler`) from a missing module (→ 404), instead of returning a misleading 404 for both. Adds a defensive guard for a module with no `publication_id`.

**Not a security fix.** Cross-publication access by authenticated staff is by design here (every user manages all publications), so the IDOR-pattern the automated review flagged is not a real vulnerability for this app. This PR is a performance + error-handling cleanup only.

## Test plan

- [ ] CI green (build, lint, type-check)
- [x] `type-check`, `lint`, and bug-pattern checks pass locally (pre-push hook green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of article module update operations with better error detection and handling.
  * Fixed a data isolation issue to prevent article module changes from unintentionally affecting other publications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Venture-Formations/aiprodaily/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->