### PR TITLE
fix(tools): make upload-image route public so tool submissions don't 401

### DIFF
--- a/src/app/api/tools/upload-image/route.ts
+++ b/src/app/api/tools/upload-image/route.ts
@@ -4,7 +4,10 @@ import { supabaseAdmin } from '@/lib/supabase'
 import { STORAGE_PUBLIC_URL } from '@/lib/config'
 
 export const POST = withApiHandler(
-  { authTier: 'authenticated', logContext: 'tools/upload-image' },
+  // Public tool submissions (anonymous or Clerk-authenticated) upload images here.
+  // This endpoint must NOT require a NextAuth session — the public Tools Directory
+  // uses Clerk, so 'authenticated' (NextAuth) wrongly 401s every submitter.
+  { authTier: 'public', logContext: 'tools/upload-image' },
   async ({ request, logger }) => {
     const fileName = request.nextUrl.searchParams.get('fileName')
 


### PR DESCRIPTION
## Problem

A customer for AI Accounting Daily (Nicole Caird) reported repeated **"Unauthorized"** errors when submitting a tool to the AI Tools Directory.

## Root cause

The public AI Tools Directory (`/tools/submit`) authenticates with **Clerk**. On submit, the form POSTs each uploaded logo/listing image to `/api/tools/upload-image` before calling the `addTool` server action.

The bulk `withApiHandler` migration (`ce1cd074`, Feb 25 2026) set that route to `authTier: 'authenticated'`, which checks a **NextAuth** session (`getServerSession`) — the dashboard/admin auth system, unrelated to Clerk. Public/anonymous tool submitters never have a NextAuth session, so every submission **that included an image** returned `{ error: 'Unauthorized' }` (401). The form surfaces that message verbatim.

This has been broken for any image-bearing submission since Feb 25, 2026.

## Fix

Restore `authTier: 'public'`, matching:
- the sibling public route `track-click` (also `public`)
- the `addTool` server action, which has no auth gate (submissions are intentionally anonymous-capable: `user?.id || 'anonymous'`)
- the route's original pre-migration behavior (unauthenticated `POST`)

## Verification

- `npm run type-check` passes
- Deployed to `staging` and confirmed
- Manual test: submit a tool **with a logo/listing image** → succeeds instead of 401

## Note

The endpoint now accepts public uploads with no file size/type validation (pre-existing; it was public before the migration too). Worth hardening separately if abuse is a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The image upload endpoint is now publicly accessible, removing authentication requirements for tool uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->