### PR TITLE
fix(send-secondary,send-review): drop forbidden rank/is_active columns from manual_articles select

### DIFF
--- a/src/app/api/campaigns/[id]/send-review/route.ts
+++ b/src/app/api/campaigns/[id]/send-review/route.ts
@@ -39,9 +39,7 @@ export const POST = withApiHandler(
         publication_id,
         manual_articles:manual_articles(
           id,
-          title,
-          is_active,
-          rank
+          title
         ),
         issue_events(
           id,

--- a/src/app/api/cron/send-secondary/__tests__/route.test.ts
+++ b/src/app/api/cron/send-secondary/__tests__/route.test.ts
@@ -253,4 +253,64 @@ describe('send-secondary cron', () => {
     expect(body.results[0].error).toMatch(/SendGrid down/i)
     expect(updateMock).not.toHaveBeenCalled()
   })
+
+  it('does NOT select forbidden columns from manual_articles (regression: rank/is_active)', async () => {
+    // Regression for the silent failure that broke every Thursday secondary
+    // send from 2026-03-31 onward: selecting `rank` triggered PostgREST 42809
+    // (rank ordered-set aggregate), `is_active` triggered 42703 (no such column).
+    // Both got swallowed as "No issue found for today".
+    const selectSpy = vi.fn().mockReturnValue({
+      eq: () => ({
+        in: () => ({
+          eq: () => ({
+            order: () => ({
+              limit: () => ({
+                single: () => Promise.resolve({
+                  data: { id: 'issue-1', date: TODAY_DATE_STR, status: 'in_review', subject_line: 'S', secondary_sent_at: null, publication_id: 'pub-1', created_at: '2026-05-04T05:00:00Z', metrics: {} },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    })
+    fromMock.mockImplementation((table: string) => {
+      if (table === 'publications') {
+        return { select: () => ({ eq: () => Promise.resolve({ data: [{ id: 'pub-1', name: 'AI Pros Daily', slug: 'aiprodaily' }], error: null }) }) }
+      }
+      if (table === 'publication_issues') {
+        return { select: selectSpy, update: vi.fn().mockReturnValue({ eq: () => Promise.resolve({ data: null, error: null }) }) }
+      }
+      if (table === 'module_articles') {
+        return { select: () => ({ eq: () => ({ eq: () => ({ not: () => Promise.resolve({ data: [{ id: 'a-1', headline: 'h', content: 'c', rank: 1, is_active: true, final_position: 1, article_module_id: 'm', post_id: 'p' }], error: null }) }) }) }) }
+      }
+      return {}
+    })
+
+    await GET(buildRequest(), { params: Promise.resolve({}) })
+
+    expect(selectSpy).toHaveBeenCalled()
+    const issueSelect: string = selectSpy.mock.calls[0][0]
+    // The forbidden tokens should not appear inside the manual_articles join
+    const manualArticlesPart = issueSelect.match(/manual_articles:manual_articles\(([^)]*)\)/)?.[1] ?? ''
+    expect(manualArticlesPart).not.toMatch(/\brank\b/)
+    expect(manualArticlesPart).not.toMatch(/\bis_active\b/)
+  })
+
+  it('surfaces PostgREST errors on issue lookup instead of silently skipping', async () => {
+    // Regression: previously `if (error || !issue)` lumped real PostgREST errors
+    // (broken query, RLS, etc.) into the same "No issue found for today" skip
+    // path with success:true, hiding bugs for weeks. Real errors must report
+    // success:false with the underlying code.
+    setupFromMock({ issueError: { code: '42809', message: 'WITHIN GROUP is required for ordered-set aggregate rank' }, issueRow: null })
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({}) })
+    const body = await response.json()
+
+    expect(body.success).toBe(false)
+    expect(body.results[0].success).toBe(false)
+    expect(body.results[0].error).toMatch(/42809/)
+    expect(sendGridFinalMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/app/api/cron/send-secondary/route.ts
+++ b/src/app/api/cron/send-secondary/route.ts
@@ -87,11 +87,16 @@ async function handleSecondarySend(log: Logger): Promise<NextResponse> {
       // Get today's issue (can be in_review, changes_made, or sent)
       const localDate = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Chicago' })
 
+      // Note: do NOT select `rank` from manual_articles — PostgREST emits it
+      // unquoted and PostgreSQL parses it as the `rank()` ordered-set aggregate,
+      // returning 42809 ("WITHIN GROUP is required for ordered-set aggregate rank").
+      // Also, manual_articles has no `is_active` column — selecting one would
+      // cause 42703. Both bugs previously short-circuited every secondary send.
       const { data: issue, error } = await supabaseAdmin
         .from('publication_issues')
         .select(`
           id, date, status, subject_line, secondary_sent_at, publication_id, created_at, metrics,
-          manual_articles:manual_articles(id, title, body, rank, is_active, section_type)
+          manual_articles:manual_articles(id, title, body, section_type)
         `)
         .eq('publication_id', publicationId)
         .in('status', ['in_review', 'changes_made', 'sent'])
@@ -101,6 +106,13 @@ async function handleSecondarySend(log: Logger): Promise<NextResponse> {
         .single()
 
       if (error || !issue) {
+        // Distinguish a real "no row" miss from a PostgREST error so the next
+        // regression of this kind doesn't masquerade as a healthy skip.
+        if (error && (error as any).code && (error as any).code !== 'PGRST116') {
+          log.error({ err: error, slug: pub.slug, date: localDate }, '[CRON] Issue lookup failed')
+          results.push({ pubId: pub.id, slug: pub.slug, success: false, error: `Issue lookup failed: ${(error as any).code} ${(error as any).message || ''}`.trim() })
+          continue
+        }
         results.push({ pubId: pub.id, slug: pub.slug, success: true, skipped: true, message: 'No issue found for today' })
         continue
       }


### PR DESCRIPTION
## Summary

The PostgREST select `manual_articles:manual_articles(..., rank, is_active, ...)` was failing every request with **HTTP 400**, silently breaking AI Accounting Daily's Thursday secondary send (and the manual `send-review` POST) for ~10 weeks.

## Root cause

Two bugs in one column list (introduced 2026-03-31, commit `1f3a8698`):

| Column | Problem |
|---|---|
| `rank` | PostgreSQL parses the unquoted token as the `rank()` ordered-set aggregate function → `42809 "WITHIN GROUP is required for ordered-set aggregate rank"`. Fatal for the whole request. |
| `is_active` | Column does not exist on `manual_articles` → `42703 "column manual_articles_1.is_active does not exist"` once `rank` is fixed. |

In `send-secondary`, the failed lookup was caught by `if (error || !issue)` which lumped real PostgREST errors into the same `"No issue found for today"` skip path that returns `success:true`. Result: every Thursday morning cron tick recorded a healthy skip, no Slack alert, no `system_logs` entry, no Sentry — the failure was invisible.

The last successful secondary send for AI Accounting Daily was **2025-12-11**. Every Thursday since (and the recent ones after the schedule was re-enabled 2026-05-15) silently no-op'd.

## Changes

- `src/app/api/cron/send-secondary/route.ts` — remove `rank`/`is_active` from the `manual_articles` select; surface PostgREST errors with code ≠ `PGRST116` as `success:false` with the underlying code instead of silent skip.
- `src/app/api/campaigns/[id]/send-review/route.ts` — same fix on the manual POST handler. (The downstream `.filter(is_active).sort(rank)` was already dead code since those columns don't exist on `manual_articles`; the join itself was the bug.)
- `src/app/api/cron/send-secondary/__tests__/route.test.ts` — two regression tests:
  1. Assert the select string excludes `rank` and `is_active` inside the `manual_articles(...)` clause.
  2. Assert PostgREST errors propagate to `success:false` rather than silently skipping.

## Verification

- `npm run type-check` — clean
- `npm run lint` — no new issues in modified files
- `npm run build` — clean
- `npm run test:run -- src/app/api/cron/send-secondary/` — **9/9 pass** (7 existing + 2 new)
- Broken query reproduced against production PostgREST as `400 / 42809`
- Fixed query verified against production PostgREST: returns the issue with `HTTP 200`

## Follow-ups (not in this PR)

- `manual_articles` schema has no `is_active` or `rank` columns; the `send-review` handler's downstream review-position update for manual articles has been a silent no-op since whenever those columns disappeared. Worth a separate cleanup pass on whether manual articles should track active/rank at all, or whether that loop should be removed.
- Audit other routes that join `manual_articles` with explicit columns for the same forbidden tokens (grep covered in the investigation — only these two files were affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
